### PR TITLE
feat: add runtime.provider_root for explicit Node and CLI path resolution (Phase 1 ai-desktops)

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -37,7 +37,11 @@ func main() {
 		os.Exit(1)
 	}
 	if config.RequiresNodeRuntime(cfg) {
-		if err := config.ValidateNodeRuntime("."); err != nil {
+		runtimeRoot := cfg.Runtime.ProviderRoot
+		if runtimeRoot == "" {
+			runtimeRoot = "."
+		}
+		if err := config.ValidateNodeRuntime(runtimeRoot); err != nil {
 			bootstrapLogger.Error("node runtime validation failed", "error", err)
 			os.Exit(1)
 		}
@@ -68,6 +72,7 @@ func main() {
 			RequiredEnv:    pcfg.RequiredEnv,
 			StreamJSON:     pcfg.StreamJSON,
 			StripANSI:      pcfg.StripANSI,
+			ProviderRoot:   cfg.Runtime.ProviderRoot,
 		})
 		if err := registry.Register(p); err != nil {
 			logger.Error("register provider", "provider", name, "error", err)

--- a/docs/service.md
+++ b/docs/service.md
@@ -194,6 +194,34 @@ logging:
 | `db_path` | `""` (disabled) | Path to the bbolt database file used to persist session metadata **and PTY output chunks** across daemon restarts. When set, `GetSession` and `ListSessions` surface completed sessions from previous daemon lifetimes. If a persisted non-terminal session still has a live PID at startup, the daemon recovers it into a `RUNNING` state, preserves replay from persisted chunks, and keeps `StopSession` available. Because the current PTY design does not re-open the original live transport, post-restart `AttachSession` is replay-only and `WriteInput`/`ResizeSession` return `UNAVAILABLE` for recovered sessions. |
 | `chunk_storage_bytes` | `0` (unlimited) | Soft upper bound on total PTY chunk bytes stored per session. Reserved for future enforcement; currently has no effect. |
 
+#### `runtime`
+
+Controls how the bridge locates provider CLIs and the Node.js runtime. These settings are optional; omitting the `runtime` block preserves previous behaviour (paths resolved relative to the daemon working directory).
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `provider_root` | `""` (daemon CWD) | Absolute path to the directory that contains `.nvmrc` and provider `node_modules`. When set: (1) Node.js version validation reads `{provider_root}/.nvmrc` instead of the daemon working directory; (2) relative `binary` and `args` paths in each provider definition resolve against `provider_root` instead of the daemon working directory. Use this when the daemon runs as a systemd service with a different `WorkingDirectory` than where provider CLIs are installed. |
+
+Example (`ai-desktops` deployment):
+
+```yaml
+runtime:
+  provider_root: "/opt/ai-agent-bridge"
+
+providers:
+  codex:
+    binary: "/usr/bin/node"
+    args: ["./node_modules/@openai/codex/bin/codex.js"]
+    startup_timeout: "60s"
+    startup_probe:   "output"
+    required_env:    ["OPENAI_API_KEY"]
+    prompt_pattern:  '(?m)(>\s*$|›)'
+```
+
+In this example, `./node_modules/@openai/codex/bin/codex.js` resolves to
+`/opt/ai-agent-bridge/node_modules/@openai/codex/bin/codex.js` regardless of
+where the daemon process is launched from.
+
 #### `providers`
 | Field | Description |
 |-------|-------------|

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,9 +19,19 @@ type Config struct {
 	Input        InputConfig               `yaml:"input"`
 	RateLimits   RateLimitsConfig          `yaml:"rate_limits"`
 	Persistence  PersistenceConfig         `yaml:"persistence"`
+	Runtime      RuntimeConfig             `yaml:"runtime"`
 	Providers    map[string]ProviderConfig `yaml:"providers"`
 	AllowedPaths []string                  `yaml:"allowed_paths"`
 	Logging      LoggingConfig             `yaml:"logging"`
+}
+
+// RuntimeConfig controls how the bridge locates provider CLIs and the Node.js
+// runtime. When ProviderRoot is set, Node version validation reads
+// {provider_root}/.nvmrc and relative provider binary/arg paths are resolved
+// relative to {provider_root} instead of the daemon working directory. When
+// empty, existing CWD-relative behaviour is preserved.
+type RuntimeConfig struct {
+	ProviderRoot string `yaml:"provider_root"`
 }
 
 type ServerConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -279,3 +279,59 @@ sessions:
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestLoadRuntimeProviderRoot(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantRoot string
+	}{
+		{
+			name: "provider_root set",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+runtime:
+  provider_root: "/opt/ai-agent-bridge"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`,
+			wantRoot: "/opt/ai-agent-bridge",
+		},
+		{
+			name: "provider_root absent",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`,
+			wantRoot: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "bridge.yaml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.Runtime.ProviderRoot != tc.wantRoot {
+				t.Fatalf("ProviderRoot=%q want %q", cfg.Runtime.ProviderRoot, tc.wantRoot)
+			}
+		})
+	}
+}

