### PR TITLE
docs: clarify apt supported suites and add Ansible example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ e2e/.env
 # Local JS dependencies
 /node_modules/
 .ballast/
+
+# Claude
+.claude/scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -119,6 +119,22 @@ sudo apt-get install -y ai-agent-bridge
 sudo systemctl enable --now ai-agent-bridge
 ```
 
+**Supported Ubuntu suites:** `noble` (24.04 LTS) and `plucky` (25.04). Replace `noble` above with `plucky` if you are on Ubuntu 25.04. The repository does not publish a `stable` or `jammy` suite — using any other suite name will result in a "does not have a Release file" error from apt.
+
+**Ansible:** use `ansible_distribution_release` to select the correct suite automatically:
+
+```yaml
+- name: Add ai-agent-bridge apt repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch={{ ansible_architecture }}
+      signed-by=/etc/apt/keyrings/ai-agent-bridge.gpg]
+      https://markcallen.github.io/ai-agent-bridge/apt
+      {{ ansible_distribution_release }} main
+    state: present
+    filename: ai-agent-bridge
+```
+
 The packaged service installs a minimal config at `/etc/ai-agent-bridge/bridge.yaml` and listens on `127.0.0.1:9445` by default. It does not bundle provider CLIs or API keys. For production use you must install the provider CLIs separately, add provider configuration, and decide how the service account should access the target repositories.
 
 ---

--- a/README.md
+++ b/README.md
@@ -129,11 +129,30 @@ sudo systemctl enable --now ai-agent-bridge
   register: dpkg_arch
   changed_when: false
 
+- name: Ensure /etc/apt/keyrings exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download ai-agent-bridge signing key
+  ansible.builtin.get_url:
+    url: https://markcallen.github.io/ai-agent-bridge/apt/ai-agent-bridge-archive-keyring.asc
+    dest: /tmp/ai-agent-bridge-keyring.asc
+    mode: '0644'
+
+- name: Dearmor signing key
+  ansible.builtin.command: >
+    gpg --dearmor -o /etc/apt/keyrings/ai-agent-bridge.gpg /tmp/ai-agent-bridge-keyring.asc
+  args:
+    creates: /etc/apt/keyrings/ai-agent-bridge.gpg
+
 - name: Add ai-agent-bridge apt repository
   ansible.builtin.apt_repository:
     repo: "deb [arch={{ dpkg_arch.stdout }} signed-by=/etc/apt/keyrings/ai-agent-bridge.gpg] https://markcallen.github.io/ai-agent-bridge/apt {{ ansible_distribution_release }} main"
     state: present
     filename: ai-agent-bridge
+  notify: Update apt cache
 ```
 
 The packaged service installs a minimal config at `/etc/ai-agent-bridge/bridge.yaml` and listens on `127.0.0.1:9445` by default. It does not bundle provider CLIs or API keys. For production use you must install the provider CLIs separately, add provider configuration, and decide how the service account should access the target repositories.

--- a/README.md
+++ b/README.md
@@ -121,16 +121,17 @@ sudo systemctl enable --now ai-agent-bridge
 
 **Supported Ubuntu suites:** `noble` (24.04 LTS) and `plucky` (25.04). Replace `noble` above with `plucky` if you are on Ubuntu 25.04. The repository does not publish a `stable` or `jammy` suite — using any other suite name will result in a "does not have a Release file" error from apt.
 
-**Ansible:** use `ansible_distribution_release` to select the correct suite automatically:
+**Ansible:** use `ansible_distribution_release` for the suite and `dpkg --print-architecture` for the arch. Do not use `ansible_architecture` — it returns the kernel arch (`x86_64`) rather than the Debian package arch (`amd64`), which causes apt to look for a non-existent `binary-x86_64/Packages` path.
 
 ```yaml
+- name: Get Debian architecture
+  ansible.builtin.command: dpkg --print-architecture
+  register: dpkg_arch
+  changed_when: false
+
 - name: Add ai-agent-bridge apt repository
   ansible.builtin.apt_repository:
-    repo: >-
-      deb [arch={{ ansible_architecture }}
-      signed-by=/etc/apt/keyrings/ai-agent-bridge.gpg]
-      https://markcallen.github.io/ai-agent-bridge/apt
-      {{ ansible_distribution_release }} main
+    repo: "deb [arch={{ dpkg_arch.stdout }} signed-by=/etc/apt/keyrings/ai-agent-bridge.gpg] https://markcallen.github.io/ai-agent-bridge/apt {{ ansible_distribution_release }} main"
     state: present
     filename: ai-agent-bridge
 ```


### PR DESCRIPTION
## Summary

- Clarifies which Ubuntu apt suites are supported (`noble` and `plucky` only) to prevent confusing "does not have a Release file" apt errors
- Adds an Ansible example for adding the apt repository with correct variable usage
- Fixes Ansible arch variable: use `dpkg --print-architecture` instead of `ansible_architecture` (which returns kernel arch `x86_64` instead of Debian package arch `amd64`)
- Ignores `.claude/scheduled_tasks.lock` in `.gitignore`

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm apt repo instructions work on Ubuntu 24.04 (`noble`) and 25.04 (`plucky`)
- [ ] Verify Ansible snippet works end-to-end on a fresh Ubuntu host

🤖 Generated with [Claude Code](https://claude.com/claude-code)