### PR TITLE
Implement PLAN.md Phase 1: provider completions (1.1, 1.3, 1.4)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -10,25 +10,25 @@ For the completed MVP scope, see [MVP_PLAN.md](MVP_PLAN.md).
 **Goal**: Close out gaps in provider support and session lifecycle management.
 
 ### 1.1 Claude Output Parsing
-- [ ] Parse Claude-specific streaming JSON output format into structured `EventType` fields
+- [x] Parse Claude-specific streaming JSON output format into structured `EventType` fields
   - Detect tool use, content blocks, thinking tokens separately
   - Map `AGENT_READY` / `RESPONSE_COMPLETE` signals to `SESSION_STARTED` / done events
-- [ ] Integration test: start → send prompt → receive parsed events → stop
+- [x] Integration test: start → send prompt → receive parsed events → stop
 
 ### 1.2 OpenCode Integration Test
 - [x] Integration test: start → send prompt → receive events → stop
 - [ ] Validate PTY interaction model if opencode requires a terminal
 
 ### 1.3 Session Idle Timeout
-- [ ] Enforce `sessions.idle_timeout` from config: stop session automatically after no `SendInput` for the configured duration
-- [ ] Emit `SESSION_STOPPED` event with reason `"idle_timeout"` on automatic stop
-- [ ] Unit test: verify idle timeout fires and cleans up session state
+- [x] Enforce `sessions.idle_timeout` from config: stop session automatically after no `SendInput` for the configured duration
+- [x] Emit `SESSION_STOPPED` event with reason `"idle_timeout"` on automatic stop
+- [x] Unit test: verify idle timeout fires and cleans up session state
 
 ### 1.4 Provider Binary Version Detection
-- [ ] Add `Version(ctx context.Context) (string, error)` to provider `Health` or a separate method
-- [ ] Call `<binary> --version` and parse output during `Health()` check
-- [ ] Surface version in `ListProviders` response
-- [ ] Log provider version at startup
+- [x] Add `Version(ctx context.Context) (string, error)` to provider `Health` or a separate method
+- [x] Call `<binary> --version` and parse output during `Health()` check
+- [x] Surface version in `ListProviders` response
+- [x] Log provider version at startup
 
 ---
 

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/ed25519"
 	"flag"
 	"log/slog"
@@ -78,6 +79,16 @@ func main() {
 		logger.Info("registered provider", "provider", name, "binary", pcfg.Binary)
 	}
 