--- a/internal/config/node_test.go
+++ b/internal/config/node_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -103,5 +104,34 @@ func TestValidateNodeRuntime(t *testing.T) {
 
 	if err := ValidateNodeRuntime(dir); err != nil {
 		t.Fatalf("ValidateNodeRuntime: %v", err)
+	}
+}
+
+func TestValidateNodeRuntimeWithExplicitRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".nvmrc"), []byte("24\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	lookPathNode = func(file string) (string, error) { return "/usr/bin/node", nil }
+	runCommand = func(name string, args ...string) ([]byte, error) {
+		return []byte("v24.1.0\n"), nil
+	}
+	t.Cleanup(func() {
+		lookPathNode = exec.LookPath
+		runCommand = func(name string, args ...string) ([]byte, error) {
+			return exec.Command(name, args...).Output()
+		}
+	})
+
+	// Validates successfully when the explicit root contains .nvmrc.
+	if err := ValidateNodeRuntime(root); err != nil {
+		t.Fatalf("ValidateNodeRuntime with root: %v", err)
+	}
+
+	// Fails when .nvmrc is absent from the given root.
+	emptyRoot := t.TempDir()
+	if err := ValidateNodeRuntime(emptyRoot); err == nil {
+		t.Fatal("expected error for missing .nvmrc")
 	}
 }

--- a/internal/provider/stdio.go
+++ b/internal/provider/stdio.go
@@ -29,6 +29,10 @@ type StdioConfig struct {
 	RequiredEnv    []string
 	StreamJSON     bool // if true, the provider uses stream-JSON mode (no PTY)
 	StripANSI      bool // if true, ANSI escape codes are stripped from PTY output
+	// ProviderRoot is an optional absolute path used as the base for resolving
+	// relative Binary and DefaultArgs paths. When empty, relative paths are
+	// resolved against the daemon working directory (legacy behaviour).
+	ProviderRoot string
 }
 
 // StdioProvider defines how to launch and validate one interactive CLI.
@@ -71,11 +75,11 @@ func (p *StdioProvider) IsStreamJSON() bool { return p.cfg.StreamJSON }
 func (p *StdioProvider) IsStripANSI() bool { return p.cfg.StripANSI }
 
 func (p *StdioProvider) BuildCommand(ctx context.Context, cfg bridge.SessionConfig) (*exec.Cmd, error) {
-	binPath, err := resolveBinaryPath(p.cfg.Binary)
+	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return nil, fmt.Errorf("%w: resolve binary %q: %v", bridge.ErrProviderUnavailable, p.cfg.Binary, err)
 	}
-	args, err := resolveCommandArgs(p.cfg.DefaultArgs)
+	args, err := resolveCommandArgs(p.cfg.DefaultArgs, p.cfg.ProviderRoot)
 	if err != nil {
 		return nil, fmt.Errorf("%w: resolve args for %q: %v", bridge.ErrProviderUnavailable, p.cfg.ProviderID, err)
 	}
@@ -120,11 +124,11 @@ func (p *StdioProvider) validateStartupPrompt(ctx context.Context) error {
 	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.StartupTimeout)
 	defer cancel()
 
-	binPath, err := resolveBinaryPath(p.cfg.Binary)
+	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return err
 	}
-	args, err := resolveCommandArgs(p.cfg.DefaultArgs)
+	args, err := resolveCommandArgs(p.cfg.DefaultArgs, p.cfg.ProviderRoot)
 	if err != nil {
 		return err
 	}
