### PR TITLE
Fix chat web Docker startup validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,30 @@ jobs:
             ./examples/chat-web/coverage/lcov.info
           flags: typescript
           name: typescript-coverage
+
+  smoke:
+    if: github.event_name == 'pull_request'
+    needs:
+      - go-lint
+      - go-test
+      - typescript-lint
+      - typescript-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Run smoke test
+        run: ./scripts/smoke.sh

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,10 +11,7 @@ jobs:
   smoke:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      (
-        github.event.workflow_run.event == 'pull_request' ||
-        github.event.workflow_run.head_branch == 'main'
-      )
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/config/bridge-docker.yaml
+++ b/config/bridge-docker.yaml
@@ -36,6 +36,7 @@ providers:
     binary: "./node_modules/.bin/claude"
     args: ["--verbose"]
     startup_timeout: "60s"
+    validate_startup: false
     startup_probe: "prompt"
     required_env: ["ANTHROPIC_API_KEY"]
     prompt_pattern: "(?m)(❯|>\\s*$)"
@@ -43,6 +44,7 @@ providers:
     binary: "./node_modules/.bin/opencode"
     args: []
     startup_timeout: "45s"
+    validate_startup: false
     startup_probe: "output"
     required_env: ["OPENAI_API_KEY"]
     prompt_pattern: "❯"
@@ -50,6 +52,7 @@ providers:
     binary: "./node_modules/.bin/codex"
     args: []
     startup_timeout: "60s"
+    validate_startup: false
     startup_probe: "output"
     required_env: ["OPENAI_API_KEY"]
     prompt_pattern: "(?m)(>\\s*$|›)"
@@ -57,6 +60,7 @@ providers:
     binary: "./node_modules/.bin/gemini"
     args: []
     startup_timeout: "60s"
+    validate_startup: false
     startup_probe: "output"
     required_env: ["GEMINI_API_KEY"]
     prompt_pattern: "^\\s*>\\s*$"

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -59,7 +59,8 @@ func LoadDotEnv(path string) error {
 	return nil
 }
 
-// ValidateProviderEnv ensures all configured providers have required env vars set.
+// ValidateProviderEnv ensures providers that validate startup eagerly have their
+// required env vars set before the bridge starts.
 func ValidateProviderEnv(cfg *Config) error {
 	for name, pcfg := range cfg.Providers {
 		if !pcfg.ShouldValidateStartup() {

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -62,6 +62,9 @@ func LoadDotEnv(path string) error {
 // ValidateProviderEnv ensures all configured providers have required env vars set.
 func ValidateProviderEnv(cfg *Config) error {
 	for name, pcfg := range cfg.Providers {
+		if !pcfg.ShouldValidateStartup() {
+			continue
+		}
 		for _, envName := range pcfg.RequiredEnv {
 			v := strings.TrimSpace(os.Getenv(envName))
 			if v == "" {

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -81,3 +81,25 @@ func TestValidateProviderEnv(t *testing.T) {
 		t.Fatalf("ValidateProviderEnv: %v", err)
 	}
 }
+
+func TestValidateProviderEnvSkipsProvidersWithStartupValidationDisabled(t *testing.T) {
+	disabled := false
+	cfg := &Config{
+		Providers: map[string]ProviderConfig{
+			"claude": {
+				RequiredEnv:     []string{"ANTHROPIC_API_KEY"},
+				ValidateStartup: &disabled,
+			},
+			"codex": {
+				RequiredEnv: []string{"OPENAI_API_KEY"},
+			},
+		},
+	}
+
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "present")
+
+	if err := ValidateProviderEnv(cfg); err != nil {
+		t.Fatalf("ValidateProviderEnv: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- skip eager provider env validation when a provider has `validate_startup: false`
- add a regression test for that config behavior
- disable startup validation for Docker-only provider entries so `chat-web` can boot without every provider API key exported

## Problem
`make chat-web-docker-start` failed because the `bridge` container exited during startup with `provider environment validation failed` when `ANTHROPIC_API_KEY` was not set. The Docker config is intended to bring the stack up for local web testing, but it was still using eager provider validation semantics.

## Testing
- `go test ./internal/config`
- `make test`
- `docker compose up --build -d chat-web`
- `docker compose ps`
- `docker compose logs --tail=50 bridge chat-web`

## Operational impact
Docker startup no longer requires all provider credentials up front. Provider sessions that actually need missing credentials will still fail when used.