### PR TITLE
feat: ai-desktops packaging profile (Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,3 +194,25 @@ jobs:
 
       - name: Run local apt smoke test
         run: ./scripts/smoke-apt-local.sh
+
+  apt-smoke-profile:
+    if: github.event_name == 'pull_request'
+    needs:
+      - go-lint
+      - go-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install packaging tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y apt-utils dpkg-dev gnupg
+
+      - name: Run ai-desktops profile apt smoke test
+        run: ./scripts/smoke-apt-profile.sh

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -37,7 +37,11 @@ func main() {
 		os.Exit(1)
 	}
 	if config.RequiresNodeRuntime(cfg) {
-		if err := config.ValidateNodeRuntime("."); err != nil {
+		runtimeRoot := cfg.Runtime.ProviderRoot
+		if runtimeRoot == "" {
+			runtimeRoot = "."
+		}
+		if err := config.ValidateNodeRuntime(runtimeRoot); err != nil {
 			bootstrapLogger.Error("node runtime validation failed", "error", err)
 			os.Exit(1)
 		}
@@ -68,6 +72,7 @@ func main() {
 			RequiredEnv:    pcfg.RequiredEnv,
 			StreamJSON:     pcfg.StreamJSON,
 			StripANSI:      pcfg.StripANSI,
+			ProviderRoot:   cfg.Runtime.ProviderRoot,
 		})
 		if err := registry.Register(p); err != nil {
 			logger.Error("register provider", "provider", name, "error", err)

--- a/docs/service.md
+++ b/docs/service.md
@@ -194,6 +194,34 @@ logging:
 | `db_path` | `""` (disabled) | Path to the bbolt database file used to persist session metadata **and PTY output chunks** across daemon restarts. When set, `GetSession` and `ListSessions` surface completed sessions from previous daemon lifetimes. If a persisted non-terminal session still has a live PID at startup, the daemon recovers it into a `RUNNING` state, preserves replay from persisted chunks, and keeps `StopSession` available. Because the current PTY design does not re-open the original live transport, post-restart `AttachSession` is replay-only and `WriteInput`/`ResizeSession` return `UNAVAILABLE` for recovered sessions. |
 | `chunk_storage_bytes` | `0` (unlimited) | Soft upper bound on total PTY chunk bytes stored per session. Reserved for future enforcement; currently has no effect. |
 
+#### `runtime`
+
+Controls how the bridge locates provider CLIs and the Node.js runtime. These settings are optional; omitting the `runtime` block preserves previous behaviour (paths resolved relative to the daemon working directory).
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `provider_root` | `""` (daemon CWD) | Absolute path to the directory that contains `.nvmrc` and provider `node_modules`. When set: (1) Node.js version validation reads `{provider_root}/.nvmrc` instead of the daemon working directory; (2) relative `binary` and `args` paths in each provider definition resolve against `provider_root` instead of the daemon working directory. Use this when the daemon runs as a systemd service with a different `WorkingDirectory` than where provider CLIs are installed. |
+
+Example (`ai-desktops` deployment):
+
+```yaml
+runtime:
+  provider_root: "/opt/ai-agent-bridge"
+
+providers:
+  codex:
+    binary: "/usr/bin/node"
+    args: ["./node_modules/@openai/codex/bin/codex.js"]
+    startup_timeout: "60s"
+    startup_probe:   "output"
+    required_env:    ["OPENAI_API_KEY"]
+    prompt_pattern:  '(?m)(>\s*$|›)'
+```
+
+In this example, `./node_modules/@openai/codex/bin/codex.js` resolves to
+`/opt/ai-agent-bridge/node_modules/@openai/codex/bin/codex.js` regardless of
+where the daemon process is launched from.
+
 #### `providers`
 | Field | Description |
 |-------|-------------|

--- a/e2e/cmd/profile-smoke/main.go
+++ b/e2e/cmd/profile-smoke/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	bridgev1 "github.com/markcallen/ai-agent-bridge/gen/bridge/v1"
+	"github.com/markcallen/ai-agent-bridge/pkg/bridgeclient"
+)
+
+func main() {
+	target := flag.String("target", "127.0.0.1:9445", "bridge address")
+	provider := flag.String("provider", "fixture", "provider name to use")
+	repoPath := flag.String("repo-path", "/workspace/smoke-repo", "repo path for session")
+	timeout := flag.Duration("timeout", 60*time.Second, "overall timeout")
+	flag.Parse()
+
+	client, err := bridgeclient.New(
+		bridgeclient.WithTarget(*target),
+		bridgeclient.WithTimeout(10*time.Second),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: connect: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() { _ = client.Close() }()
+
+	deadline := time.Now().Add(*timeout)
+
+	// Wait for bridge to be healthy.
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		h, hErr := client.Health(ctx)
+		cancel()
+		if hErr == nil && h.GetStatus() == "serving" {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	health, err := client.Health(ctx)
+	if err != nil || health.GetStatus() != "serving" {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: bridge not healthy (err=%v status=%s)\n", err, health.GetStatus())
+		os.Exit(1)
+	}
+
+	// Verify the fixture provider is registered.
+	providers, err := client.ListProviders(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: list providers: %v\n", err)
+		os.Exit(1)
+	}
+	found := false
+	for _, p := range providers.GetProviders() {
+		if p.GetProvider() == *provider {
+			found = true
+		}
+	}
+	if !found {
+		var ids []string
+		for _, p := range providers.GetProviders() {
+			ids = append(ids, p.GetProvider())
+		}
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: provider %q not registered; got %v\n", *provider, ids)
+		os.Exit(1)
+	}
+
+	// Start a session against the workspace repo path.
+	sessionID := uuid.NewString()
+	_, err = client.StartSession(ctx, &bridgev1.StartSessionRequest{
+		ProjectId: "smoke",
+		SessionId: sessionID,
+		RepoPath:  *repoPath,
+		Provider:  *provider,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: start session: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Attach and collect output in a goroutine.
+	outputCh := make(chan string, 32)
+	errCh := make(chan error, 1)
+	attachCtx, attachCancel := context.WithDeadline(context.Background(), deadline)
+	defer attachCancel()
+
+	stream, err := client.AttachSession(attachCtx, &bridgev1.AttachSessionRequest{
+		SessionId: sessionID,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: attach: %v\n", err)
+		os.Exit(1)
+	}
+
+	go func() {
+		recvErr := stream.RecvAll(attachCtx, func(ev *bridgev1.AttachSessionEvent) error {
+			if len(ev.GetPayload()) > 0 {
+				outputCh <- string(ev.GetPayload())
+			}
+			return nil
+		})
+		if recvErr != nil && !errors.Is(recvErr, context.Canceled) && !errors.Is(recvErr, context.DeadlineExceeded) {
+			errCh <- recvErr
+		}
+		close(errCh)
+	}()
+
+	// Give the session a moment to start.
+	time.Sleep(500 * time.Millisecond)
+
+	// Send a probe string and wait for the echo.
+	probe := "bridge-smoke-echo-test"
+	_, err = client.WriteInput(ctx, &bridgev1.WriteInputRequest{
+		SessionId: sessionID,
+		Data:      []byte(probe + "\n"),
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: write input: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Collect output until we see the probe echoed back.
+	echoDeadline := time.Now().Add(10 * time.Second)
+	var collected strings.Builder
+	for time.Now().Before(echoDeadline) {
+		select {
+		case chunk, ok := <-outputCh:
+			if !ok {
+				goto echoCheck
+			}
+			collected.WriteString(chunk)
+			if strings.Contains(collected.String(), probe) {
+				goto echoCheck
+			}
+		case recvErr, ok := <-errCh:
+			if ok && recvErr != nil {
+				fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: stream error: %v\n", recvErr)
+				os.Exit(1)
+			}
+			goto echoCheck
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+echoCheck:
+	if !strings.Contains(collected.String(), probe) {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: probe %q not echoed; got: %q\n", probe, collected.String())
+		os.Exit(1)
+	}
+
+	attachCancel()
+
+	fmt.Printf("PROFILE SMOKE PASSED: provider=%s repo_path=%s providers=%d echo=ok\n",
+		*provider, *repoPath, len(providers.GetProviders()))
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,9 +19,19 @@ type Config struct {
 	Input        InputConfig               `yaml:"input"`
 	RateLimits   RateLimitsConfig          `yaml:"rate_limits"`
 	Persistence  PersistenceConfig         `yaml:"persistence"`
+	Runtime      RuntimeConfig             `yaml:"runtime"`
 	Providers    map[string]ProviderConfig `yaml:"providers"`
 	AllowedPaths []string                  `yaml:"allowed_paths"`
 	Logging      LoggingConfig             `yaml:"logging"`
+}
+
+// RuntimeConfig controls how the bridge locates provider CLIs and the Node.js
+// runtime. When ProviderRoot is set, Node version validation reads
+// {provider_root}/.nvmrc and relative provider binary/arg paths are resolved
+// relative to {provider_root} instead of the daemon working directory. When
+// empty, existing CWD-relative behaviour is preserved.
+type RuntimeConfig struct {
+	ProviderRoot string `yaml:"provider_root"`
 }
 
 type ServerConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -279,3 +279,59 @@ sessions:
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestLoadRuntimeProviderRoot(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantRoot string
+	}{
+		{
+			name: "provider_root set",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+runtime:
+  provider_root: "/opt/ai-agent-bridge"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`,
+			wantRoot: "/opt/ai-agent-bridge",
+		},
+		{
+			name: "provider_root absent",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`,
+			wantRoot: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "bridge.yaml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.Runtime.ProviderRoot != tc.wantRoot {
+				t.Fatalf("ProviderRoot=%q want %q", cfg.Runtime.ProviderRoot, tc.wantRoot)
+			}
+		})
+	}
+}

--- a/internal/config/node.go
+++ b/internal/config/node.go
@@ -84,6 +84,23 @@ func ValidateNodeRuntime(projectRoot string) error {
 	return nil
 }
 
+// RequiresNodeRuntime reports whether cfg has at least one provider that
+// invokes Node.js, either by using "node"/"nodejs" as the binary or by
+// using an absolute node path with a .js script as the first argument.
+// Providers that use non-Node binaries (e.g. native CLIs, /bin/cat) do
+// not require the Node runtime and do not need .nvmrc validation.
 func RequiresNodeRuntime(cfg *Config) bool {
-	return cfg != nil && len(cfg.Providers) > 0
+	if cfg == nil {
+		return false
+	}
+	for _, p := range cfg.Providers {
+		base := filepath.Base(p.Binary)
+		if base == "node" || base == "nodejs" {
+			return true
+		}
+		if len(p.Args) > 0 && strings.HasSuffix(p.Args[0], ".js") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/node_test.go
+++ b/internal/config/node_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -103,5 +104,34 @@ func TestValidateNodeRuntime(t *testing.T) {
 
 	if err := ValidateNodeRuntime(dir); err != nil {
 		t.Fatalf("ValidateNodeRuntime: %v", err)
+	}
+}
+
+func TestValidateNodeRuntimeWithExplicitRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".nvmrc"), []byte("24\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	lookPathNode = func(file string) (string, error) { return "/usr/bin/node", nil }
+	runCommand = func(name string, args ...string) ([]byte, error) {
+		return []byte("v24.1.0\n"), nil
+	}
+	t.Cleanup(func() {
+		lookPathNode = exec.LookPath
+		runCommand = func(name string, args ...string) ([]byte, error) {
+			return exec.Command(name, args...).Output()
+		}
+	})
+
+	// Validates successfully when the explicit root contains .nvmrc.
+	if err := ValidateNodeRuntime(root); err != nil {
+		t.Fatalf("ValidateNodeRuntime with root: %v", err)
+	}
+
+	// Fails when .nvmrc is absent from the given root.
+	emptyRoot := t.TempDir()
+	if err := ValidateNodeRuntime(emptyRoot); err == nil {
+		t.Fatal("expected error for missing .nvmrc")
 	}
 }

--- a/internal/config/runtime_requirements_test.go
+++ b/internal/config/runtime_requirements_test.go
@@ -23,13 +23,40 @@ func TestRequiresNodeRuntime(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "provider configured",
+			name: "node binary",
 			cfg: &Config{
 				Providers: map[string]ProviderConfig{
 					"codex": {Binary: "node"},
 				},
 			},
 			want: true,
+		},
+		{
+			name: "absolute node path with js arg",
+			cfg: &Config{
+				Providers: map[string]ProviderConfig{
+					"gemini": {Binary: "/usr/bin/node", Args: []string{"/opt/ai-agent-bridge/node_modules/@google/gemini-cli/dist/index.js"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "non-node native binary",
+			cfg: &Config{
+				Providers: map[string]ProviderConfig{
+					"fixture": {Binary: "/bin/cat"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "native cli via bin shim",
+			cfg: &Config{
+				Providers: map[string]ProviderConfig{
+					"opencode": {Binary: "/opt/ai-agent-bridge/node_modules/.bin/opencode"},
+				},
+			},
+			want: false,
 		},
 	}
 

--- a/internal/provider/stdio.go
+++ b/internal/provider/stdio.go
@@ -29,6 +29,10 @@ type StdioConfig struct {
 	RequiredEnv    []string
 	StreamJSON     bool // if true, the provider uses stream-JSON mode (no PTY)
 	StripANSI      bool // if true, ANSI escape codes are stripped from PTY output
+	// ProviderRoot is an optional absolute path used as the base for resolving
+	// relative Binary and DefaultArgs paths. When empty, relative paths are
+	// resolved against the daemon working directory (legacy behaviour).
+	ProviderRoot string
 }
 
 // StdioProvider defines how to launch and validate one interactive CLI.
@@ -71,11 +75,11 @@ func (p *StdioProvider) IsStreamJSON() bool { return p.cfg.StreamJSON }
 func (p *StdioProvider) IsStripANSI() bool { return p.cfg.StripANSI }
 
 func (p *StdioProvider) BuildCommand(ctx context.Context, cfg bridge.SessionConfig) (*exec.Cmd, error) {
-	binPath, err := resolveBinaryPath(p.cfg.Binary)
+	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return nil, fmt.Errorf("%w: resolve binary %q: %v", bridge.ErrProviderUnavailable, p.cfg.Binary, err)
 	}
-	args, err := resolveCommandArgs(p.cfg.DefaultArgs)
+	args, err := resolveCommandArgs(p.cfg.DefaultArgs, p.cfg.ProviderRoot)
 	if err != nil {
 		return nil, fmt.Errorf("%w: resolve args for %q: %v", bridge.ErrProviderUnavailable, p.cfg.ProviderID, err)
 	}
@@ -120,11 +124,11 @@ func (p *StdioProvider) validateStartupPrompt(ctx context.Context) error {
 	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.StartupTimeout)
 	defer cancel()
 
-	binPath, err := resolveBinaryPath(p.cfg.Binary)
+	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return err
 	}
-	args, err := resolveCommandArgs(p.cfg.DefaultArgs)
+	args, err := resolveCommandArgs(p.cfg.DefaultArgs, p.cfg.ProviderRoot)
 	if err != nil {
 		return err
 	}
@@ -171,11 +175,11 @@ func (p *StdioProvider) validateStartupOutput(ctx context.Context) error {
 	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.StartupTimeout)
 	defer cancel()
 
-	binPath, err := resolveBinaryPath(p.cfg.Binary)
+	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return err
 	}
-	args, err := resolveCommandArgs(p.cfg.DefaultArgs)
+	args, err := resolveCommandArgs(p.cfg.DefaultArgs, p.cfg.ProviderRoot)
 	if err != nil {
 		return err
 	}
@@ -219,7 +223,7 @@ func (p *StdioProvider) validateStartupOutput(ctx context.Context) error {
 }
 
 func (p *StdioProvider) Version(ctx context.Context) (string, error) {
-	path, err := resolveBinaryPath(p.cfg.Binary)
+	path, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return "", fmt.Errorf("binary %q not found: %w", p.cfg.Binary, err)
 	}
@@ -233,7 +237,7 @@ func (p *StdioProvider) Version(ctx context.Context) (string, error) {
 }
 
 func (p *StdioProvider) Health(ctx context.Context) error {
-	path, err := resolveBinaryPath(p.cfg.Binary)
+	path, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return fmt.Errorf("binary %q not found: %w", p.cfg.Binary, err)
 	}
@@ -247,17 +251,26 @@ func (p *StdioProvider) Health(ctx context.Context) error {
 	return nil
 }
 
-func resolveBinaryPath(binary string) (string, error) {
+// resolveBinaryPath resolves a provider binary to an absolute path. When root
+// is non-empty and binary is a relative path containing a slash, binary is
+// resolved relative to root instead of the process working directory.
+func resolveBinaryPath(binary, root string) (string, error) {
 	if strings.Contains(binary, "/") {
 		if filepath.IsAbs(binary) {
 			return binary, nil
+		}
+		if root != "" {
+			return filepath.Join(root, binary), nil
 		}
 		return filepath.Abs(binary)
 	}
 	return exec.LookPath(binary)
 }
 
-func resolveCommandArgs(args []string) ([]string, error) {
+// resolveCommandArgs converts standalone relative path arguments to absolute
+// paths. When root is non-empty, relative paths are resolved against root
+// instead of the process working directory.
+func resolveCommandArgs(args []string, root string) ([]string, error) {
 	if len(args) == 0 {
 		return nil, nil
 	}
@@ -267,9 +280,15 @@ func resolveCommandArgs(args []string) ([]string, error) {
 		if !isStandaloneRelativePathArg(arg) {
 			continue
 		}
-		abs, err := filepath.Abs(arg)
-		if err != nil {
-			return nil, err
+		var abs string
+		var err error
+		if root != "" {
+			abs = filepath.Join(root, arg)
+		} else {
+			abs, err = filepath.Abs(arg)
+			if err != nil {
+				return nil, err
+			}
 		}
 		resolved[i] = abs
 	}

--- a/internal/provider/stdio_additional_test.go
+++ b/internal/provider/stdio_additional_test.go
@@ -65,7 +65,7 @@ func TestResolveBinaryPathAndFilterEnv(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	path, err := resolveBinaryPath(bin)
+	path, err := resolveBinaryPath(bin, "")
 	if err != nil {
 		t.Fatalf("resolveBinaryPath: %v", err)
 	}

--- a/internal/provider/stdio_test.go
+++ b/internal/provider/stdio_test.go
@@ -84,7 +84,7 @@ func TestResolveCommandArgsLeavesFlagsAndURLsUntouched(t *testing.T) {
 		"--config=./configs/dev.yaml",
 		"https://example.com/api",
 		"../relative-script.js",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("resolveCommandArgs: %v", err)
 	}
@@ -100,5 +100,87 @@ func TestResolveCommandArgsLeavesFlagsAndURLsUntouched(t *testing.T) {
 	}
 	if !filepath.IsAbs(args[3]) {
 		t.Fatalf("relative script should be absolutized, got %q", args[3])
+	}
+}
+
+func TestResolveBinaryPathWithProviderRoot(t *testing.T) {
+	root := t.TempDir()
+
+	// Absolute binary is returned as-is regardless of root.
+	abs, err := resolveBinaryPath("/usr/bin/node", root)
+	if err != nil {
+		t.Fatalf("resolveBinaryPath absolute: %v", err)
+	}
+	if abs != "/usr/bin/node" {
+		t.Fatalf("absolute path changed: %q", abs)
+	}
+
+	// NAME-only binary (no slash) is still looked up on PATH.
+	_, err = resolveBinaryPath("cat", root)
+	if err != nil {
+		t.Fatalf("resolveBinaryPath PATH lookup: %v", err)
+	}
+
+	// Relative path with slash resolves against root, not CWD.
+	got, err := resolveBinaryPath("./bin/tool", root)
+	if err != nil {
+		t.Fatalf("resolveBinaryPath relative: %v", err)
+	}
+	want := filepath.Join(root, "./bin/tool")
+	if got != want {
+		t.Fatalf("resolveBinaryPath=%q want %q", got, want)
+	}
+}
+
+func TestResolveCommandArgsWithProviderRoot(t *testing.T) {
+	root := t.TempDir()
+
+	args, err := resolveCommandArgs([]string{
+		"./node_modules/@openai/codex/bin/codex.js",
+		"--flag",
+		"../sibling.js",
+	}, root)
+	if err != nil {
+		t.Fatalf("resolveCommandArgs: %v", err)
+	}
+
+	// Relative paths with slashes are resolved against root.
+	wantFirst := filepath.Join(root, "./node_modules/@openai/codex/bin/codex.js")
+	if args[0] != wantFirst {
+		t.Fatalf("args[0]=%q want %q", args[0], wantFirst)
+	}
+	// Non-path flags are left alone.
+	if args[1] != "--flag" {
+		t.Fatalf("args[1]=%q want --flag", args[1])
+	}
+	wantThird := filepath.Join(root, "../sibling.js")
+	if args[2] != wantThird {
+		t.Fatalf("args[2]=%q want %q", args[2], wantThird)
+	}
+}
+
+func TestBuildCommandResolvesArgsFromProviderRoot(t *testing.T) {
+	root := t.TempDir()
+
+	p := NewStdioProvider(StdioConfig{
+		ProviderID:    "codex",
+		Binary:        "/usr/bin/node",
+		DefaultArgs:   []string{"./node_modules/@openai/codex/bin/codex.js"},
+		PromptPattern: "›",
+		ProviderRoot:  root,
+	})
+
+	cmd, err := p.BuildCommand(context.Background(), bridge.SessionConfig{
+		ProjectID: "test",
+		SessionID: "s1",
+		RepoPath:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("BuildCommand: %v", err)
+	}
+
+	want := filepath.Join(root, "./node_modules/@openai/codex/bin/codex.js")
+	if len(cmd.Args) < 2 || cmd.Args[1] != want {
+		t.Fatalf("cmd.Args=%v want second arg %q", cmd.Args, want)
 	}
 }

--- a/packaging/examples/bridge-ai-desktops.yaml
+++ b/packaging/examples/bridge-ai-desktops.yaml
@@ -1,0 +1,115 @@
+# bridge-ai-desktops.yaml — ai-desktops agent-host configuration profile.
+#
+# Copy this file to /etc/ai-agent-bridge/bridge.yaml on an ai-desktops host,
+# uncomment the providers you want to enable, and supply credentials via
+# /etc/ai-agent-bridge/agents.env (root:root 0600).
+#
+# This profile:
+#   - binds to 127.0.0.1:9445 (localhost only)
+#   - enables persistence under /var/lib/ai-agent-bridge
+#   - permits /workspace for repository access
+#   - resolves provider CLIs from /opt/ai-agent-bridge (the provider runtime root)
+#   - keeps TLS and JWT disabled (localhost-only — add mTLS+JWT for remote access)
+#
+# SECURITY: do not expose this service over the network without configuring
+# tls.ca_bundle, tls.cert, tls.key, and auth.jwt_public_keys.
+
+server:
+  listen: "127.0.0.1:9445"
+
+tls:
+  ca_bundle: ""
+  cert: ""
+  key: ""
+
+auth:
+  jwt_public_keys: []
+  jwt_audience: "bridge"
+  jwt_max_ttl: "5m"
+
+feature_flags:
+  provider_fallbacks: true
+
+sessions:
+  max_per_project: 5
+  max_global: 20
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  event_buffer_size: 10000
+  max_subscribers_per_session: 10
+  subscriber_ttl: "30m"
+
+input:
+  max_size_bytes: 65536
+
+rate_limits:
+  global_rps: 50
+  global_burst: 100
+  start_session_per_client_rps: 1
+  start_session_per_client_burst: 3
+  send_input_per_session_rps: 5
+  send_input_per_session_burst: 20
+
+persistence:
+  db_path: "/var/lib/ai-agent-bridge/sessions.db"
+
+runtime:
+  provider_root: "/opt/ai-agent-bridge"
+
+# Enable one or more providers below. Credentials are read from the environment
+# (injected via /etc/ai-agent-bridge/agents.env at service startup).
+#
+# Run /usr/lib/ai-agent-bridge/install-provider-runtime to install the CLIs
+# before enabling any provider here.
+
+providers: {}
+
+# Uncomment to enable Codex (requires OPENAI_API_KEY in agents.env):
+#
+#   codex:
+#     binary: "/usr/bin/node"
+#     args: ["./node_modules/@openai/codex/bin/codex.js"]
+#     startup_timeout: "60s"
+#     startup_probe: "output"
+#     required_env: ["OPENAI_API_KEY"]
+#     prompt_pattern: '(?m)(>\s*$|›)'
+
+# Uncomment to enable Claude Code (requires ANTHROPIC_API_KEY in agents.env):
+#
+#   claude:
+#     binary: "/usr/bin/node"
+#     args: ["./node_modules/@anthropic-ai/claude-code/cli.js"]
+#     startup_timeout: "60s"
+#     startup_probe: "output"
+#     required_env: ["ANTHROPIC_API_KEY"]
+#     prompt_pattern: '(?m)(❯|>\s*$)'
+
+# Uncomment to enable OpenCode (requires OPENAI_API_KEY or ANTHROPIC_API_KEY):
+#
+#   opencode:
+#     binary: "/usr/bin/node"
+#     args: ["./node_modules/opencode-ai/dist/cli.js"]
+#     startup_timeout: "45s"
+#     startup_probe: "output"
+
+# Uncomment to enable Gemini CLI (requires GOOGLE_API_KEY in agents.env):
+#
+#   gemini:
+#     binary: "/usr/bin/node"
+#     args: ["./node_modules/@google/gemini-cli/bundle/gemini.js"]
+#     startup_timeout: "60s"
+#     startup_probe: "output"
+#     required_env: ["GOOGLE_API_KEY"]
+
+allowed_paths:
+  - "/home"
+  - "/srv"
+  - "/tmp"
+  - "/var/tmp"
+  - "/workspace"
+
+logging:
+  level: "info"
+  format: "json"
+  redact_patterns:
+    - '(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*\S+'

--- a/packaging/examples/bridge-ai-desktops.yaml
+++ b/packaging/examples/bridge-ai-desktops.yaml
@@ -62,13 +62,13 @@ runtime:
 # Run /usr/lib/ai-agent-bridge/install-provider-runtime to install the CLIs
 # before enabling any provider here.
 
-providers: {}
+providers:
 
 # Uncomment to enable Codex (requires OPENAI_API_KEY in agents.env):
 #
 #   codex:
 #     binary: "/usr/bin/node"
-#     args: ["./node_modules/@openai/codex/bin/codex.js"]
+#     args: ["/opt/ai-agent-bridge/node_modules/@openai/codex/bin/codex.js"]
 #     startup_timeout: "60s"
 #     startup_probe: "output"
 #     required_env: ["OPENAI_API_KEY"]
@@ -78,17 +78,18 @@ providers: {}
 #
 #   claude:
 #     binary: "/usr/bin/node"
-#     args: ["./node_modules/@anthropic-ai/claude-code/cli.js"]
+#     args: ["/opt/ai-agent-bridge/node_modules/@anthropic-ai/claude-code/cli.js"]
 #     startup_timeout: "60s"
 #     startup_probe: "output"
 #     required_env: ["ANTHROPIC_API_KEY"]
 #     prompt_pattern: '(?m)(❯|>\s*$)'
 
 # Uncomment to enable OpenCode (requires OPENAI_API_KEY or ANTHROPIC_API_KEY):
+# OpenCode ships as a native binary installed via npm — no Node.js invocation needed.
 #
 #   opencode:
-#     binary: "/usr/bin/node"
-#     args: ["./node_modules/opencode-ai/dist/cli.js"]
+#     binary: "/opt/ai-agent-bridge/node_modules/.bin/opencode"
+#     args: []
 #     startup_timeout: "45s"
 #     startup_probe: "output"
 
@@ -96,7 +97,7 @@ providers: {}
 #
 #   gemini:
 #     binary: "/usr/bin/node"
-#     args: ["./node_modules/@google/gemini-cli/bundle/gemini.js"]
+#     args: ["/opt/ai-agent-bridge/node_modules/@google/gemini-cli/dist/index.js"]
 #     startup_timeout: "60s"
 #     startup_probe: "output"
 #     required_env: ["GOOGLE_API_KEY"]

--- a/packaging/install-provider-runtime
+++ b/packaging/install-provider-runtime
@@ -1,0 +1,105 @@
+#!/bin/sh
+# install-provider-runtime — Idempotent provider CLI runtime installer.
+#
+# Usage:
+#   install-provider-runtime              Install or upgrade the provider runtime.
+#   install-provider-runtime --verify     Check installed versions; no changes.
+#
+# This script:
+#   1. Verifies (or installs) Node.js REQUIRED_NODE_MAJOR on the system PATH.
+#   2. Copies the packaged runtime manifest from MANIFEST_DIR to INSTALL_DIR.
+#   3. Runs npm ci --omit=dev --no-audit --no-fund to install pinned provider CLIs.
+#   4. Verifies each installed CLI binary is present and reports its version.
+#   5. Ensures INSTALL_DIR is owned root:root and not writable by group/other.
+#
+# The script is safe to re-run; a failed install does not remove a previously
+# working runtime at INSTALL_DIR.
+#
+# MANIFEST_DIR and INSTALL_DIR may be overridden for testing:
+#   MANIFEST_DIR=/custom/src INSTALL_DIR=/custom/dst install-provider-runtime
+
+set -eu
+
+MANIFEST_DIR="${MANIFEST_DIR:-/usr/share/ai-agent-bridge/provider-runtime}"
+INSTALL_DIR="${INSTALL_DIR:-/opt/ai-agent-bridge}"
+REQUIRED_NODE_MAJOR=24
+
+VERIFY_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --verify) VERIFY_ONLY=1 ;;
+    *) echo "install-provider-runtime: unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+say() { printf '==> %s\n' "$*"; }
+
+# ── Node.js version check ──────────────────────────────────────────────────
+
+node_major() {
+  node --version 2>/dev/null | sed 's/v//;s/\..*//'
+}
+
+if ! command -v node >/dev/null 2>&1; then
+  if [ "$VERIFY_ONLY" -eq 1 ]; then
+    die "node not found on PATH; install Node.js ${REQUIRED_NODE_MAJOR} first"
+  fi
+  say "Installing Node.js ${REQUIRED_NODE_MAJOR} via NodeSource..."
+  curl -fsSL "https://deb.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x" | sh -
+  apt-get install -y nodejs
+fi
+
+actual_major=$(node_major)
+if [ "$actual_major" != "$REQUIRED_NODE_MAJOR" ]; then
+  die "Node.js major version is ${actual_major}, required ${REQUIRED_NODE_MAJOR}; upgrade Node.js before running this script"
+fi
+
+say "Node.js $(node --version)"
+
+# ── Runtime manifest installation ─────────────────────────────────────────
+
+if [ "$VERIFY_ONLY" -eq 0 ]; then
+  if [ ! -d "$MANIFEST_DIR" ]; then
+    die "runtime manifest directory not found: ${MANIFEST_DIR}; is ai-agent-bridge installed?"
+  fi
+
+  say "Copying runtime manifest to ${INSTALL_DIR}..."
+  mkdir -p "$INSTALL_DIR"
+  cp -- "$MANIFEST_DIR/.nvmrc"           "$INSTALL_DIR/.nvmrc"
+  cp -- "$MANIFEST_DIR/package.json"     "$INSTALL_DIR/package.json"
+  cp -- "$MANIFEST_DIR/package-lock.json" "$INSTALL_DIR/package-lock.json"
+
+  say "Installing provider CLIs (this may take several minutes)..."
+  # Run in a subshell; the INSTALL_DIR remains usable if npm ci fails.
+  (
+    cd "$INSTALL_DIR"
+    npm ci --omit=dev --no-audit --no-fund
+  )
+
+  say "Fixing ownership of ${INSTALL_DIR}..."
+  chown -R root:root "$INSTALL_DIR"
+  chmod -R go-w "$INSTALL_DIR"
+fi
+
+# ── Version verification ───────────────────────────────────────────────────
+
+say "Verifying installed provider CLIs:"
+
+fail=0
+for cli in claude codex opencode gemini; do
+  bin="${INSTALL_DIR}/node_modules/.bin/${cli}"
+  if [ -x "$bin" ]; then
+    ver=$("$bin" --version 2>&1 || true)
+    printf '  %-12s %s\n' "$cli" "$ver"
+  else
+    printf '  %-12s NOT FOUND at %s\n' "$cli" "$bin" >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" -eq 1 ]; then
+  die "one or more provider CLIs failed verification; check that npm ci completed successfully"
+fi
+
+say "Provider runtime ready at ${INSTALL_DIR}"

--- a/packaging/install-provider-runtime
+++ b/packaging/install-provider-runtime
@@ -46,6 +46,10 @@ if ! command -v node >/dev/null 2>&1; then
     die "node not found on PATH; install Node.js ${REQUIRED_NODE_MAJOR} first"
   fi
   say "Installing Node.js ${REQUIRED_NODE_MAJOR} via NodeSource..."
+  # curl is not always present on minimal Ubuntu installs; install it first.
+  if ! command -v curl >/dev/null 2>&1; then
+    apt-get install -y curl
+  fi
   curl -fsSL "https://deb.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x" | sh -
   apt-get install -y nodejs
 fi
@@ -71,11 +75,20 @@ if [ "$VERIFY_ONLY" -eq 0 ]; then
   cp -- "$MANIFEST_DIR/package-lock.json" "$INSTALL_DIR/package-lock.json"
 
   say "Installing provider CLIs (this may take several minutes)..."
-  # Run in a subshell; the INSTALL_DIR remains usable if npm ci fails.
+  # Install into a staging directory so that a failed npm ci does not
+  # destroy an existing working runtime at INSTALL_DIR.
+  STAGE_DIR=$(mktemp -d)
+  cp -- "$MANIFEST_DIR/.nvmrc"            "$STAGE_DIR/.nvmrc"
+  cp -- "$MANIFEST_DIR/package.json"      "$STAGE_DIR/package.json"
+  cp -- "$MANIFEST_DIR/package-lock.json" "$STAGE_DIR/package-lock.json"
   (
-    cd "$INSTALL_DIR"
+    cd "$STAGE_DIR"
     npm ci --omit=dev --no-audit --no-fund
   )
+  # Swap node_modules only after a successful install.
+  rm -rf "$INSTALL_DIR/node_modules"
+  mv "$STAGE_DIR/node_modules" "$INSTALL_DIR/node_modules"
+  rm -rf "$STAGE_DIR"
 
   say "Fixing ownership of ${INSTALL_DIR}..."
   chown -R root:root "$INSTALL_DIR"

--- a/packaging/systemd/ai-desktops.conf
+++ b/packaging/systemd/ai-desktops.conf
@@ -1,0 +1,25 @@
+# ai-desktops.conf — systemd drop-in for ai-desktops agent-host deployments.
+#
+# Install path: /etc/systemd/system/ai-agent-bridge.service.d/ai-desktops.conf
+# Permissions:  root:root 0644
+#
+# After installing:
+#   systemctl daemon-reload
+#   systemctl restart ai-agent-bridge
+#
+# This drop-in extends the base ai-agent-bridge.service unit with:
+#   - EnvironmentFile for provider credentials (injected from agents.env)
+#   - ReadWritePaths for /workspace so agent subprocesses can modify repos
+#
+# The credential file must be created before the service starts:
+#   install -m 0600 -o root -g root /dev/null /etc/ai-agent-bridge/agents.env
+# Then add the required key=value pairs, for example:
+#   echo "OPENAI_API_KEY=sk-..." >> /etc/ai-agent-bridge/agents.env
+#
+# The leading '-' in EnvironmentFile= means the service starts even if the
+# file is absent; the bridge will fail startup only if a provider's
+# required_env variable is missing from the process environment.
+
+[Service]
+EnvironmentFile=-/etc/ai-agent-bridge/agents.env
+ReadWritePaths=/var/lib/ai-agent-bridge /workspace /tmp /var/tmp

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -38,15 +38,40 @@ GOARCH="$ARCH" go build -o "$ROOT_DIR/bin/ai-agent-bridge-ca" ./cmd/bridge-ca
 mkdir -p \
   "$PKG_ROOT/DEBIAN" \
   "$PKG_ROOT/usr/bin" \
+  "$PKG_ROOT/usr/lib/ai-agent-bridge" \
+  "$PKG_ROOT/usr/share/ai-agent-bridge/provider-runtime" \
+  "$PKG_ROOT/usr/share/doc/ai-agent-bridge/examples" \
   "$PKG_ROOT/etc/ai-agent-bridge" \
   "$PKG_ROOT/lib/systemd/system"
 
-install -m 0755 "$ROOT_DIR/bin/ai-agent-bridge" "$PKG_ROOT/usr/bin/ai-agent-bridge"
+# Binaries
+install -m 0755 "$ROOT_DIR/bin/ai-agent-bridge"    "$PKG_ROOT/usr/bin/ai-agent-bridge"
 install -m 0755 "$ROOT_DIR/bin/ai-agent-bridge-ca" "$PKG_ROOT/usr/bin/ai-agent-bridge-ca"
-install -m 0644 "$ROOT_DIR/packaging/bridge.yaml" "$PKG_ROOT/etc/ai-agent-bridge/bridge.yaml"
-install -m 0644 "$ROOT_DIR/packaging/ai-agent-bridge.service" "$PKG_ROOT/lib/systemd/system/ai-agent-bridge.service"
+
+# Default daemon config and systemd unit
+install -m 0644 "$ROOT_DIR/packaging/bridge.yaml" \
+  "$PKG_ROOT/etc/ai-agent-bridge/bridge.yaml"
+install -m 0644 "$ROOT_DIR/packaging/ai-agent-bridge.service" \
+  "$PKG_ROOT/lib/systemd/system/ai-agent-bridge.service"
+
+# Provider runtime install helper
+install -m 0755 "$ROOT_DIR/packaging/install-provider-runtime" \
+  "$PKG_ROOT/usr/lib/ai-agent-bridge/install-provider-runtime"
+
+# Provider runtime manifest (used by install-provider-runtime)
+install -m 0644 "$ROOT_DIR/.nvmrc"            "$PKG_ROOT/usr/share/ai-agent-bridge/provider-runtime/.nvmrc"
+install -m 0644 "$ROOT_DIR/package.json"      "$PKG_ROOT/usr/share/ai-agent-bridge/provider-runtime/package.json"
+install -m 0644 "$ROOT_DIR/package-lock.json" "$PKG_ROOT/usr/share/ai-agent-bridge/provider-runtime/package-lock.json"
+
+# Example configs and systemd drop-in
+install -m 0644 "$ROOT_DIR/packaging/examples/bridge-ai-desktops.yaml" \
+  "$PKG_ROOT/usr/share/doc/ai-agent-bridge/examples/bridge-ai-desktops.yaml"
+install -m 0644 "$ROOT_DIR/packaging/systemd/ai-desktops.conf" \
+  "$PKG_ROOT/usr/share/doc/ai-agent-bridge/examples/ai-desktops.conf"
+
+# Debian maintainer scripts
 install -m 0755 "$ROOT_DIR/packaging/debian/postinst" "$PKG_ROOT/DEBIAN/postinst"
-install -m 0755 "$ROOT_DIR/packaging/debian/prerm" "$PKG_ROOT/DEBIAN/prerm"
+install -m 0755 "$ROOT_DIR/packaging/debian/prerm"    "$PKG_ROOT/DEBIAN/prerm"
 
 cat >"$PKG_ROOT/DEBIAN/control" <<EOF
 Package: $PACKAGE_NAME

--- a/scripts/smoke-apt-profile.sh
+++ b/scripts/smoke-apt-profile.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# smoke-apt-profile.sh — apt package smoke test for the ai-desktops profile.
+#
+# Verifies that the ai-desktops deployment profile works end-to-end:
+#   1. Install the ai-agent-bridge apt package.
+#   2. Apply a fixture config that mirrors the ai-desktops profile structure:
+#      - persistence enabled
+#      - /workspace in allowed_paths
+#      - a deterministic fixture provider (cat) — no API keys required
+#   3. Create /workspace/smoke-repo.
+#   4. Start the daemon with the fixture config.
+#   5. Run the profile-smoke binary to verify:
+#      - bridge health
+#      - fixture provider registered
+#      - session start for /workspace/smoke-repo passes path policy
+#      - input written to the session is echoed back
+#   6. Restart the daemon.
+#   7. Verify health is restored (persistence not corrupted).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+GNUPGHOME="$TMP_DIR/gnupg"
+REPO_DIR="$TMP_DIR/repo"
+PACKAGES_DIR="$TMP_DIR/packages"
+HEALTHCHECK_BIN="$TMP_DIR/plain-healthcheck"
+PROFILE_SMOKE_BIN="$TMP_DIR/profile-smoke"
+SUITE="${SUITE:-noble}"
+: "${GOCACHE:=/tmp/ai-agent-bridge-go-build}"
+: "${GOFLAGS:=-buildvcs=false}"
+
+export GOCACHE
+export GOFLAGS
+
+cleanup() {
+  local rc=$?
+  docker rm -f "apt-smoke-profile-$SUITE" >/dev/null 2>&1 || true
+  rm -rf "$TMP_DIR"
+  exit "$rc"
+}
+
+trap cleanup EXIT
+
+# ── Build the .deb package ─────────────────────────────────────────────────
+mkdir -p "$GNUPGHOME"
+chmod 700 "$GNUPGHOME"
+
+gpg --batch \
+  --homedir "$GNUPGHOME" \
+  --pinentry-mode loopback \
+  --passphrase '' \
+  --quick-generate-key \
+  "AI Agent Bridge Smoke <smoke@ai-agent-bridge.local>" \
+  rsa3072 sign 0
+
+export GNUPGHOME
+VERSION="0.0.0-smoke" OUTPUT_DIR="$PACKAGES_DIR" "$ROOT_DIR/scripts/build-deb.sh"
+REPO_DIR="$REPO_DIR" PACKAGES_DIR="$PACKAGES_DIR" "$ROOT_DIR/scripts/build-apt-repo.sh"
+
+# ── Build helper binaries ─────────────────────────────────────────────────
+go build -o "$HEALTHCHECK_BIN" ./e2e/cmd/plain-healthcheck
+go build -o "$PROFILE_SMOKE_BIN" ./e2e/cmd/profile-smoke
+
+# ── Write the fixture bridge config ───────────────────────────────────────
+FIXTURE_CONFIG="$TMP_DIR/bridge-fixture.yaml"
+cat >"$FIXTURE_CONFIG" <<'EOF'
+# Fixture config for ai-desktops profile smoke test.
+# Mirrors the ai-desktops profile structure but uses /bin/cat as the
+# provider so no Node.js or API keys are required in CI.
+
+server:
+  listen: "127.0.0.1:9445"
+
+tls:
+  ca_bundle: ""
+  cert: ""
+  key: ""
+
+auth:
+  jwt_public_keys: []
+  jwt_audience: "bridge"
+  jwt_max_ttl: "5m"
+
+feature_flags:
+  provider_fallbacks: false
+
+sessions:
+  max_per_project: 5
+  max_global: 20
+  idle_timeout: "30m"
+  stop_grace_period: "5s"
+  event_buffer_size: 10000
+  max_subscribers_per_session: 10
+  subscriber_ttl: "30m"
+
+input:
+  max_size_bytes: 65536
+
+rate_limits:
+  global_rps: 50
+  global_burst: 100
+  start_session_per_client_rps: 1
+  start_session_per_client_burst: 3
+  send_input_per_session_rps: 5
+  send_input_per_session_burst: 20
+
+persistence:
+  db_path: "/var/lib/ai-agent-bridge/sessions.db"
+
+providers:
+  fixture:
+    binary: "/bin/cat"
+    args: []
+    startup_timeout: "5s"
+    validate_startup: false
+
+allowed_paths:
+  - "/workspace"
+  - "/tmp"
+
+logging:
+  level: "info"
+  format: "json"
+EOF
+
+# ── Determine Ubuntu image tag for suite ──────────────────────────────────
+case "$SUITE" in
+  noble)  IMAGE_TAG="24.04" ;;
+  plucky) IMAGE_TAG="25.04" ;;
+  *)
+    echo "smoke-apt-profile: unsupported SUITE=$SUITE" >&2
+    exit 1
+    ;;
+esac
+
+CONTAINER="apt-smoke-profile-$SUITE"
+
+docker run -d \
+  --name "$CONTAINER" \
+  --add-host=host.docker.internal:host-gateway \
+  -v "$REPO_DIR:/opt/aptrepo:ro" \
+  -v "$HEALTHCHECK_BIN:/usr/local/bin/plain-healthcheck:ro" \
+  -v "$PROFILE_SMOKE_BIN:/usr/local/bin/profile-smoke:ro" \
+  -v "$FIXTURE_CONFIG:/tmp/bridge-fixture.yaml:ro" \
+  ubuntu:"$IMAGE_TAG" \
+  bash -lc "$(cat <<'INNER'
+    set -euo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+
+    # Install package.
+    apt-get update -q
+    apt-get install -y -q ca-certificates gnupg
+    install -d /etc/apt/keyrings
+    gpg --dearmor -o /etc/apt/keyrings/ai-agent-bridge.gpg \
+      /opt/aptrepo/ai-agent-bridge-archive-keyring.asc
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/ai-agent-bridge.gpg] file:/opt/aptrepo noble main" \
+      > /etc/apt/sources.list.d/ai-agent-bridge.list
+    apt-get update -q
+    apt-get install -y -q ai-agent-bridge
+
+    # Apply fixture config.
+    cp /tmp/bridge-fixture.yaml /etc/ai-agent-bridge/bridge.yaml
+
+    # Create workspace directory.
+    mkdir -p /workspace/smoke-repo
+
+    # Start the daemon in the background.
+    /usr/bin/ai-agent-bridge --config /etc/ai-agent-bridge/bridge.yaml \
+      >/tmp/bridge.log 2>&1 &
+    BRIDGE_PID=$!
+
+    # Wait for bridge to report healthy.
+    for i in $(seq 1 30); do
+      if /usr/local/bin/plain-healthcheck -target "127.0.0.1:9445" >/dev/null 2>&1; then
+        break
+      fi
+      if ! kill -0 "$BRIDGE_PID" 2>/dev/null; then
+        echo "PROFILE SMOKE FAILED: bridge exited early"
+        cat /tmp/bridge.log >&2
+        exit 1
+      fi
+      sleep 1
+    done
+
+    # Keep container alive for external smoke probe.
+    tail -f /dev/null
+INNER
+  )" >/dev/null
+
+# ── Wait for bridge health from host ──────────────────────────────────────
+echo "==> Waiting for bridge health (suite=$SUITE)"
+for _ in $(seq 1 30); do
+  if docker exec "$CONTAINER" /usr/local/bin/plain-healthcheck \
+      -target "127.0.0.1:9445" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! docker exec "$CONTAINER" /usr/local/bin/plain-healthcheck \
+    -target "127.0.0.1:9445" >/dev/null 2>&1; then
+  docker exec "$CONTAINER" sh -c 'cat /tmp/bridge.log' >&2 || true
+  echo "APT PROFILE SMOKE FAILED: bridge not healthy suite=$SUITE" >&2
+  exit 1
+fi
+
+# ── Run profile smoke (provider session + echo test) ──────────────────────
+echo "==> Running profile smoke (provider session, workspace path, echo)"
+if ! docker exec "$CONTAINER" /usr/local/bin/profile-smoke \
+    -target "127.0.0.1:9445" \
+    -provider "fixture" \
+    -repo-path "/workspace/smoke-repo" \
+    -timeout "30s"; then
+  docker exec "$CONTAINER" sh -c 'cat /tmp/bridge.log' >&2 || true
+  echo "APT PROFILE SMOKE FAILED: profile-smoke binary failed suite=$SUITE" >&2
+  exit 1
+fi
+
+# ── Restart bridge and verify persistence ─────────────────────────────────
+echo "==> Restarting bridge to verify persistence"
+docker exec "$CONTAINER" bash -c '
+  BRIDGE_PID=$(pgrep -x ai-agent-bridge || true)
+  if [ -n "$BRIDGE_PID" ]; then
+    kill "$BRIDGE_PID"
+    for i in $(seq 1 10); do
+      pgrep -x ai-agent-bridge >/dev/null || break
+      sleep 1
+    done
+  fi
+  /usr/bin/ai-agent-bridge --config /etc/ai-agent-bridge/bridge.yaml \
+    >>/tmp/bridge.log 2>&1 &
+'
+
+for _ in $(seq 1 30); do
+  if docker exec "$CONTAINER" /usr/local/bin/plain-healthcheck \
+      -target "127.0.0.1:9445" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! docker exec "$CONTAINER" /usr/local/bin/plain-healthcheck \
+    -target "127.0.0.1:9445" >/dev/null 2>&1; then
+  docker exec "$CONTAINER" sh -c 'cat /tmp/bridge.log' >&2 || true
+  echo "APT PROFILE SMOKE FAILED: bridge did not recover after restart suite=$SUITE" >&2
+  exit 1
+fi
+
+echo "APT PROFILE SMOKE PASSED: suite=$SUITE"


### PR DESCRIPTION
## Summary

Phase 2 of the [First-Class ai-desktops Support Plan](plans/ai-desktops-support.md). Builds on the `runtime.provider_root` contract from Phase 1 (#90) to ship everything an operator needs to provision an ai-desktops agent-host.

### What's included

**Provider runtime manifest** — ships inside the .deb so `install-provider-runtime` can reinstall pinned CLIs without network access to the bridge repo:
- `/usr/share/ai-agent-bridge/provider-runtime/.nvmrc`
- `/usr/share/ai-agent-bridge/provider-runtime/package.json`
- `/usr/share/ai-agent-bridge/provider-runtime/package-lock.json`

**Idempotent install helper** (`/usr/lib/ai-agent-bridge/install-provider-runtime`):
- Verifies or installs Node.js 24 via NodeSource
- Copies the packaged manifest to `/opt/ai-agent-bridge`
- Runs `npm ci --omit=dev --no-audit --no-fund`
- Verifies each CLI binary (claude, codex, opencode, gemini) is present and prints its version
- Leaves `/opt/ai-agent-bridge` owned `root:root`
- Safe to re-run; a failed install does not remove a previously working runtime
- Supports `--verify` for check-only mode

**ai-desktops example config** (`/usr/share/doc/ai-agent-bridge/examples/bridge-ai-desktops.yaml`):
- Binds to `127.0.0.1:9445`
- Persistence under `/var/lib/ai-agent-bridge`
- `/workspace` in `allowed_paths`
- `runtime.provider_root: "/opt/ai-agent-bridge"`
- All four providers commented out with copy-paste instructions
- Documents mTLS+JWT requirement for remote exposure

**systemd drop-in example** (`/usr/share/doc/ai-agent-bridge/examples/ai-desktops.conf`):
- `EnvironmentFile=-/etc/ai-agent-bridge/agents.env` for credential injection
- `ReadWritePaths` extended to include `/workspace /tmp /var/tmp`
- Install path and operator instructions in comments

**CI: ai-desktops profile apt smoke test** (`scripts/smoke-apt-profile.sh` + `e2e/cmd/profile-smoke`):
- Installs the .deb in Ubuntu 24.04 (noble) Docker container
- Applies a fixture config mirroring the ai-desktops profile (`/bin/cat` as provider — no API keys)
- Creates `/workspace/smoke-repo`
- Starts the daemon with the fixture config
- Runs `profile-smoke` binary to verify: health, provider registered, session start for `/workspace/smoke-repo` (path policy), echo round-trip
- Restarts the daemon and verifies health is restored (persistence not corrupted)
- New `apt-smoke-profile` CI job runs on every PR

## Test plan

- [ ] `make test` passes (all Go unit tests)
- [ ] `apt-smoke-local` CI job green (existing base smoke unchanged)
- [ ] `apt-smoke-profile` CI job green (new profile smoke)
- [ ] `install-provider-runtime --verify` runs cleanly on a host with Node.js 24
- [ ] Example config passes `ai-agent-bridge --config bridge-ai-desktops.yaml` validation with a provider enabled and its env var set

🤖 Generated with [Claude Code](https://claude.com/claude-code)