@@ -171,11 +175,11 @@ func (p *StdioProvider) validateStartupOutput(ctx context.Context) error {
 	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.StartupTimeout)
 	defer cancel()
 
-	binPath, err := resolveBinaryPath(p.cfg.Binary)
+	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return err
 	}
-	args, err := resolveCommandArgs(p.cfg.DefaultArgs)
+	args, err := resolveCommandArgs(p.cfg.DefaultArgs, p.cfg.ProviderRoot)
 	if err != nil {
 		return err
 	}
@@ -219,7 +223,7 @@ func (p *StdioProvider) validateStartupOutput(ctx context.Context) error {
 }
 
 func (p *StdioProvider) Version(ctx context.Context) (string, error) {
-	path, err := resolveBinaryPath(p.cfg.Binary)
+	path, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return "", fmt.Errorf("binary %q not found: %w", p.cfg.Binary, err)
 	}
@@ -233,7 +237,7 @@ func (p *StdioProvider) Version(ctx context.Context) (string, error) {
 }
 
 func (p *StdioProvider) Health(ctx context.Context) error {
-	path, err := resolveBinaryPath(p.cfg.Binary)
+	path, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return fmt.Errorf("binary %q not found: %w", p.cfg.Binary, err)
 	}
@@ -247,17 +251,26 @@ func (p *StdioProvider) Health(ctx context.Context) error {
 	return nil
 }
 