+	// Log provider versions at startup.
+	startupCtx := context.Background()
+	for name := range cfg.Providers {
+		if p, err := registry.Get(name); err == nil {
+			if v, err := p.Version(startupCtx); err == nil {
+				logger.Info("provider version", "provider", name, "version", v)
+			}
+		}
+	}
+
 	// Set up policy
 	policy := bridge.Policy{
 		MaxPerProject: cfg.Sessions.MaxPerProject,
@@ -96,7 +107,8 @@ func main() {
 	}
 
 	// Set up supervisor
-	sup := bridge.NewSupervisor(registry, policy, cfg.Sessions.EventBufferSize, subConfig)
+	idleTimeout := config.ParseDuration(cfg.Sessions.IdleTimeout, 30*time.Minute)
+	sup := bridge.NewSupervisor(registry, policy, cfg.Sessions.EventBufferSize, subConfig, idleTimeout)
 	sup.SetRedactor(redactor.Redact)
 	defer sup.Close()
 

--- a/gen/bridge/v1/bridge.pb.go
+++ b/gen/bridge/v1/bridge.pb.go
@@ -1129,6 +1129,7 @@ type ProviderInfo struct {
 	Provider      string                 `protobuf:"bytes,1,opt,name=provider,proto3" json:"provider,omitempty"`
 	Available     bool                   `protobuf:"varint,2,opt,name=available,proto3" json:"available,omitempty"`
 	Binary        string                 `protobuf:"bytes,3,opt,name=binary,proto3" json:"binary,omitempty"`
+	Version       string                 `protobuf:"bytes,4,opt,name=version,proto3" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1180,6 +1181,13 @@ func (x *ProviderInfo) GetAvailable() bool {
 func (x *ProviderInfo) GetBinary() string {
 	if x != nil {
 		return x.Binary
+	}
+	return ""
+}
+
+func (x *ProviderInfo) GetVersion() string {
+	if x != nil {
+		return x.Version
 	}
 	return ""
 }
@@ -1270,11 +1278,12 @@ const file_bridge_v1_bridge_proto_rawDesc = "" +
 	"\x05error\x18\x03 \x01(\tR\x05error\"\x16\n" +
 	"\x14ListProvidersRequest\"N\n" +
 	"\x15ListProvidersResponse\x125\n" +
-	"\tproviders\x18\x01 \x03(\v2\x17.bridge.v1.ProviderInfoR\tproviders\"`\n" +
+	"\tproviders\x18\x01 \x03(\v2\x17.bridge.v1.ProviderInfoR\tproviders\"z\n" +
 	"\fProviderInfo\x12\x1a\n" +
 	"\bprovider\x18\x01 \x01(\tR\bprovider\x12\x1c\n" +
 	"\tavailable\x18\x02 \x01(\bR\tavailable\x12\x16\n" +
-	"\x06binary\x18\x03 \x01(\tR\x06binary*\xbc\x01\n" +
+	"\x06binary\x18\x03 \x01(\tR\x06binary\x12\x18\n" +
+	"\aversion\x18\x04 \x01(\tR\aversion*\xbc\x01\n" +
 	"\rSessionStatus\x12\x1e\n" +
 	"\x1aSESSION_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17SESSION_STATUS_STARTING\x10\x01\x12\x1a\n" +

--- a/internal/bridge/provider.go
+++ b/internal/bridge/provider.go
@@ -24,6 +24,9 @@ type Provider interface {
 
 	// Health checks if the provider binary is available.
 	Health(ctx context.Context) error
+
+	// Version returns the version string of the provider binary.
+	Version(ctx context.Context) (string, error)
 }
 
 // SessionConfig holds configuration for starting a new agent session.

--- a/internal/bridge/supervisor.go
+++ b/internal/bridge/supervisor.go
@@ -31,11 +31,13 @@ type SessionInfo struct {
 
 // Supervisor manages the lifecycle of agent sessions.
 type Supervisor struct {
-	registry  *Registry
-	policy    Policy
-	bufSize   int
-	subConfig SubscriberConfig
-	redact    func(string) string
+	registry        *Registry
+	policy          Policy
+	bufSize         int
+	subConfig       SubscriberConfig
+	idleTimeout     time.Duration
+	cleanupInterval time.Duration // defaults to 5m; overridable in tests
+	redact          func(string) string
 
 	mu       sync.RWMutex
 	sessions map[string]*managedSession // keyed by session_id
@@ -44,25 +46,29 @@ type Supervisor struct {
 }
 
 type managedSession struct {
-	info   SessionInfo
-	handle SessionHandle
-	buf    *EventBuffer
-	subMgr *SubscriberManager
-	cancel context.CancelFunc
+	info         SessionInfo
+	handle       SessionHandle
+	buf          *EventBuffer
+	subMgr       *SubscriberManager
+	cancel       context.CancelFunc
+	lastActivity time.Time
+	stopReason   string // set before Stop(); forwardEvents surfaces it in the final event
 }
 
 // NewSupervisor creates a new session supervisor.
-func NewSupervisor(registry *Registry, policy Policy, eventBufSize int, subConfig SubscriberConfig) *Supervisor {
+func NewSupervisor(registry *Registry, policy Policy, eventBufSize int, subConfig SubscriberConfig, idleTimeout time.Duration) *Supervisor {
 	if eventBufSize <= 0 {
 		eventBufSize = 10000
 	}
 	s := &Supervisor{
-		registry:  registry,
-		policy:    policy,
-		bufSize:   eventBufSize,
-		subConfig: subConfig,
-		sessions:  make(map[string]*managedSession),
-		done:      make(chan struct{}),
+		registry:        registry,
+		policy:          policy,
+		bufSize:         eventBufSize,
+		subConfig:       subConfig,
+		idleTimeout:     idleTimeout,
+		cleanupInterval: 5 * time.Minute,
+		sessions:        make(map[string]*managedSession),
+		done:            make(chan struct{}),
 	}
 	go s.cleanupLoop()
 	return s
@@ -76,7 +82,7 @@ func (s *Supervisor) SetRedactor(fn func(string) string) {
 }
 
 func (s *Supervisor) cleanupLoop() {
-	ticker := time.NewTicker(5 * time.Minute)
+	ticker := time.NewTicker(s.cleanupInterval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -88,6 +94,22 @@ func (s *Supervisor) cleanupLoop() {
 				ms.subMgr.CleanupExpired()
 			}
 			s.mu.RUnlock()
+
+			if s.idleTimeout > 0 {
+				s.mu.Lock()
+				var idleSessions []string
+				for id, ms := range s.sessions {
+					if ms.info.State == SessionStateRunning &&
+						time.Since(ms.lastActivity) > s.idleTimeout {
+						ms.stopReason = "idle_timeout"
+						idleSessions = append(idleSessions, id)
+					}
+				}
+				s.mu.Unlock()
+				for _, id := range idleSessions {
+					go s.Stop(id, false) //nolint:errcheck
+				}
+			}
 		}
 	}
 }
@@ -162,11 +184,12 @@ func (s *Supervisor) Start(ctx context.Context, cfg SessionConfig) (*SessionInfo
 	}
 
 	ms := &managedSession{
-		info:   info,
-		handle: handle,
-		buf:    buf,
-		subMgr: subMgr,
-		cancel: cancel,
+		info:         info,
+		handle:       handle,
+		buf:          buf,
+		subMgr:       subMgr,
+		cancel:       cancel,
+		lastActivity: now,
 	}
 
 	s.mu.Lock()
@@ -243,6 +266,10 @@ func (s *Supervisor) Send(sessionID, text string) (uint64, error) {
 	if err := provider.Send(ms.handle, text); err != nil {
 		return 0, err
 	}
+
+	s.mu.Lock()
+	ms.lastActivity = time.Now().UTC()
+	s.mu.Unlock()
 
 	seq := ms.buf.Append(Event{
 		Timestamp: time.Now().UTC(),
@@ -349,6 +376,16 @@ func (s *Supervisor) forwardEvents(sessionID string, provider Provider, handle S
 	for e := range events {
 		e.Text = s.redactString(e.Text)
 		e.Error = s.redactString(e.Error)
+
+		// Override text with stop reason for idle-timeout terminations.
+		if e.Done && e.Type == EventTypeSessionStopped {
+			s.mu.RLock()
+			if ms, ok := s.sessions[sessionID]; ok && ms.stopReason != "" {
+				e.Text = ms.stopReason
+			}
+			s.mu.RUnlock()
+		}
+
 		buf.Append(e)
 
 		// Update session state on terminal events

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -7,7 +7,8 @@ func NewClaudeProvider() *StdioProvider {
 	return NewStdioProvider(StdioConfig{
 		ProviderID:     "claude",
 		Binary:         "claude",
-		DefaultArgs:    []string{"--print", "--verbose"},
+		DefaultArgs:    []string{"--output-format", "stream-json", "--verbose"},
+		StreamJSON:     true,
 		StartupTimeout: 30 * time.Second,
 		StopGrace:      10 * time.Second,
 	})

--- a/internal/provider/codex_exec.go
+++ b/internal/provider/codex_exec.go
@@ -53,6 +53,19 @@ func NewCodexExecProvider(cfg CodexExecConfig) *CodexExecProvider {
 
 func (p *CodexExecProvider) ID() string { return p.providerID }
 
+func (p *CodexExecProvider) Version(ctx context.Context) (string, error) {
+	path, err := resolveBinaryPath(p.binary)
+	if err != nil {
+		return "", fmt.Errorf("binary %q not found: %w", p.binary, err)
+	}
+	cmd := exec.CommandContext(ctx, path, "--version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("version check: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 func (p *CodexExecProvider) Health(ctx context.Context) error {
 	path, err := resolveBinaryPath(p.binary)
 	if err != nil {

--- a/internal/provider/codex_exec.go
+++ b/internal/provider/codex_exec.go
@@ -59,6 +59,7 @@ func (p *CodexExecProvider) Version(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("binary %q not found: %w", p.binary, err)
 	}
 	cmd := exec.CommandContext(ctx, path, "--version")
+	cmd.Env = filterEnv(os.Environ())
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("version check: %w", err)

--- a/internal/provider/stdio.go
+++ b/internal/provider/stdio.go
@@ -81,6 +81,19 @@ func NewStdioProvider(cfg StdioConfig) *StdioProvider {
 
 func (p *StdioProvider) ID() string { return p.cfg.ProviderID }
 
+func (p *StdioProvider) Version(ctx context.Context) (string, error) {
+	path, err := resolveBinaryPath(p.cfg.Binary)
+	if err != nil {
+		return "", fmt.Errorf("binary %q not found: %w", p.cfg.Binary, err)
+	}
+	cmd := exec.CommandContext(ctx, path, "--version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("version check: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 func (p *StdioProvider) Health(ctx context.Context) error {
 	path, err := resolveBinaryPath(p.cfg.Binary)
 	if err != nil {

--- a/internal/provider/stdio.go
+++ b/internal/provider/stdio.go
@@ -87,6 +87,7 @@ func (p *StdioProvider) Version(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("binary %q not found: %w", p.cfg.Binary, err)
 	}
 	cmd := exec.CommandContext(ctx, path, "--version")
+	cmd.Env = filterEnv(os.Environ())
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("version check: %w", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -406,9 +406,15 @@ func (s *BridgeServer) ListProviders(ctx context.Context, req *bridgev1.ListProv
 
 	providers := make([]*bridgev1.ProviderInfo, 0, len(ids))
 	for _, id := range ids {
+		p, _ := s.registry.Get(id)
+		var version string
+		if p != nil {
+			version, _ = p.Version(ctx)
+		}
 		pi := &bridgev1.ProviderInfo{
 			Provider:  id,
 			Available: results[id] == nil,
+			Version:   version,
 		}
 		providers = append(providers, pi)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -406,14 +406,16 @@ func (s *BridgeServer) ListProviders(ctx context.Context, req *bridgev1.ListProv
 
 	providers := make([]*bridgev1.ProviderInfo, 0, len(ids))
 	for _, id := range ids {
-		p, _ := s.registry.Get(id)
+		available := results[id] == nil
 		var version string
-		if p != nil {
-			version, _ = p.Version(ctx)
+		if available {
+			if p, err := s.registry.Get(id); err == nil {
+				version, _ = p.Version(ctx)
+			}
 		}
 		pi := &bridgev1.ProviderInfo{
 			Provider:  id,
-			Available: results[id] == nil,
+			Available: available,
 			Version:   version,
 		}
 		providers = append(providers, pi)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -24,6 +24,9 @@ func (p *testProvider) ID() string { return p.id }
 func (p *testProvider) Health(ctx context.Context) error {
 	return nil
 }
+func (p *testProvider) Version(ctx context.Context) (string, error) {
+	return "test-1.0", nil
+}
 func (p *testProvider) Start(ctx context.Context, cfg bridge.SessionConfig) (bridge.SessionHandle, error) {
 	h := &testHandle{id: cfg.SessionID, events: make(chan bridge.Event, 32)}
 	h.events <- bridge.Event{
@@ -92,7 +95,7 @@ func newTestServer(t *testing.T, policy bridge.Policy) *BridgeServer {
 	if err := reg.Register(&testProvider{id: "test"}); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
-	sup := bridge.NewSupervisor(reg, policy, 64, bridge.DefaultSubscriberConfig())
+	sup := bridge.NewSupervisor(reg, policy, 64, bridge.DefaultSubscriberConfig(), 0)
 	t.Cleanup(func() { sup.Close() })
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	return New(sup, reg, logger, RateLimitConfig{
@@ -235,7 +238,7 @@ func TestRateLimitStartSessionPerClient(t *testing.T) {
 	if err := reg.Register(&testProvider{id: "test"}); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
-	sup := bridge.NewSupervisor(reg, bridge.DefaultPolicy(), 64, bridge.DefaultSubscriberConfig())
+	sup := bridge.NewSupervisor(reg, bridge.DefaultPolicy(), 64, bridge.DefaultSubscriberConfig(), 0)
 	t.Cleanup(func() { sup.Close() })
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	s := New(sup, reg, logger, RateLimitConfig{
@@ -273,7 +276,7 @@ func TestRateLimitSendInputPerSession(t *testing.T) {
 	if err := reg.Register(&testProvider{id: "test"}); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
-	sup := bridge.NewSupervisor(reg, bridge.DefaultPolicy(), 64, bridge.DefaultSubscriberConfig())
+	sup := bridge.NewSupervisor(reg, bridge.DefaultPolicy(), 64, bridge.DefaultSubscriberConfig(), 0)
 	t.Cleanup(func() { sup.Close() })
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	s := New(sup, reg, logger, RateLimitConfig{

--- a/proto/bridge/v1/bridge.proto
+++ b/proto/bridge/v1/bridge.proto
@@ -159,4 +159,5 @@ message ProviderInfo {
   string provider = 1;
   bool available = 2;
   string binary = 3;
+  string version = 4;
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Phase 1.1 — Claude stream-json output parsing**: Enable `StreamJSON` mode in `NewClaudeProvider()` with `--output-format stream-json --verbose` args; the parse logic was already present but not wired. Add `TestClaudeProviderStreamJSON` integration test.
- **Phase 1.3 — Session idle timeout**: Add `idleTimeout`/`cleanupInterval` to `Supervisor`, `lastActivity`/`stopReason` to `managedSession`; wire idle checking in `cleanupLoop`; surface stop reason in `SESSION_STOPPED` event text; parse `cfg.Sessions.IdleTimeout` in `main.go`. Add `TestIdleTimeout`.
- **Phase 1.4 — Provider binary version detection**: Add `Version(ctx)` to the `Provider` interface and implement on `StdioProvider` and `CodexExecProvider`; add `version` field to `ProviderInfo` proto (regenerated); populate in `ListProviders` RPC; log at startup. Add `TestStdioProviderVersion`.

## Test plan

- [x] All unit tests pass (`make test`) — race-free
- [x] All 7 e2e tests pass (`make test-e2e`)
- [x] `make build` succeeds (proto regen + compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)