-func resolveBinaryPath(binary string) (string, error) {
+// resolveBinaryPath resolves a provider binary to an absolute path. When root
+// is non-empty and binary is a relative path containing a slash, binary is
+// resolved relative to root instead of the process working directory.
+func resolveBinaryPath(binary, root string) (string, error) {
 	if strings.Contains(binary, "/") {
 		if filepath.IsAbs(binary) {
 			return binary, nil
+		}
+		if root != "" {
+			return filepath.Join(root, binary), nil
 		}
 		return filepath.Abs(binary)
 	}
 	return exec.LookPath(binary)
 }
 
-func resolveCommandArgs(args []string) ([]string, error) {
+// resolveCommandArgs converts standalone relative path arguments to absolute
+// paths. When root is non-empty, relative paths are resolved against root
+// instead of the process working directory.
+func resolveCommandArgs(args []string, root string) ([]string, error) {
 	if len(args) == 0 {
 		return nil, nil
 	}
@@ -267,9 +280,15 @@ func resolveCommandArgs(args []string) ([]string, error) {
 		if !isStandaloneRelativePathArg(arg) {
 			continue
 		}
-		abs, err := filepath.Abs(arg)
-		if err != nil {
-			return nil, err
+		var abs string
+		var err error
+		if root != "" {
+			abs = filepath.Join(root, arg)
+		} else {
+			abs, err = filepath.Abs(arg)
+			if err != nil {
+				return nil, err
+			}
 		}
 		resolved[i] = abs
 	}

--- a/internal/provider/stdio_additional_test.go
+++ b/internal/provider/stdio_additional_test.go
@@ -65,7 +65,7 @@ func TestResolveBinaryPathAndFilterEnv(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	path, err := resolveBinaryPath(bin)
+	path, err := resolveBinaryPath(bin, "")
 	if err != nil {
 		t.Fatalf("resolveBinaryPath: %v", err)
 	}

--- a/internal/provider/stdio_test.go
+++ b/internal/provider/stdio_test.go
@@ -84,7 +84,7 @@ func TestResolveCommandArgsLeavesFlagsAndURLsUntouched(t *testing.T) {
 		"--config=./configs/dev.yaml",
 		"https://example.com/api",
 		"../relative-script.js",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("resolveCommandArgs: %v", err)
 	}
@@ -100,5 +100,87 @@ func TestResolveCommandArgsLeavesFlagsAndURLsUntouched(t *testing.T) {
 	}
 	if !filepath.IsAbs(args[3]) {
 		t.Fatalf("relative script should be absolutized, got %q", args[3])
+	}
+}
+
+func TestResolveBinaryPathWithProviderRoot(t *testing.T) {
+	root := t.TempDir()
+
+	// Absolute binary is returned as-is regardless of root.
+	abs, err := resolveBinaryPath("/usr/bin/node", root)
+	if err != nil {
+		t.Fatalf("resolveBinaryPath absolute: %v", err)
+	}
+	if abs != "/usr/bin/node" {
+		t.Fatalf("absolute path changed: %q", abs)
+	}
+
+	// NAME-only binary (no slash) is still looked up on PATH.
+	_, err = resolveBinaryPath("cat", root)
+	if err != nil {
+		t.Fatalf("resolveBinaryPath PATH lookup: %v", err)
+	}
+
+	// Relative path with slash resolves against root, not CWD.
+	got, err := resolveBinaryPath("./bin/tool", root)
+	if err != nil {
+		t.Fatalf("resolveBinaryPath relative: %v", err)
+	}
+	want := filepath.Join(root, "./bin/tool")
+	if got != want {
+		t.Fatalf("resolveBinaryPath=%q want %q", got, want)
+	}
+}
+
+func TestResolveCommandArgsWithProviderRoot(t *testing.T) {
+	root := t.TempDir()
+
+	args, err := resolveCommandArgs([]string{
+		"./node_modules/@openai/codex/bin/codex.js",
+		"--flag",
+		"../sibling.js",
+	}, root)
+	if err != nil {
+		t.Fatalf("resolveCommandArgs: %v", err)
+	}
+
+	// Relative paths with slashes are resolved against root.
+	wantFirst := filepath.Join(root, "./node_modules/@openai/codex/bin/codex.js")
+	if args[0] != wantFirst {
+		t.Fatalf("args[0]=%q want %q", args[0], wantFirst)
+	}
+	// Non-path flags are left alone.
+	if args[1] != "--flag" {
+		t.Fatalf("args[1]=%q want --flag", args[1])
+	}
+	wantThird := filepath.Join(root, "../sibling.js")
+	if args[2] != wantThird {
+		t.Fatalf("args[2]=%q want %q", args[2], wantThird)
+	}
+}
+
+func TestBuildCommandResolvesArgsFromProviderRoot(t *testing.T) {
+	root := t.TempDir()
+
+	p := NewStdioProvider(StdioConfig{
+		ProviderID:    "codex",
+		Binary:        "/usr/bin/node",
+		DefaultArgs:   []string{"./node_modules/@openai/codex/bin/codex.js"},
+		PromptPattern: "›",
+		ProviderRoot:  root,
+	})
+
+	cmd, err := p.BuildCommand(context.Background(), bridge.SessionConfig{
+		ProjectID: "test",
+		SessionID: "s1",
+		RepoPath:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("BuildCommand: %v", err)
+	}
+
+	want := filepath.Join(root, "./node_modules/@openai/codex/bin/codex.js")
+	if len(cmd.Args) < 2 || cmd.Args[1] != want {
+		t.Fatalf("cmd.Args=%v want second arg %q", cmd.Args, want)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `runtime.provider_root` config field to `Config` struct
- When set, Node.js version validation reads `{provider_root}/.nvmrc` instead of the daemon CWD — provider-enabled startup no longer fails when `WorkingDirectory` differs from where the bridge source/runtime lives
- When set, relative `binary` and `args` values in provider configs resolve against the provider root instead of CWD — enables a stable `/opt/ai-agent-bridge` install layout used by the ai-desktops deployment profile
- Backward compatible: when `runtime.provider_root` is absent, all existing CWD-relative behaviour is preserved

This is Phase 1 of the [ai-desktops support plan](plans/ai-desktops-support.md). It implements the "Bridge Runtime Contract" phase which unblocks packaging, the ai-desktops config profile, and the systemd drop-in work in later phases.

## Test plan

- [ ] `make test` passes (all packages green, race detector on)
- [ ] `make test-cover` shows `internal/config` ≥75% and `internal/provider` ≥75%
- [ ] `TestLoadRuntimeProviderRoot` — config parsing with/without `runtime.provider_root`
- [ ] `TestValidateNodeRuntimeWithExplicitRoot` — Node validation with explicit root path
- [ ] `TestResolveBinaryPathWithProviderRoot` — absolute, PATH, and relative binary resolution
- [ ] `TestResolveCommandArgsWithProviderRoot` — relative args resolve against root
- [ ] `TestBuildCommandResolvesArgsFromProviderRoot` — end-to-end via `BuildCommand`

🤖 Generated with [Claude Code](https://claude.com/claude-code)