### PR TITLE
feat: first-class ai-desktops support — phases 1–3 (provider_root, packaging, docs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,3 +194,25 @@ jobs:
 
       - name: Run local apt smoke test
         run: ./scripts/smoke-apt-local.sh
+
+  apt-smoke-profile:
+    if: github.event_name == 'pull_request'
+    needs:
+      - go-lint
+      - go-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install packaging tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y apt-utils dpkg-dev gnupg
+
+      - name: Run ai-desktops profile apt smoke test
+        run: ./scripts/smoke-apt-profile.sh

--- a/PRD.md
+++ b/PRD.md
@@ -250,6 +250,40 @@ The bridge must be installable on supported Ubuntu hosts through a signed apt re
 - The release workflow includes smoke coverage that validates apt installation in containers and on an EC2 host.
 - `README.md` and `docs/` describe package installation, runtime prerequisites, and service behavior accurately.
 
+## 7.7 ai-desktops Agent-Host Deployment Target
+
+The bridge must support a first-class deployment profile for the **ai-desktops** platform: Ubuntu 24.04 machines where the daemon runs as a system service and AI agents operate against repositories mounted under `/workspace`.
+
+### Deployment Profile Requirements
+
+- The package must ship a provider runtime installer (`install-provider-runtime`) that:
+  - Verifies or installs Node.js at the required major version.
+  - Installs pinned provider CLIs (Claude Code, Codex, OpenCode, Gemini) into `/opt/ai-agent-bridge` using `npm ci` with a staging directory pattern so a failed install never destroys a working runtime.
+  - Reports installed CLI versions for operator verification.
+- The package must ship an ai-desktops example config (`bridge-ai-desktops.yaml`) with correct provider stanzas for all four supported providers and `/workspace` included in `allowed_paths`.
+- The package must ship a systemd drop-in example (`ai-desktops.conf`) that:
+  - Injects provider API keys from `/etc/ai-agent-bridge/agents.env` at service startup.
+  - Grants agent subprocesses write access to `/workspace`, `/var/lib/ai-agent-bridge`, `/tmp`, and `/var/tmp`.
+- Provider API keys must be stored in `/etc/ai-agent-bridge/agents.env` with `root:root 0600` permissions and never written to disk by the bridge itself.
+- The Node.js runtime validation must only run when at least one configured provider actually invokes Node.js (native binary providers such as OpenCode must not trigger Node validation).
+
+### Supported Providers on ai-desktops
+
+| Provider | Invocation | Required Credential |
+|---|---|---|
+| Claude Code | `/usr/bin/node ... @anthropic-ai/claude-code/cli.js` | `ANTHROPIC_API_KEY` |
+| Codex | `/usr/bin/node ... @openai/codex/bin/codex.js` | `OPENAI_API_KEY` |
+| OpenCode | `/opt/ai-agent-bridge/node_modules/.bin/opencode` (native binary) | `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` |
+| Gemini CLI | `/usr/bin/node ... @google/gemini-cli/dist/index.js` | `GOOGLE_API_KEY` |
+
+### Acceptance Criteria
+
+- `install-provider-runtime` installs all four provider CLIs and reports their versions on a clean Ubuntu 24.04 host with Node.js 24.
+- A failed `npm ci` during runtime install does not remove a previously working `/opt/ai-agent-bridge/node_modules`.
+- An apt profile smoke test verifies: package install, fixture provider registration, session start, `/workspace` access, echo round-trip, daemon restart, and health check — all without real API keys.
+- The bridge daemon starts with an OpenCode (native binary) provider configured and does not trigger Node.js runtime validation.
+- `docs/ai-desktops.md` provides a complete operator provisioning guide covering architecture, install, config, credentials, upgrade, and troubleshooting.
+
 ---
 
 ## 8. gRPC API Contract (v1)

--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ scripts/                       Development helper scripts
 ## Documentation
 
 - [docs/service.md](docs/service.md) — Architecture, configuration reference, security
+- [docs/install-ubuntu.md](docs/install-ubuntu.md) — apt repository installation and package details
+- [docs/ai-desktops.md](docs/ai-desktops.md) — ai-desktops agent-host provisioning guide
 - [docs/go-sdk.md](docs/go-sdk.md) — Go SDK reference
 - [docs/node-sdk.md](docs/node-sdk.md) — Node.js SDK and React hook reference
 - [docs/grpc-api.md](docs/grpc-api.md) — Full gRPC API reference

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -37,7 +37,11 @@ func main() {
 		os.Exit(1)
 	}
 	if config.RequiresNodeRuntime(cfg) {
-		if err := config.ValidateNodeRuntime("."); err != nil {
+		runtimeRoot := cfg.Runtime.ProviderRoot
+		if runtimeRoot == "" {
+			runtimeRoot = "."
+		}
+		if err := config.ValidateNodeRuntime(runtimeRoot); err != nil {
 			bootstrapLogger.Error("node runtime validation failed", "error", err)
 			os.Exit(1)
 		}
@@ -68,6 +72,7 @@ func main() {
 			RequiredEnv:    pcfg.RequiredEnv,
 			StreamJSON:     pcfg.StreamJSON,
 			StripANSI:      pcfg.StripANSI,
+			ProviderRoot:   cfg.Runtime.ProviderRoot,
 		})
 		if err := registry.Register(p); err != nil {
 			logger.Error("register provider", "provider", name, "error", err)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This is the canonical documentation index for the repository.
 ## Core Guides
 
 - [install-ubuntu.md](install-ubuntu.md): apt repository installation, package contents, systemd behavior, and runtime prerequisites.
+- [ai-desktops.md](ai-desktops.md): provisioning, operating, and troubleshooting the bridge on an ai-desktops Ubuntu 24.04 agent host with provider CLIs, `/workspace` access, and credential injection.
 - [service.md](service.md): daemon architecture, configuration, security model, Docker usage, and operational details.
 - [grpc-api.md](grpc-api.md): protobuf RPC surface, message fields, error codes, and client generation details.
 - [go-sdk.md](go-sdk.md): Go SDK usage, client options, reconnect behavior, and API examples.
@@ -14,9 +15,10 @@ This is the canonical documentation index for the repository.
 ## Recommended Reading Order
 
 1. [install-ubuntu.md](install-ubuntu.md) if you are installing the packaged daemon on Ubuntu
-2. [service.md](service.md)
-3. [grpc-api.md](grpc-api.md)
-4. [go-sdk.md](go-sdk.md) or [node-sdk.md](node-sdk.md), depending on the client you are building
+2. [ai-desktops.md](ai-desktops.md) if you are setting up an ai-desktops agent host
+3. [service.md](service.md)
+4. [grpc-api.md](grpc-api.md)
+5. [go-sdk.md](go-sdk.md) or [node-sdk.md](node-sdk.md), depending on the client you are building
 
 ## Local Development
 

--- a/docs/ai-desktops.md
+++ b/docs/ai-desktops.md
@@ -1,0 +1,362 @@
+# ai-desktops Agent-Host Guide
+
+This guide covers provisioning, operating, and troubleshooting `ai-agent-bridge` on an **ai-desktops** Ubuntu 24.04 host — a machine where the bridge runs as a system service and spawns AI agent CLIs against repositories under `/workspace`.
+
+---
+
+## Architecture and Security Boundary
+
+```
+ai-desktops host (Ubuntu 24.04)
+┌─────────────────────────────────────────────────────┐
+│                                                     │
+│  /workspace/<repo>       ← agent working directories │
+│                                                     │
+│  ai-agent-bridge daemon  127.0.0.1:9445             │
+│    ↕ PTY                                            │
+│  claude / codex / opencode / gemini                 │
+│    (from /opt/ai-agent-bridge/node_modules/)        │
+│                                                     │
+│  /etc/ai-agent-bridge/                              │
+│    bridge.yaml           ← operator-supplied config │
+│    agents.env            ← root:root 0600, API keys │
+│                                                     │
+│  /opt/ai-agent-bridge/   ← provider CLIs, root:root │
+│  /var/lib/ai-agent-bridge/sessions.db  ← persistence │
+│                                                     │
+└─────────────────────────────────────────────────────┘
+         ↑ localhost only — no external exposure
+```
+
+**Security constraints:**
+
+- The bridge listens on `127.0.0.1:9445` only. Do not expose it publicly without adding mTLS and JWT (see [service.md](service.md)).
+- Provider API keys live in `/etc/ai-agent-bridge/agents.env` (`root:root 0600`). They are injected into the daemon environment at service startup and never written to disk by the bridge.
+- The service account (`ai-agent-bridge`) cannot write to `/opt/ai-agent-bridge`. Only root can update provider CLIs.
+- Agent subprocesses inherit the systemd sandbox and can write to `/workspace`, `/var/lib/ai-agent-bridge`, `/tmp`, and `/var/tmp` only.
+
+---
+
+## Package Install
+
+Install `ai-agent-bridge` from the apt repository:
+
+```bash
+curl -fsSL https://markcallen.github.io/ai-agent-bridge/install.sh | sudo bash
+sudo systemctl enable --now ai-agent-bridge
+sudo systemctl status ai-agent-bridge
+```
+
+The base package installs a provider-neutral daemon. It starts and passes a health check, but no AI providers are configured yet.
+
+**What the package installs:**
+
+```
+/usr/bin/ai-agent-bridge
+/usr/bin/ai-agent-bridge-ca
+/etc/ai-agent-bridge/bridge.yaml           ← default (no providers)
+/lib/systemd/system/ai-agent-bridge.service
+/usr/lib/ai-agent-bridge/install-provider-runtime
+/usr/share/ai-agent-bridge/provider-runtime/.nvmrc
+/usr/share/ai-agent-bridge/provider-runtime/package.json
+/usr/share/ai-agent-bridge/provider-runtime/package-lock.json
+/usr/share/doc/ai-agent-bridge/examples/bridge-ai-desktops.yaml
+/usr/share/doc/ai-agent-bridge/examples/ai-desktops.conf
+```
+
+---
+
+## Provisioning Flow
+
+Run these steps once after installing the package, or re-run them on upgrade.
+
+### 1. Install the Provider Runtime
+
+```bash
+sudo /usr/lib/ai-agent-bridge/install-provider-runtime
+```
+
+This script:
+
+1. Installs or verifies Node.js 24 via NodeSource (if not already present).
+2. Copies the packaged runtime manifest to `/opt/ai-agent-bridge`.
+3. Runs `npm ci --omit=dev` in a staging directory and swaps `node_modules` into place only on success — a failed install leaves the existing runtime working.
+4. Verifies each installed CLI binary is present and prints its version.
+5. Sets ownership of `/opt/ai-agent-bridge` to `root:root`.
+
+To verify an existing installation without making changes:
+
+```bash
+sudo /usr/lib/ai-agent-bridge/install-provider-runtime --verify
+```
+
+### 2. Apply the ai-desktops Config
+
+Copy and customize the example config:
+
+```bash
+sudo cp /usr/share/doc/ai-agent-bridge/examples/bridge-ai-desktops.yaml \
+  /etc/ai-agent-bridge/bridge.yaml
+sudo $EDITOR /etc/ai-agent-bridge/bridge.yaml
+```
+
+Uncomment one or more provider blocks in the config. See [Provider Configuration](#provider-configuration) below.
+
+### 3. Install the systemd Drop-In
+
+```bash
+sudo mkdir -p /etc/systemd/system/ai-agent-bridge.service.d
+sudo cp /usr/share/doc/ai-agent-bridge/examples/ai-desktops.conf \
+  /etc/systemd/system/ai-agent-bridge.service.d/ai-desktops.conf
+```
+
+The drop-in extends the base unit with:
+- `EnvironmentFile=-/etc/ai-agent-bridge/agents.env` — injects credentials from the env file
+- `ReadWritePaths=/var/lib/ai-agent-bridge /workspace /tmp /var/tmp` — grants agent write access to `/workspace`
+
+### 4. Create the Credentials File
+
+Create the credentials file before starting the service:
+
+```bash
+sudo install -m 0600 -o root -g root /dev/null /etc/ai-agent-bridge/agents.env
+```
+
+Add required API key variables for the providers you enabled:
+
+```bash
+# For Claude Code:
+echo "ANTHROPIC_API_KEY=sk-ant-..." | sudo tee -a /etc/ai-agent-bridge/agents.env >/dev/null
+
+# For Codex:
+echo "OPENAI_API_KEY=sk-..." | sudo tee -a /etc/ai-agent-bridge/agents.env >/dev/null
+
+# For Gemini CLI:
+echo "GOOGLE_API_KEY=AIza..." | sudo tee -a /etc/ai-agent-bridge/agents.env >/dev/null
+```
+
+The leading `-` in `EnvironmentFile=-/path` means the service starts even if the file is absent. The bridge itself fails at startup if a configured provider's `required_env` variable is missing from the process environment.
+
+### 5. Reload and Restart
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart ai-agent-bridge
+sudo systemctl status ai-agent-bridge
+```
+
+### 6. Verify Health
+
+```bash
+sudo journalctl -u ai-agent-bridge --no-pager -n 30
+```
+
+Look for `bridge daemon starting` and `registered provider` log lines.
+
+---
+
+## Provider Runtime Layout
+
+After running `install-provider-runtime`, the runtime is at:
+
+```
+/opt/ai-agent-bridge/
+  .nvmrc                         ← required Node.js major version
+  package.json                   ← pinned provider CLI versions
+  package-lock.json              ← reproducible install manifest
+  node_modules/
+    @anthropic-ai/claude-code/   ← Claude Code CLI
+    @openai/codex/               ← Codex CLI
+    opencode-ai/                 ← OpenCode (native binary)
+    @google/gemini-cli/          ← Gemini CLI
+    .bin/
+      claude
+      codex
+      opencode
+      gemini
+```
+
+---
+
+## Provider Configuration
+
+Edit `/etc/ai-agent-bridge/bridge.yaml`. Uncomment the relevant block and supply credentials via `/etc/ai-agent-bridge/agents.env`.
+
+### Claude Code
+
+```yaml
+providers:
+  claude:
+    binary: "/usr/bin/node"
+    args: ["/opt/ai-agent-bridge/node_modules/@anthropic-ai/claude-code/cli.js"]
+    startup_timeout: "60s"
+    startup_probe: "output"
+    required_env: ["ANTHROPIC_API_KEY"]
+    prompt_pattern: '(?m)(❯|>\s*$)'
+```
+
+Requires `ANTHROPIC_API_KEY` in `/etc/ai-agent-bridge/agents.env`.
+
+### Codex
+
+```yaml
+providers:
+  codex:
+    binary: "/usr/bin/node"
+    args: ["/opt/ai-agent-bridge/node_modules/@openai/codex/bin/codex.js"]
+    startup_timeout: "60s"
+    startup_probe: "output"
+    required_env: ["OPENAI_API_KEY"]
+    prompt_pattern: '(?m)(>\s*$|›)'
+```
+
+Requires `OPENAI_API_KEY` in `/etc/ai-agent-bridge/agents.env`.
+
+### OpenCode
+
+OpenCode ships as a native binary — no Node invocation needed.
+
+```yaml
+providers:
+  opencode:
+    binary: "/opt/ai-agent-bridge/node_modules/.bin/opencode"
+    args: []
+    startup_timeout: "45s"
+    startup_probe: "output"
+```
+
+Requires `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` (depending on which model is configured in OpenCode).
+
+### Gemini CLI
+
+```yaml
+providers:
+  gemini:
+    binary: "/usr/bin/node"
+    args: ["/opt/ai-agent-bridge/node_modules/@google/gemini-cli/dist/index.js"]
+    startup_timeout: "60s"
+    startup_probe: "output"
+    required_env: ["GOOGLE_API_KEY"]
+```
+
+Requires `GOOGLE_API_KEY` in `/etc/ai-agent-bridge/agents.env`.
+
+---
+
+## Environment File Contract
+
+The credentials file is the only supported mechanism for injecting secrets into the bridge service:
+
+| Path | Owner | Mode | Purpose |
+|---|---|---|---|
+| `/etc/ai-agent-bridge/agents.env` | `root:root` | `0600` | Provider API keys and secrets |
+
+Each line is a `KEY=value` pair. The bridge daemon inherits these variables at startup and passes them to provider subprocesses. The bridge never logs, redacts-and-logs, or writes secret values.
+
+**Do not:**
+- Write secrets into `bridge.yaml` or any other world-readable file.
+- Store secrets in the repository, apt package, AMI, or instance metadata.
+- Set permissions above `0600` on `agents.env`.
+
+---
+
+## Upgrade Workflow
+
+When a new `ai-agent-bridge` package is published:
+
+```bash
+sudo apt-get update
+sudo apt-get upgrade -y ai-agent-bridge
+sudo /usr/lib/ai-agent-bridge/install-provider-runtime
+sudo systemctl daemon-reload
+sudo systemctl restart ai-agent-bridge
+sudo systemctl status ai-agent-bridge
+```
+
+The `install-provider-runtime` step re-copies the updated manifest and reinstalls pinned provider CLIs into a staging directory. Existing workspaces and session persistence are unaffected.
+
+---
+
+## Troubleshooting
+
+### Service fails to start
+
+```bash
+sudo journalctl -u ai-agent-bridge --no-pager -n 50
+```
+
+Common causes:
+
+| Log message | Fix |
+|---|---|
+| `node runtime validation failed` | Node.js not installed or wrong version. Run `install-provider-runtime`. |
+| `provider environment validation failed` | A required env var is missing. Check `agents.env`. |
+| `open session store` | `/var/lib/ai-agent-bridge` not writable. Check systemd `ReadWritePaths`. |
+| `listen ... bind: address already in use` | Port 9445 in use. Check `ss -tlnp` and resolve the conflict. |
+
+### Check Node.js version
+
+```bash
+node --version           # should print v24.x.x
+/usr/lib/ai-agent-bridge/install-provider-runtime --verify
+```
+
+### Check provider CLI binaries
+
+```bash
+/opt/ai-agent-bridge/node_modules/.bin/claude --version
+/opt/ai-agent-bridge/node_modules/.bin/codex --version
+/opt/ai-agent-bridge/node_modules/.bin/opencode --version
+/opt/ai-agent-bridge/node_modules/.bin/gemini --version
+```
+
+### Check runtime.provider_root is correct
+
+If you see `node runtime validation failed: read .nvmrc: ...`, the bridge cannot find the `.nvmrc` at the configured `runtime.provider_root`. Verify:
+
+```bash
+cat /etc/ai-agent-bridge/bridge.yaml | grep provider_root
+ls /opt/ai-agent-bridge/.nvmrc
+```
+
+### Check /workspace access
+
+```bash
+# Verify the drop-in is installed:
+cat /etc/systemd/system/ai-agent-bridge.service.d/ai-desktops.conf
+
+# Verify the bridge policy allows /workspace:
+grep workspace /etc/ai-agent-bridge/bridge.yaml
+
+# Verify the directory exists:
+ls -la /workspace
+```
+
+### Check bridge health
+
+```bash
+# Using the bridge-ca healthcheck binary (if built):
+/usr/local/bin/plain-healthcheck -target 127.0.0.1:9445
+
+# Using grpc-health-probe if installed:
+grpc-health-probe -addr 127.0.0.1:9445
+```
+
+### View live logs
+
+```bash
+sudo journalctl -u ai-agent-bridge -f
+```
+
+---
+
+## Localhost-Only Default and Remote Exposure Warning
+
+By default the bridge binds to `127.0.0.1:9445`. All connections originate from the same host. There is no encryption or authentication required for localhost-only use.
+
+**If you expose the bridge over the network** (by changing `server.listen` to `0.0.0.0:9445` or forwarding port 9445), you must also configure:
+
+- `tls.ca_bundle`, `tls.cert`, `tls.key` — mTLS to authenticate clients
+- `auth.jwt_public_keys` — JWT (Ed25519) to authorize RPCs
+
+See [service.md — Security](service.md) for the full mTLS + JWT configuration reference.

--- a/docs/ai-desktops.md
+++ b/docs/ai-desktops.md
@@ -57,6 +57,7 @@ The base package installs a provider-neutral daemon. It starts and passes a heal
 /etc/ai-agent-bridge/bridge.yaml           ← default (no providers)
 /lib/systemd/system/ai-agent-bridge.service
 /usr/lib/ai-agent-bridge/install-provider-runtime
+/usr/lib/ai-agent-bridge/ai-desktops-doctor
 /usr/share/ai-agent-bridge/provider-runtime/.nvmrc
 /usr/share/ai-agent-bridge/provider-runtime/package.json
 /usr/share/ai-agent-bridge/provider-runtime/package-lock.json
@@ -274,6 +275,52 @@ sudo systemctl status ai-agent-bridge
 ```
 
 The `install-provider-runtime` step re-copies the updated manifest and reinstalls pinned provider CLIs into a staging directory. Existing workspaces and session persistence are unaffected.
+
+---
+
+## Doctor Check
+
+Run the included readiness check to confirm the host is correctly configured as an agent-host before or after provisioning:
+
+```bash
+sudo /usr/lib/ai-agent-bridge/ai-desktops-doctor
+```
+
+The script checks ten items and prints `[OK]`, `[FAIL]`, or `[WARN]` for each:
+
+| Check | What it verifies |
+|---|---|
+| Package version | `ai-agent-bridge` apt package is installed |
+| Service state | `ai-agent-bridge.service` is active |
+| Port 9445 | Daemon is listening on `127.0.0.1:9445` |
+| Node.js | Node.js v24.x.x is on `PATH` |
+| Provider runtime | `/opt/ai-agent-bridge/node_modules/` is present |
+| Configured providers | One or more providers are enabled in `bridge.yaml` |
+| Credentials | Required env variables are present in `agents.env` (names only, not values) |
+| `/workspace` policy | Bridge `allowed_paths` includes `/workspace` |
+| systemd drop-in | Drop-in is installed and grants `ReadWritePaths=/workspace` |
+| Bridge health | Bridge responds on `127.0.0.1:9445` |
+
+The script exits `0` if all checks pass and `1` if any `[FAIL]` item is found. `[WARN]` items are informational and do not cause a non-zero exit.
+
+```
+ai-desktops bridge doctor
+=========================
+
+[OK]   Package version: ai-agent-bridge 0.4.0
+[OK]   Service state: active
+[OK]   Port 9445: bound to 127.0.0.1
+[OK]   Node.js: v24.2.0
+[OK]   Provider runtime: /opt/ai-agent-bridge (node_modules present)
+[OK]   Configured providers: claude
+       ANTHROPIC_API_KEY: set
+[OK]   Credentials: all required variables present
+[OK]   /workspace: listed in bridge allowed_paths
+[OK]   systemd drop-in: /etc/systemd/system/ai-agent-bridge.service.d/ai-desktops.conf (ReadWritePaths includes /workspace)
+[OK]   Bridge health: healthy (127.0.0.1:9445)
+
+Result: 10 OK, 0 FAIL
+```
 
 ---
 

--- a/docs/install-ubuntu.md
+++ b/docs/install-ubuntu.md
@@ -77,3 +77,15 @@ For a usable agent host you still need to:
 2. Supply the required API keys and environment for those providers.
 3. Replace the default provider-less config with your real provider and auth settings.
 4. Review the service account and repository path permissions before exposing the daemon beyond localhost.
+
+## ai-desktops Agent-Host Profile
+
+If you are provisioning a dedicated Ubuntu 24.04 machine where the bridge runs as a system service and spawns AI agents against repositories under `/workspace`, follow the **ai-desktops** profile instead of the manual steps above.
+
+The ai-desktops profile adds:
+
+- A provider runtime installer (`/usr/lib/ai-agent-bridge/install-provider-runtime`) that installs pinned Claude, Codex, OpenCode, and Gemini CLIs into `/opt/ai-agent-bridge`.
+- An example config (`/usr/share/doc/ai-agent-bridge/examples/bridge-ai-desktops.yaml`) with all four provider stanzas pre-written and the `/workspace` path policy enabled.
+- A systemd drop-in (`/usr/share/doc/ai-agent-bridge/examples/ai-desktops.conf`) that injects credentials from `/etc/ai-agent-bridge/agents.env` and grants agent write access to `/workspace`.
+
+See [ai-desktops.md](ai-desktops.md) for the full provisioning guide.

--- a/docs/service.md
+++ b/docs/service.md
@@ -200,7 +200,7 @@ Controls how the bridge locates provider CLIs and the Node.js runtime. These set
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `provider_root` | `""` (daemon CWD) | Absolute path to the directory that contains `.nvmrc` and provider `node_modules`. When set: (1) Node.js version validation reads `{provider_root}/.nvmrc` instead of the daemon working directory; (2) relative `binary` and `args` paths in each provider definition resolve against `provider_root` instead of the daemon working directory. Use this when the daemon runs as a systemd service with a different `WorkingDirectory` than where provider CLIs are installed. |
+| `provider_root` | `""` (daemon CWD) | Absolute path to the directory that contains `.nvmrc` and provider `node_modules`. When set: (1) Node.js version validation reads `{provider_root}/.nvmrc` instead of the daemon working directory; (2) a relative `binary` path (one that contains a `/`) resolves against `provider_root`; (3) bare standalone relative path arguments (e.g. `./node_modules/foo/bin/cli.js`) resolve against `provider_root`. Plain command names looked up via `PATH` (e.g. `node`) and embedded flag values (e.g. `--config=./foo`) are not affected. Use this when the daemon runs as a systemd service with a different `WorkingDirectory` than where provider CLIs are installed. |
 
 Example (`ai-desktops` deployment):
 

--- a/docs/service.md
+++ b/docs/service.md
@@ -194,6 +194,34 @@ logging:
 | `db_path` | `""` (disabled) | Path to the bbolt database file used to persist session metadata **and PTY output chunks** across daemon restarts. When set, `GetSession` and `ListSessions` surface completed sessions from previous daemon lifetimes. If a persisted non-terminal session still has a live PID at startup, the daemon recovers it into a `RUNNING` state, preserves replay from persisted chunks, and keeps `StopSession` available. Because the current PTY design does not re-open the original live transport, post-restart `AttachSession` is replay-only and `WriteInput`/`ResizeSession` return `UNAVAILABLE` for recovered sessions. |
 | `chunk_storage_bytes` | `0` (unlimited) | Soft upper bound on total PTY chunk bytes stored per session. Reserved for future enforcement; currently has no effect. |
 
+#### `runtime`
+
+Controls how the bridge locates provider CLIs and the Node.js runtime. These settings are optional; omitting the `runtime` block preserves previous behaviour (paths resolved relative to the daemon working directory).
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `provider_root` | `""` (daemon CWD) | Absolute path to the directory that contains `.nvmrc` and provider `node_modules`. When set: (1) Node.js version validation reads `{provider_root}/.nvmrc` instead of the daemon working directory; (2) relative `binary` and `args` paths in each provider definition resolve against `provider_root` instead of the daemon working directory. Use this when the daemon runs as a systemd service with a different `WorkingDirectory` than where provider CLIs are installed. |
+
+Example (`ai-desktops` deployment):
+
+```yaml
+runtime:
+  provider_root: "/opt/ai-agent-bridge"
+
+providers:
+  codex:
+    binary: "/usr/bin/node"
+    args: ["./node_modules/@openai/codex/bin/codex.js"]
+    startup_timeout: "60s"
+    startup_probe:   "output"
+    required_env:    ["OPENAI_API_KEY"]
+    prompt_pattern:  '(?m)(>\s*$|›)'
+```
+
+In this example, `./node_modules/@openai/codex/bin/codex.js` resolves to
+`/opt/ai-agent-bridge/node_modules/@openai/codex/bin/codex.js` regardless of
+where the daemon process is launched from.
+
 #### `providers`
 | Field | Description |
 |-------|-------------|

--- a/e2e/cmd/profile-smoke/main.go
+++ b/e2e/cmd/profile-smoke/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	bridgev1 "github.com/markcallen/ai-agent-bridge/gen/bridge/v1"
+	"github.com/markcallen/ai-agent-bridge/pkg/bridgeclient"
+)
+
+func main() {
+	target := flag.String("target", "127.0.0.1:9445", "bridge address")
+	provider := flag.String("provider", "fixture", "provider name to use")
+	repoPath := flag.String("repo-path", "/workspace/smoke-repo", "repo path for session")
+	timeout := flag.Duration("timeout", 60*time.Second, "overall timeout")
+	flag.Parse()
+
+	client, err := bridgeclient.New(
+		bridgeclient.WithTarget(*target),
+		bridgeclient.WithTimeout(10*time.Second),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: connect: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() { _ = client.Close() }()
+
+	deadline := time.Now().Add(*timeout)
+
+	// Wait for bridge to be healthy.
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		h, hErr := client.Health(ctx)
+		cancel()
+		if hErr == nil && h.GetStatus() == "serving" {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	health, err := client.Health(ctx)
+	if err != nil || health.GetStatus() != "serving" {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: bridge not healthy (err=%v status=%s)\n", err, health.GetStatus())
+		os.Exit(1)
+	}
+
+	// Verify the fixture provider is registered.
+	providers, err := client.ListProviders(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: list providers: %v\n", err)
+		os.Exit(1)
+	}
+	found := false
+	for _, p := range providers.GetProviders() {
+		if p.GetProvider() == *provider {
+			found = true
+		}
+	}
+	if !found {
+		var ids []string
+		for _, p := range providers.GetProviders() {
+			ids = append(ids, p.GetProvider())
+		}
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: provider %q not registered; got %v\n", *provider, ids)
+		os.Exit(1)
+	}
+
+	// Start a session against the workspace repo path.
+	sessionID := uuid.NewString()
+	_, err = client.StartSession(ctx, &bridgev1.StartSessionRequest{
+		ProjectId: "smoke",
+		SessionId: sessionID,
+		RepoPath:  *repoPath,
+		Provider:  *provider,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: start session: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Attach and collect output in a goroutine.
+	outputCh := make(chan string, 32)
+	errCh := make(chan error, 1)
+	attachCtx, attachCancel := context.WithDeadline(context.Background(), deadline)
+	defer attachCancel()
+
+	stream, err := client.AttachSession(attachCtx, &bridgev1.AttachSessionRequest{
+		SessionId: sessionID,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: attach: %v\n", err)
+		os.Exit(1)
+	}
+
+	go func() {
+		recvErr := stream.RecvAll(attachCtx, func(ev *bridgev1.AttachSessionEvent) error {
+			if len(ev.GetPayload()) > 0 {
+				outputCh <- string(ev.GetPayload())
+			}
+			return nil
+		})
+		if recvErr != nil && !errors.Is(recvErr, context.Canceled) && !errors.Is(recvErr, context.DeadlineExceeded) {
+			errCh <- recvErr
+		}
+		close(errCh)
+	}()
+
+	// Give the session a moment to start.
+	time.Sleep(500 * time.Millisecond)
+
+	// Send a probe string and wait for the echo.
+	probe := "bridge-smoke-echo-test"
+	_, err = client.WriteInput(ctx, &bridgev1.WriteInputRequest{
+		SessionId: sessionID,
+		Data:      []byte(probe + "\n"),
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: write input: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Collect output until we see the probe echoed back.
+	echoDeadline := time.Now().Add(10 * time.Second)
+	var collected strings.Builder
+	for time.Now().Before(echoDeadline) {
+		select {
+		case chunk, ok := <-outputCh:
+			if !ok {
+				goto echoCheck
+			}
+			collected.WriteString(chunk)
+			if strings.Contains(collected.String(), probe) {
+				goto echoCheck
+			}
+		case recvErr, ok := <-errCh:
+			if ok && recvErr != nil {
+				fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: stream error: %v\n", recvErr)
+				os.Exit(1)
+			}
+			goto echoCheck
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+echoCheck:
+	if !strings.Contains(collected.String(), probe) {
+		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: probe %q not echoed; got: %q\n", probe, collected.String())
+		os.Exit(1)
+	}
+
+	attachCancel()
+
+	fmt.Printf("PROFILE SMOKE PASSED: provider=%s repo_path=%s providers=%d echo=ok\n",
+		*provider, *repoPath, len(providers.GetProviders()))
+}

--- a/e2e/cmd/profile-smoke/main.go
+++ b/e2e/cmd/profile-smoke/main.go
@@ -88,6 +88,7 @@ func main() {
 	}
 
 	// Attach and collect output in a goroutine.
+	clientID := uuid.NewString()
 	outputCh := make(chan string, 32)
 	errCh := make(chan error, 1)
 	attachCtx, attachCancel := context.WithDeadline(context.Background(), deadline)
@@ -95,6 +96,7 @@ func main() {
 
 	stream, err := client.AttachSession(attachCtx, &bridgev1.AttachSessionRequest{
 		SessionId: sessionID,
+		ClientId:  clientID,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "PROFILE SMOKE FAILED: attach: %v\n", err)
@@ -121,6 +123,7 @@ func main() {
 	probe := "bridge-smoke-echo-test"
 	_, err = client.WriteInput(ctx, &bridgev1.WriteInputRequest{
 		SessionId: sessionID,
+		ClientId:  clientID,
 		Data:      []byte(probe + "\n"),
 	})
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,9 +19,19 @@ type Config struct {
 	Input        InputConfig               `yaml:"input"`
 	RateLimits   RateLimitsConfig          `yaml:"rate_limits"`
 	Persistence  PersistenceConfig         `yaml:"persistence"`
+	Runtime      RuntimeConfig             `yaml:"runtime"`
 	Providers    map[string]ProviderConfig `yaml:"providers"`
 	AllowedPaths []string                  `yaml:"allowed_paths"`
 	Logging      LoggingConfig             `yaml:"logging"`
+}
+
+// RuntimeConfig controls how the bridge locates provider CLIs and the Node.js
+// runtime. When ProviderRoot is set, Node version validation reads
+// {provider_root}/.nvmrc and relative provider binary/arg paths are resolved
+// relative to {provider_root} instead of the daemon working directory. When
+// empty, existing CWD-relative behaviour is preserved.
+type RuntimeConfig struct {
+	ProviderRoot string `yaml:"provider_root"`
 }
 
 type ServerConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -239,6 +240,9 @@ func validate(cfg *Config) error {
 	}
 	if cfg.RateLimits.SendInputPerSessionRPS <= 0 || cfg.RateLimits.SendInputPerSessionBurst <= 0 {
 		return fmt.Errorf("config: rate_limits.send_input_per_session_rps/send_input_per_session_burst must be > 0")
+	}
+	if cfg.Runtime.ProviderRoot != "" && !filepath.IsAbs(cfg.Runtime.ProviderRoot) {
+		return fmt.Errorf("config: runtime.provider_root must be an absolute path, got %q", cfg.Runtime.ProviderRoot)
 	}
 	if _, err := time.ParseDuration(cfg.Auth.JWTMaxTTL); err != nil {
 		return fmt.Errorf("config: auth.jwt_max_ttl: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -285,6 +285,7 @@ func TestLoadRuntimeProviderRoot(t *testing.T) {
 		name     string
 		content  string
 		wantRoot string
+		wantErr  bool
 	}{
 		{
 			name: "provider_root set",
@@ -316,6 +317,22 @@ sessions:
 `,
 			wantRoot: "",
 		},
+		{
+			name: "provider_root relative path rejected",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+runtime:
+  provider_root: "relative/path"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`,
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -326,6 +343,12 @@ sessions:
 				t.Fatalf("WriteFile: %v", err)
 			}
 			cfg, err := Load(path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("Load: %v", err)
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -279,3 +279,59 @@ sessions:
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestLoadRuntimeProviderRoot(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantRoot string
+	}{
+		{
+			name: "provider_root set",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+runtime:
+  provider_root: "/opt/ai-agent-bridge"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`,
+			wantRoot: "/opt/ai-agent-bridge",
+		},
+		{
+			name: "provider_root absent",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`,
+			wantRoot: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "bridge.yaml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.Runtime.ProviderRoot != tc.wantRoot {
+				t.Fatalf("ProviderRoot=%q want %q", cfg.Runtime.ProviderRoot, tc.wantRoot)
+			}
+		})
+	}
+}

--- a/internal/config/node.go
+++ b/internal/config/node.go
@@ -98,9 +98,6 @@ func RequiresNodeRuntime(cfg *Config) bool {
 		if base == "node" || base == "nodejs" {
 			return true
 		}
-		if len(p.Args) > 0 && strings.HasSuffix(p.Args[0], ".js") {
-			return true
-		}
 	}
 	return false
 }

--- a/internal/config/node.go
+++ b/internal/config/node.go
@@ -84,6 +84,23 @@ func ValidateNodeRuntime(projectRoot string) error {
 	return nil
 }
 
+// RequiresNodeRuntime reports whether cfg has at least one provider that
+// invokes Node.js, either by using "node"/"nodejs" as the binary or by
+// using an absolute node path with a .js script as the first argument.
+// Providers that use non-Node binaries (e.g. native CLIs, /bin/cat) do
+// not require the Node runtime and do not need .nvmrc validation.
 func RequiresNodeRuntime(cfg *Config) bool {
-	return cfg != nil && len(cfg.Providers) > 0
+	if cfg == nil {
+		return false
+	}
+	for _, p := range cfg.Providers {
+		base := filepath.Base(p.Binary)
+		if base == "node" || base == "nodejs" {
+			return true
+		}
+		if len(p.Args) > 0 && strings.HasSuffix(p.Args[0], ".js") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/node.go
+++ b/internal/config/node.go
@@ -85,10 +85,9 @@ func ValidateNodeRuntime(projectRoot string) error {
 }
 
 // RequiresNodeRuntime reports whether cfg has at least one provider that
-// invokes Node.js, either by using "node"/"nodejs" as the binary or by
-// using an absolute node path with a .js script as the first argument.
-// Providers that use non-Node binaries (e.g. native CLIs, /bin/cat) do
-// not require the Node runtime and do not need .nvmrc validation.
+// invokes Node.js, detected by the provider binary base name being "node"
+// or "nodejs". Providers that use non-Node binaries (e.g. native CLIs,
+// /bin/cat) do not require the Node runtime and do not need .nvmrc validation.
 func RequiresNodeRuntime(cfg *Config) bool {
 	if cfg == nil {
 		return false

--- a/internal/config/node_test.go
+++ b/internal/config/node_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -113,16 +112,16 @@ func TestValidateNodeRuntimeWithExplicitRoot(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
+	oldLookPathNode := lookPathNode
+	oldRunCommand := runCommand
+	t.Cleanup(func() {
+		lookPathNode = oldLookPathNode
+		runCommand = oldRunCommand
+	})
 	lookPathNode = func(file string) (string, error) { return "/usr/bin/node", nil }
 	runCommand = func(name string, args ...string) ([]byte, error) {
 		return []byte("v24.1.0\n"), nil
 	}
-	t.Cleanup(func() {
-		lookPathNode = exec.LookPath
-		runCommand = func(name string, args ...string) ([]byte, error) {
-			return exec.Command(name, args...).Output()
-		}
-	})
 
 	// Validates successfully when the explicit root contains .nvmrc.
 	if err := ValidateNodeRuntime(root); err != nil {

--- a/internal/config/node_test.go
+++ b/internal/config/node_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -103,5 +104,34 @@ func TestValidateNodeRuntime(t *testing.T) {
 
 	if err := ValidateNodeRuntime(dir); err != nil {
 		t.Fatalf("ValidateNodeRuntime: %v", err)
+	}
+}
+
+func TestValidateNodeRuntimeWithExplicitRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".nvmrc"), []byte("24\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	lookPathNode = func(file string) (string, error) { return "/usr/bin/node", nil }
+	runCommand = func(name string, args ...string) ([]byte, error) {
+		return []byte("v24.1.0\n"), nil
+	}
+	t.Cleanup(func() {
+		lookPathNode = exec.LookPath
+		runCommand = func(name string, args ...string) ([]byte, error) {
+			return exec.Command(name, args...).Output()
+		}
+	})
+
+	// Validates successfully when the explicit root contains .nvmrc.
+	if err := ValidateNodeRuntime(root); err != nil {
+		t.Fatalf("ValidateNodeRuntime with root: %v", err)
+	}
+
+	// Fails when .nvmrc is absent from the given root.
+	emptyRoot := t.TempDir()
+	if err := ValidateNodeRuntime(emptyRoot); err == nil {
+		t.Fatal("expected error for missing .nvmrc")
 	}
 }

--- a/internal/config/runtime_requirements_test.go
+++ b/internal/config/runtime_requirements_test.go
@@ -23,13 +23,40 @@ func TestRequiresNodeRuntime(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "provider configured",
+			name: "node binary",
 			cfg: &Config{
 				Providers: map[string]ProviderConfig{
 					"codex": {Binary: "node"},
 				},
 			},
 			want: true,
+		},
+		{
+			name: "absolute node path with js arg",
+			cfg: &Config{
+				Providers: map[string]ProviderConfig{
+					"gemini": {Binary: "/usr/bin/node", Args: []string{"/opt/ai-agent-bridge/node_modules/@google/gemini-cli/dist/index.js"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "non-node native binary",
+			cfg: &Config{
+				Providers: map[string]ProviderConfig{
+					"fixture": {Binary: "/bin/cat"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "native cli via bin shim",
+			cfg: &Config{
+				Providers: map[string]ProviderConfig{
+					"opencode": {Binary: "/opt/ai-agent-bridge/node_modules/.bin/opencode"},
+				},
+			},
+			want: false,
 		},
 	}
 

--- a/internal/provider/stdio.go
+++ b/internal/provider/stdio.go
@@ -251,6 +251,18 @@ func (p *StdioProvider) Health(ctx context.Context) error {
 	return nil
 }
 
+// absRoot returns root as an absolute path. If root is already absolute it is
+// returned unchanged. If root is relative it is made absolute relative to the
+// process working directory. This ensures that binary and arg paths joined
+// against root do not accidentally resolve relative to cmd.Dir (the session
+// repo path) when the process working directory differs.
+func absRoot(root string) (string, error) {
+	if filepath.IsAbs(root) {
+		return root, nil
+	}
+	return filepath.Abs(root)
+}
+
 // resolveBinaryPath resolves a provider binary to an absolute path. When root
 // is non-empty and binary is a relative path containing a slash, binary is
 // resolved relative to root instead of the process working directory.
@@ -260,7 +272,11 @@ func resolveBinaryPath(binary, root string) (string, error) {
 			return binary, nil
 		}
 		if root != "" {
-			return filepath.Join(root, binary), nil
+			absR, err := absRoot(root)
+			if err != nil {
+				return "", fmt.Errorf("absolutize provider root: %w", err)
+			}
+			return filepath.Join(absR, binary), nil
 		}
 		return filepath.Abs(binary)
 	}
@@ -268,8 +284,10 @@ func resolveBinaryPath(binary, root string) (string, error) {
 }
 
 // resolveCommandArgs converts standalone relative path arguments to absolute
-// paths. When root is non-empty, relative paths are resolved against root
-// instead of the process working directory.
+// paths. Only bare path arguments (e.g. "./foo" or "../foo") are rewritten;
+// command names resolved via PATH and embedded flag values (e.g.
+// "--config=./foo") are left unchanged. When root is non-empty, relative paths
+// are resolved against root instead of the process working directory.
 func resolveCommandArgs(args []string, root string) ([]string, error) {
 	if len(args) == 0 {
 		return nil, nil
@@ -283,7 +301,11 @@ func resolveCommandArgs(args []string, root string) ([]string, error) {
 		var abs string
 		var err error
 		if root != "" {
-			abs = filepath.Join(root, arg)
+			absR, err := absRoot(root)
+			if err != nil {
+				return nil, fmt.Errorf("absolutize provider root: %w", err)
+			}
+			abs = filepath.Join(absR, arg)
 		} else {
 			abs, err = filepath.Abs(arg)
 			if err != nil {

--- a/internal/provider/stdio.go
+++ b/internal/provider/stdio.go
@@ -29,6 +29,10 @@ type StdioConfig struct {
 	RequiredEnv    []string
 	StreamJSON     bool // if true, the provider uses stream-JSON mode (no PTY)
 	StripANSI      bool // if true, ANSI escape codes are stripped from PTY output
+	// ProviderRoot is an optional absolute path used as the base for resolving
+	// relative Binary and DefaultArgs paths. When empty, relative paths are
+	// resolved against the daemon working directory (legacy behaviour).
+	ProviderRoot string
 }
 
 // StdioProvider defines how to launch and validate one interactive CLI.
@@ -71,11 +75,11 @@ func (p *StdioProvider) IsStreamJSON() bool { return p.cfg.StreamJSON }
 func (p *StdioProvider) IsStripANSI() bool { return p.cfg.StripANSI }
 
 func (p *StdioProvider) BuildCommand(ctx context.Context, cfg bridge.SessionConfig) (*exec.Cmd, error) {
-	binPath, err := resolveBinaryPath(p.cfg.Binary)
+	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return nil, fmt.Errorf("%w: resolve binary %q: %v", bridge.ErrProviderUnavailable, p.cfg.Binary, err)
 	}
-	args, err := resolveCommandArgs(p.cfg.DefaultArgs)
+	args, err := resolveCommandArgs(p.cfg.DefaultArgs, p.cfg.ProviderRoot)
 	if err != nil {
 		return nil, fmt.Errorf("%w: resolve args for %q: %v", bridge.ErrProviderUnavailable, p.cfg.ProviderID, err)
 	}
@@ -120,11 +124,11 @@ func (p *StdioProvider) validateStartupPrompt(ctx context.Context) error {
 	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.StartupTimeout)
 	defer cancel()
 
-	binPath, err := resolveBinaryPath(p.cfg.Binary)
+	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return err
 	}
-	args, err := resolveCommandArgs(p.cfg.DefaultArgs)
+	args, err := resolveCommandArgs(p.cfg.DefaultArgs, p.cfg.ProviderRoot)
 	if err != nil {
 		return err
 	}
@@ -171,11 +175,11 @@ func (p *StdioProvider) validateStartupOutput(ctx context.Context) error {
 	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.StartupTimeout)
 	defer cancel()
 
-	binPath, err := resolveBinaryPath(p.cfg.Binary)
+	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return err
 	}
-	args, err := resolveCommandArgs(p.cfg.DefaultArgs)
+	args, err := resolveCommandArgs(p.cfg.DefaultArgs, p.cfg.ProviderRoot)
 	if err != nil {
 		return err
 	}
@@ -219,7 +223,7 @@ func (p *StdioProvider) validateStartupOutput(ctx context.Context) error {
 }
 
 func (p *StdioProvider) Version(ctx context.Context) (string, error) {
-	path, err := resolveBinaryPath(p.cfg.Binary)
+	path, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return "", fmt.Errorf("binary %q not found: %w", p.cfg.Binary, err)
 	}
@@ -233,7 +237,7 @@ func (p *StdioProvider) Version(ctx context.Context) (string, error) {
 }
 
 func (p *StdioProvider) Health(ctx context.Context) error {
-	path, err := resolveBinaryPath(p.cfg.Binary)
+	path, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
 	if err != nil {
 		return fmt.Errorf("binary %q not found: %w", p.cfg.Binary, err)
 	}
@@ -247,17 +251,26 @@ func (p *StdioProvider) Health(ctx context.Context) error {
 	return nil
 }
 
-func resolveBinaryPath(binary string) (string, error) {
+// resolveBinaryPath resolves a provider binary to an absolute path. When root
+// is non-empty and binary is a relative path containing a slash, binary is
+// resolved relative to root instead of the process working directory.
+func resolveBinaryPath(binary, root string) (string, error) {
 	if strings.Contains(binary, "/") {
 		if filepath.IsAbs(binary) {
 			return binary, nil
+		}
+		if root != "" {
+			return filepath.Join(root, binary), nil
 		}
 		return filepath.Abs(binary)
 	}
 	return exec.LookPath(binary)
 }
 
-func resolveCommandArgs(args []string) ([]string, error) {
+// resolveCommandArgs converts standalone relative path arguments to absolute
+// paths. When root is non-empty, relative paths are resolved against root
+// instead of the process working directory.
+func resolveCommandArgs(args []string, root string) ([]string, error) {
 	if len(args) == 0 {
 		return nil, nil
 	}
@@ -267,9 +280,15 @@ func resolveCommandArgs(args []string) ([]string, error) {
 		if !isStandaloneRelativePathArg(arg) {
 			continue
 		}
-		abs, err := filepath.Abs(arg)
-		if err != nil {
-			return nil, err
+		var abs string
+		var err error
+		if root != "" {
+			abs = filepath.Join(root, arg)
+		} else {
+			abs, err = filepath.Abs(arg)
+			if err != nil {
+				return nil, err
+			}
 		}
 		resolved[i] = abs
 	}

--- a/internal/provider/stdio_additional_test.go
+++ b/internal/provider/stdio_additional_test.go
@@ -65,7 +65,7 @@ func TestResolveBinaryPathAndFilterEnv(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	path, err := resolveBinaryPath(bin)
+	path, err := resolveBinaryPath(bin, "")
 	if err != nil {
 		t.Fatalf("resolveBinaryPath: %v", err)
 	}

--- a/internal/provider/stdio_test.go
+++ b/internal/provider/stdio_test.go
@@ -84,7 +84,7 @@ func TestResolveCommandArgsLeavesFlagsAndURLsUntouched(t *testing.T) {
 		"--config=./configs/dev.yaml",
 		"https://example.com/api",
 		"../relative-script.js",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("resolveCommandArgs: %v", err)
 	}
@@ -100,5 +100,87 @@ func TestResolveCommandArgsLeavesFlagsAndURLsUntouched(t *testing.T) {
 	}
 	if !filepath.IsAbs(args[3]) {
 		t.Fatalf("relative script should be absolutized, got %q", args[3])
+	}
+}
+
+func TestResolveBinaryPathWithProviderRoot(t *testing.T) {
+	root := t.TempDir()
+
+	// Absolute binary is returned as-is regardless of root.
+	abs, err := resolveBinaryPath("/usr/bin/node", root)
+	if err != nil {
+		t.Fatalf("resolveBinaryPath absolute: %v", err)
+	}
+	if abs != "/usr/bin/node" {
+		t.Fatalf("absolute path changed: %q", abs)
+	}
+
+	// NAME-only binary (no slash) is still looked up on PATH.
+	_, err = resolveBinaryPath("cat", root)
+	if err != nil {
+		t.Fatalf("resolveBinaryPath PATH lookup: %v", err)
+	}
+
+	// Relative path with slash resolves against root, not CWD.
+	got, err := resolveBinaryPath("./bin/tool", root)
+	if err != nil {
+		t.Fatalf("resolveBinaryPath relative: %v", err)
+	}
+	want := filepath.Join(root, "./bin/tool")
+	if got != want {
+		t.Fatalf("resolveBinaryPath=%q want %q", got, want)
+	}
+}
+
+func TestResolveCommandArgsWithProviderRoot(t *testing.T) {
+	root := t.TempDir()
+
+	args, err := resolveCommandArgs([]string{
+		"./node_modules/@openai/codex/bin/codex.js",
+		"--flag",
+		"../sibling.js",
+	}, root)
+	if err != nil {
+		t.Fatalf("resolveCommandArgs: %v", err)
+	}
+
+	// Relative paths with slashes are resolved against root.
+	wantFirst := filepath.Join(root, "./node_modules/@openai/codex/bin/codex.js")
+	if args[0] != wantFirst {
+		t.Fatalf("args[0]=%q want %q", args[0], wantFirst)
+	}
+	// Non-path flags are left alone.
+	if args[1] != "--flag" {
+		t.Fatalf("args[1]=%q want --flag", args[1])
+	}
+	wantThird := filepath.Join(root, "../sibling.js")
+	if args[2] != wantThird {
+		t.Fatalf("args[2]=%q want %q", args[2], wantThird)
+	}
+}
+
+func TestBuildCommandResolvesArgsFromProviderRoot(t *testing.T) {
+	root := t.TempDir()
+
+	p := NewStdioProvider(StdioConfig{
+		ProviderID:    "codex",
+		Binary:        "/usr/bin/node",
+		DefaultArgs:   []string{"./node_modules/@openai/codex/bin/codex.js"},
+		PromptPattern: "›",
+		ProviderRoot:  root,
+	})
+
+	cmd, err := p.BuildCommand(context.Background(), bridge.SessionConfig{
+		ProjectID: "test",
+		SessionID: "s1",
+		RepoPath:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("BuildCommand: %v", err)
+	}
+
+	want := filepath.Join(root, "./node_modules/@openai/codex/bin/codex.js")
+	if len(cmd.Args) < 2 || cmd.Args[1] != want {
+		t.Fatalf("cmd.Args=%v want second arg %q", cmd.Args, want)
 	}
 }

--- a/packaging/examples/bridge-ai-desktops.yaml
+++ b/packaging/examples/bridge-ai-desktops.yaml
@@ -1,0 +1,115 @@
+# bridge-ai-desktops.yaml — ai-desktops agent-host configuration profile.
+#
+# Copy this file to /etc/ai-agent-bridge/bridge.yaml on an ai-desktops host,
+# uncomment the providers you want to enable, and supply credentials via
+# /etc/ai-agent-bridge/agents.env (root:root 0600).
+#
+# This profile:
+#   - binds to 127.0.0.1:9445 (localhost only)
+#   - enables persistence under /var/lib/ai-agent-bridge
+#   - permits /workspace for repository access
+#   - resolves provider CLIs from /opt/ai-agent-bridge (the provider runtime root)
+#   - keeps TLS and JWT disabled (localhost-only — add mTLS+JWT for remote access)
+#
+# SECURITY: do not expose this service over the network without configuring
+# tls.ca_bundle, tls.cert, tls.key, and auth.jwt_public_keys.
+
+server:
+  listen: "127.0.0.1:9445"
+
+tls:
+  ca_bundle: ""
+  cert: ""
+  key: ""
+
+auth:
+  jwt_public_keys: []
+  jwt_audience: "bridge"
+  jwt_max_ttl: "5m"
+
+feature_flags:
+  provider_fallbacks: true
+
+sessions:
+  max_per_project: 5
+  max_global: 20
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  event_buffer_size: 10000
+  max_subscribers_per_session: 10
+  subscriber_ttl: "30m"
+
+input:
+  max_size_bytes: 65536
+
+rate_limits:
+  global_rps: 50
+  global_burst: 100
+  start_session_per_client_rps: 1
+  start_session_per_client_burst: 3
+  send_input_per_session_rps: 5
+  send_input_per_session_burst: 20
+
+persistence:
+  db_path: "/var/lib/ai-agent-bridge/sessions.db"
+
+runtime:
+  provider_root: "/opt/ai-agent-bridge"
+
+# Enable one or more providers below. Credentials are read from the environment
+# (injected via /etc/ai-agent-bridge/agents.env at service startup).
+#
+# Run /usr/lib/ai-agent-bridge/install-provider-runtime to install the CLIs
+# before enabling any provider here.
+
+providers: {}
+
+# Uncomment to enable Codex (requires OPENAI_API_KEY in agents.env):
+#
+#   codex:
+#     binary: "/usr/bin/node"
+#     args: ["./node_modules/@openai/codex/bin/codex.js"]
+#     startup_timeout: "60s"
+#     startup_probe: "output"
+#     required_env: ["OPENAI_API_KEY"]
+#     prompt_pattern: '(?m)(>\s*$|›)'
+
+# Uncomment to enable Claude Code (requires ANTHROPIC_API_KEY in agents.env):
+#
+#   claude:
+#     binary: "/usr/bin/node"
+#     args: ["./node_modules/@anthropic-ai/claude-code/cli.js"]
+#     startup_timeout: "60s"
+#     startup_probe: "output"
+#     required_env: ["ANTHROPIC_API_KEY"]
+#     prompt_pattern: '(?m)(❯|>\s*$)'
+
+# Uncomment to enable OpenCode (requires OPENAI_API_KEY or ANTHROPIC_API_KEY):
+#
+#   opencode:
+#     binary: "/usr/bin/node"
+#     args: ["./node_modules/opencode-ai/dist/cli.js"]
+#     startup_timeout: "45s"
+#     startup_probe: "output"
+
+# Uncomment to enable Gemini CLI (requires GOOGLE_API_KEY in agents.env):
+#
+#   gemini:
+#     binary: "/usr/bin/node"
+#     args: ["./node_modules/@google/gemini-cli/bundle/gemini.js"]
+#     startup_timeout: "60s"
+#     startup_probe: "output"
+#     required_env: ["GOOGLE_API_KEY"]
+
+allowed_paths:
+  - "/home"
+  - "/srv"
+  - "/tmp"
+  - "/var/tmp"
+  - "/workspace"
+
+logging:
+  level: "info"
+  format: "json"
+  redact_patterns:
+    - '(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*\S+'

--- a/packaging/examples/bridge-ai-desktops.yaml
+++ b/packaging/examples/bridge-ai-desktops.yaml
@@ -62,13 +62,13 @@ runtime:
 # Run /usr/lib/ai-agent-bridge/install-provider-runtime to install the CLIs
 # before enabling any provider here.
 
-providers: {}
+providers:
 
 # Uncomment to enable Codex (requires OPENAI_API_KEY in agents.env):
 #
 #   codex:
 #     binary: "/usr/bin/node"
-#     args: ["./node_modules/@openai/codex/bin/codex.js"]
+#     args: ["/opt/ai-agent-bridge/node_modules/@openai/codex/bin/codex.js"]
 #     startup_timeout: "60s"
 #     startup_probe: "output"
 #     required_env: ["OPENAI_API_KEY"]
@@ -78,17 +78,18 @@ providers: {}
 #
 #   claude:
 #     binary: "/usr/bin/node"
-#     args: ["./node_modules/@anthropic-ai/claude-code/cli.js"]
+#     args: ["/opt/ai-agent-bridge/node_modules/@anthropic-ai/claude-code/cli.js"]
 #     startup_timeout: "60s"
 #     startup_probe: "output"
 #     required_env: ["ANTHROPIC_API_KEY"]
 #     prompt_pattern: '(?m)(❯|>\s*$)'
 
 # Uncomment to enable OpenCode (requires OPENAI_API_KEY or ANTHROPIC_API_KEY):
+# OpenCode ships as a native binary installed via npm — no Node.js invocation needed.
 #
 #   opencode:
-#     binary: "/usr/bin/node"
-#     args: ["./node_modules/opencode-ai/dist/cli.js"]
+#     binary: "/opt/ai-agent-bridge/node_modules/.bin/opencode"
+#     args: []
 #     startup_timeout: "45s"
 #     startup_probe: "output"
 
@@ -96,7 +97,7 @@ providers: {}
 #
 #   gemini:
 #     binary: "/usr/bin/node"
-#     args: ["./node_modules/@google/gemini-cli/bundle/gemini.js"]
+#     args: ["/opt/ai-agent-bridge/node_modules/@google/gemini-cli/dist/index.js"]
 #     startup_timeout: "60s"
 #     startup_probe: "output"
 #     required_env: ["GOOGLE_API_KEY"]

--- a/packaging/install-provider-runtime
+++ b/packaging/install-provider-runtime
@@ -1,0 +1,105 @@
+#!/bin/sh
+# install-provider-runtime — Idempotent provider CLI runtime installer.
+#
+# Usage:
+#   install-provider-runtime              Install or upgrade the provider runtime.
+#   install-provider-runtime --verify     Check installed versions; no changes.
+#
+# This script:
+#   1. Verifies (or installs) Node.js REQUIRED_NODE_MAJOR on the system PATH.
+#   2. Copies the packaged runtime manifest from MANIFEST_DIR to INSTALL_DIR.
+#   3. Runs npm ci --omit=dev --no-audit --no-fund to install pinned provider CLIs.
+#   4. Verifies each installed CLI binary is present and reports its version.
+#   5. Ensures INSTALL_DIR is owned root:root and not writable by group/other.
+#
+# The script is safe to re-run; a failed install does not remove a previously
+# working runtime at INSTALL_DIR.
+#
+# MANIFEST_DIR and INSTALL_DIR may be overridden for testing:
+#   MANIFEST_DIR=/custom/src INSTALL_DIR=/custom/dst install-provider-runtime
+
+set -eu
+
+MANIFEST_DIR="${MANIFEST_DIR:-/usr/share/ai-agent-bridge/provider-runtime}"
+INSTALL_DIR="${INSTALL_DIR:-/opt/ai-agent-bridge}"
+REQUIRED_NODE_MAJOR=24
+
+VERIFY_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --verify) VERIFY_ONLY=1 ;;
+    *) echo "install-provider-runtime: unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+say() { printf '==> %s\n' "$*"; }
+
+# ── Node.js version check ──────────────────────────────────────────────────
+
+node_major() {
+  node --version 2>/dev/null | sed 's/v//;s/\..*//'
+}
+
+if ! command -v node >/dev/null 2>&1; then
+  if [ "$VERIFY_ONLY" -eq 1 ]; then
+    die "node not found on PATH; install Node.js ${REQUIRED_NODE_MAJOR} first"
+  fi
+  say "Installing Node.js ${REQUIRED_NODE_MAJOR} via NodeSource..."
+  curl -fsSL "https://deb.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x" | sh -
+  apt-get install -y nodejs
+fi
+
+actual_major=$(node_major)
+if [ "$actual_major" != "$REQUIRED_NODE_MAJOR" ]; then
+  die "Node.js major version is ${actual_major}, required ${REQUIRED_NODE_MAJOR}; upgrade Node.js before running this script"
+fi
+
+say "Node.js $(node --version)"
+
+# ── Runtime manifest installation ─────────────────────────────────────────
+
+if [ "$VERIFY_ONLY" -eq 0 ]; then
+  if [ ! -d "$MANIFEST_DIR" ]; then
+    die "runtime manifest directory not found: ${MANIFEST_DIR}; is ai-agent-bridge installed?"
+  fi
+
+  say "Copying runtime manifest to ${INSTALL_DIR}..."
+  mkdir -p "$INSTALL_DIR"
+  cp -- "$MANIFEST_DIR/.nvmrc"           "$INSTALL_DIR/.nvmrc"
+  cp -- "$MANIFEST_DIR/package.json"     "$INSTALL_DIR/package.json"
+  cp -- "$MANIFEST_DIR/package-lock.json" "$INSTALL_DIR/package-lock.json"
+
+  say "Installing provider CLIs (this may take several minutes)..."
+  # Run in a subshell; the INSTALL_DIR remains usable if npm ci fails.
+  (
+    cd "$INSTALL_DIR"
+    npm ci --omit=dev --no-audit --no-fund
+  )
+
+  say "Fixing ownership of ${INSTALL_DIR}..."
+  chown -R root:root "$INSTALL_DIR"
+  chmod -R go-w "$INSTALL_DIR"
+fi
+
+# ── Version verification ───────────────────────────────────────────────────
+
+say "Verifying installed provider CLIs:"
+
+fail=0
+for cli in claude codex opencode gemini; do
+  bin="${INSTALL_DIR}/node_modules/.bin/${cli}"
+  if [ -x "$bin" ]; then
+    ver=$("$bin" --version 2>&1 || true)
+    printf '  %-12s %s\n' "$cli" "$ver"
+  else
+    printf '  %-12s NOT FOUND at %s\n' "$cli" "$bin" >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" -eq 1 ]; then
+  die "one or more provider CLIs failed verification; check that npm ci completed successfully"
+fi
+
+say "Provider runtime ready at ${INSTALL_DIR}"

--- a/packaging/install-provider-runtime
+++ b/packaging/install-provider-runtime
@@ -75,9 +75,12 @@ if [ "$VERIFY_ONLY" -eq 0 ]; then
   cp -- "$MANIFEST_DIR/package-lock.json" "$INSTALL_DIR/package-lock.json"
 
   say "Installing provider CLIs (this may take several minutes)..."
-  # Install into a staging directory so that a failed npm ci does not
-  # destroy an existing working runtime at INSTALL_DIR.
-  STAGE_DIR=$(mktemp -d)
+  # Stage inside INSTALL_DIR's parent so that mv is always on the same
+  # filesystem (avoids cross-device link errors and data loss when /tmp is
+  # on a different mount from /opt).  If npm ci fails, the existing
+  # node_modules is preserved via a rename-to-backup / rename-on-success
+  # pattern so the host is never left without working provider CLIs.
+  STAGE_DIR=$(mktemp -d -p "$INSTALL_DIR/..")
   cp -- "$MANIFEST_DIR/.nvmrc"            "$STAGE_DIR/.nvmrc"
   cp -- "$MANIFEST_DIR/package.json"      "$STAGE_DIR/package.json"
   cp -- "$MANIFEST_DIR/package-lock.json" "$STAGE_DIR/package-lock.json"
@@ -85,10 +88,15 @@ if [ "$VERIFY_ONLY" -eq 0 ]; then
     cd "$STAGE_DIR"
     npm ci --omit=dev --no-audit --no-fund
   )
-  # Swap node_modules only after a successful install.
-  rm -rf "$INSTALL_DIR/node_modules"
+  # Atomically swap node_modules using rename.  Keep the old modules as a
+  # backup directory; remove it only after the new one is in place so that
+  # a power failure mid-swap still leaves the host with usable CLIs.
+  OLD_DIR="${INSTALL_DIR}/node_modules.old.$$"
+  if [ -d "$INSTALL_DIR/node_modules" ]; then
+    mv "$INSTALL_DIR/node_modules" "$OLD_DIR"
+  fi
   mv "$STAGE_DIR/node_modules" "$INSTALL_DIR/node_modules"
-  rm -rf "$STAGE_DIR"
+  rm -rf "$OLD_DIR" "$STAGE_DIR"
 
   say "Fixing ownership of ${INSTALL_DIR}..."
   chown -R root:root "$INSTALL_DIR"

--- a/packaging/install-provider-runtime
+++ b/packaging/install-provider-runtime
@@ -46,6 +46,10 @@ if ! command -v node >/dev/null 2>&1; then
     die "node not found on PATH; install Node.js ${REQUIRED_NODE_MAJOR} first"
   fi
   say "Installing Node.js ${REQUIRED_NODE_MAJOR} via NodeSource..."
+  # curl is not always present on minimal Ubuntu installs; install it first.
+  if ! command -v curl >/dev/null 2>&1; then
+    apt-get install -y curl
+  fi
   curl -fsSL "https://deb.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x" | sh -
   apt-get install -y nodejs
 fi
@@ -71,11 +75,20 @@ if [ "$VERIFY_ONLY" -eq 0 ]; then
   cp -- "$MANIFEST_DIR/package-lock.json" "$INSTALL_DIR/package-lock.json"
 
   say "Installing provider CLIs (this may take several minutes)..."
-  # Run in a subshell; the INSTALL_DIR remains usable if npm ci fails.
+  # Install into a staging directory so that a failed npm ci does not
+  # destroy an existing working runtime at INSTALL_DIR.
+  STAGE_DIR=$(mktemp -d)
+  cp -- "$MANIFEST_DIR/.nvmrc"            "$STAGE_DIR/.nvmrc"
+  cp -- "$MANIFEST_DIR/package.json"      "$STAGE_DIR/package.json"
+  cp -- "$MANIFEST_DIR/package-lock.json" "$STAGE_DIR/package-lock.json"
   (
-    cd "$INSTALL_DIR"
+    cd "$STAGE_DIR"
     npm ci --omit=dev --no-audit --no-fund
   )
+  # Swap node_modules only after a successful install.
+  rm -rf "$INSTALL_DIR/node_modules"
+  mv "$STAGE_DIR/node_modules" "$INSTALL_DIR/node_modules"
+  rm -rf "$STAGE_DIR"
 
   say "Fixing ownership of ${INSTALL_DIR}..."
   chown -R root:root "$INSTALL_DIR"

--- a/packaging/install-provider-runtime
+++ b/packaging/install-provider-runtime
@@ -23,6 +23,7 @@ set -eu
 MANIFEST_DIR="${MANIFEST_DIR:-/usr/share/ai-agent-bridge/provider-runtime}"
 INSTALL_DIR="${INSTALL_DIR:-/opt/ai-agent-bridge}"
 REQUIRED_NODE_MAJOR=24
+export DEBIAN_FRONTEND=noninteractive
 
 VERIFY_ONLY=0
 for arg in "$@"; do
@@ -34,6 +35,12 @@ done
 
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 say() { printf '==> %s\n' "$*"; }
+
+# ── Root check ────────────────────────────────────────────────────────────────
+
+if [ "$(id -u)" -ne 0 ]; then
+  die "install-provider-runtime must be run as root (use sudo)"
+fi
 
 # ── Node.js version check ──────────────────────────────────────────────────
 
@@ -48,10 +55,14 @@ if ! command -v node >/dev/null 2>&1; then
   say "Installing Node.js ${REQUIRED_NODE_MAJOR} via NodeSource..."
   # curl is not always present on minimal Ubuntu installs; install it first.
   if ! command -v curl >/dev/null 2>&1; then
-    apt-get install -y curl
+    apt-get update -q
+    apt-get install -y -q curl
   fi
+  # The NodeSource setup script adds a new apt source; run apt-get update
+  # afterwards so nodejs is fetched from the correct repository.
   curl -fsSL "https://deb.nodesource.com/setup_${REQUIRED_NODE_MAJOR}.x" | sh -
-  apt-get install -y nodejs
+  apt-get update -q
+  apt-get install -y -q nodejs
 fi
 
 actual_major=$(node_major)

--- a/packaging/systemd/ai-desktops.conf
+++ b/packaging/systemd/ai-desktops.conf
@@ -1,0 +1,25 @@
+# ai-desktops.conf — systemd drop-in for ai-desktops agent-host deployments.
+#
+# Install path: /etc/systemd/system/ai-agent-bridge.service.d/ai-desktops.conf
+# Permissions:  root:root 0644
+#
+# After installing:
+#   systemctl daemon-reload
+#   systemctl restart ai-agent-bridge
+#
+# This drop-in extends the base ai-agent-bridge.service unit with:
+#   - EnvironmentFile for provider credentials (injected from agents.env)
+#   - ReadWritePaths for /workspace so agent subprocesses can modify repos
+#
+# The credential file must be created before the service starts:
+#   install -m 0600 -o root -g root /dev/null /etc/ai-agent-bridge/agents.env
+# Then add the required key=value pairs, for example:
+#   echo "OPENAI_API_KEY=sk-..." >> /etc/ai-agent-bridge/agents.env
+#
+# The leading '-' in EnvironmentFile= means the service starts even if the
+# file is absent; the bridge will fail startup only if a provider's
+# required_env variable is missing from the process environment.
+
+[Service]
+EnvironmentFile=-/etc/ai-agent-bridge/agents.env
+ReadWritePaths=/var/lib/ai-agent-bridge /workspace /tmp /var/tmp

--- a/plans/ai-desktops-support.md
+++ b/plans/ai-desktops-support.md
@@ -1,0 +1,416 @@
+# First-Class ai-desktops Support Plan
+
+## Status
+
+In progress. Phases 1 and 2 (minus runtime manifest packaging) and all documentation (§7) are complete and merged via PR #93. Phase 3 (ai-desktops-side provisioning and doctor check) is next.
+
+## Context
+
+`ai-agent-bridge` is already installed by the `ai-desktops` image on Ubuntu 24.04
+and starts successfully as a systemd service. The packaged default is a useful
+health-check baseline:
+
+- `/usr/bin/ai-agent-bridge` is installed from the apt repository.
+- `/etc/ai-agent-bridge/bridge.yaml` binds to `127.0.0.1:9445`.
+- `/var/lib/ai-agent-bridge/sessions.db` persists session metadata and output.
+- The daemon runs as the dedicated `ai-agent-bridge` system account.
+- TLS and JWT are disabled for localhost-only desktop use.
+- No providers are configured, so the service cannot start an AI agent session.
+
+The current package is intentionally provider-neutral, but an `ai-desktops`
+machine needs an opinionated agent-host profile. The profile must install pinned
+provider CLIs, make workspace repositories available to agent subprocesses, and
+provide credentials to the daemon without weakening the default package for
+other users.
+
+## Observed Gaps
+
+### Provider Runtime
+
+The desktop image currently has Node.js 18 and no `npm` executable. The bridge
+repo pins Node.js 24 in `.nvmrc` and pins provider CLI versions in
+`package.json`.
+
+When providers are configured, daemon startup calls:
+
+```go
+config.ValidateNodeRuntime(".")
+```
+
+The packaged systemd service uses:
+
+```ini
+WorkingDirectory=/var/lib/ai-agent-bridge
+```
+
+That directory does not contain `.nvmrc`, so adding providers to the packaged
+config causes daemon startup to fail before any provider can be registered.
+
+### Workspace Access
+
+The packaged config allows repository paths under `/home`, `/srv`, `/tmp`, and
+`/var/tmp`. `ai-desktops` checks repositories out under `/workspace`, so session
+requests for desktop repositories are denied by policy.
+
+The systemd unit also uses:
+
+```ini
+ProtectSystem=strict
+ReadWritePaths=/var/lib/ai-agent-bridge
+```
+
+Agent subprocesses inherit that sandbox and cannot modify `/workspace`, even if
+the bridge policy allows the path.
+
+### Credentials
+
+Provider CLIs need API keys or provider-specific authentication. The apt package
+does not define a credential injection mechanism for an agent-host deployment.
+Secrets must not be written into the package, AMI, repository, or world-readable
+configuration.
+
+### Validation
+
+Existing apt smoke tests prove that the provider-neutral daemon installs and
+starts. They do not prove that an `ai-desktops` host can start a real provider
+session against a repository under `/workspace`.
+
+## Goals
+
+- Preserve the minimal provider-neutral apt package as a valid default.
+- Add a supported `ai-desktops` agent-host deployment profile.
+- Install Node.js 24 and pinned AI agent CLIs in a stable system path.
+- Allow bridge-managed agents to operate on repositories under `/workspace`.
+- Inject credentials through a root-controlled runtime mechanism.
+- Keep the bridge bound to localhost by default.
+- Add automated validation for package startup and desktop agent-host startup.
+- Document the operator workflow for provisioning, upgrading, and debugging.
+
+## Non-Goals
+
+- Expose the bridge publicly over the desktop hostname.
+- Store API keys in the repository, apt package, AMI, or desktop metadata.
+- Replace the existing mTLS and JWT support for non-local deployments.
+- Couple the apt package to a specific cloud secrets backend.
+- Install every provider CLI when a desktop is configured for only one provider.
+
+## Design
+
+### 1. Add an Explicit Runtime Root
+
+Introduce a stable provider runtime root:
+
+```text
+/opt/ai-agent-bridge/
+  .nvmrc
+  package.json
+  package-lock.json
+  node_modules/
+```
+
+The runtime root is owned by `root:root` and is writable only during
+provisioning or upgrades. Provider sessions run code from repositories under
+`/workspace`; they must not mutate the provider runtime.
+
+Add a daemon flag or config field for the runtime root:
+
+```yaml
+runtime:
+  provider_root: "/opt/ai-agent-bridge"
+```
+
+Use this path for Node version validation and relative provider arguments.
+Do not derive runtime behavior from the daemon process working directory.
+
+Acceptance criteria:
+
+- Provider-enabled startup does not depend on `WorkingDirectory`.
+- Node validation reads `/opt/ai-agent-bridge/.nvmrc`.
+- Relative provider script paths resolve below the configured provider root.
+- Existing provider-neutral configs continue to start without a runtime root.
+- Unit tests cover configured, missing, and invalid runtime roots.
+
+### 2. Package the Provider Runtime Manifest
+
+Ship the pinned runtime manifest separately from the daemon config:
+
+```text
+/usr/share/ai-agent-bridge/provider-runtime/.nvmrc
+/usr/share/ai-agent-bridge/provider-runtime/package.json
+/usr/share/ai-agent-bridge/provider-runtime/package-lock.json
+```
+
+Add an idempotent install helper:
+
+```text
+/usr/lib/ai-agent-bridge/install-provider-runtime
+```
+
+The helper:
+
+1. Installs or verifies Node.js 24.
+2. Copies the packaged runtime manifest to `/opt/ai-agent-bridge`.
+3. Runs `npm ci --omit=dev --no-audit --no-fund`.
+4. Verifies each installed CLI version.
+5. Leaves `/opt/ai-agent-bridge` owned by `root:root`.
+
+Keep this opt-in. Installing the base `ai-agent-bridge` package must not
+automatically download third-party provider CLIs.
+
+Acceptance criteria:
+
+- The helper is safe to run repeatedly.
+- CLI versions match the repo lockfile.
+- A failed install leaves the existing runtime usable.
+- The helper prints installed versions and actionable errors.
+
+### 3. Add an ai-desktops Config Profile
+
+Add a packaged example:
+
+```text
+/usr/share/doc/ai-agent-bridge/examples/bridge-ai-desktops.yaml
+```
+
+The profile:
+
+- binds to `127.0.0.1:9445`;
+- enables persistence under `/var/lib/ai-agent-bridge`;
+- permits `/workspace`;
+- uses absolute provider runtime paths;
+- supports enabling a selected provider subset;
+- keeps TLS and JWT disabled for localhost-only use;
+- documents that remote exposure requires mTLS and JWT.
+
+Example Codex provider:
+
+```yaml
+providers:
+  codex:
+    binary: "/usr/bin/node"
+    args: ["/opt/ai-agent-bridge/node_modules/@openai/codex/bin/codex.js"]
+    startup_timeout: "60s"
+    startup_probe: "output"
+    required_env: ["OPENAI_API_KEY"]
+    prompt_pattern: "(?m)(>\\s*$|›)"
+```
+
+Acceptance criteria:
+
+- The example config passes config validation.
+- Starting the daemon with the example and selected credentials registers the
+  selected providers.
+- `/workspace/<repo>` passes path policy validation.
+
+### 4. Add a systemd ai-desktops Drop-In
+
+Keep the base systemd unit restrictive. Add a documented drop-in for desktop
+hosts:
+
+```text
+/etc/systemd/system/ai-agent-bridge.service.d/ai-desktops.conf
+```
+
+Contents:
+
+```ini
+[Service]
+EnvironmentFile=-/etc/ai-agent-bridge/agents.env
+ReadWritePaths=/var/lib/ai-agent-bridge /workspace /tmp /var/tmp
+```
+
+Do not change `WorkingDirectory` once provider runtime resolution is explicit.
+
+The credential file must be:
+
+```text
+root:root 0600 /etc/ai-agent-bridge/agents.env
+```
+
+Acceptance criteria:
+
+- Base package installs without granting `/workspace` access.
+- Desktop provisioning installs the drop-in and restarts the daemon.
+- Agent subprocesses can edit repositories under `/workspace`.
+- The service account cannot write to `/opt/ai-agent-bridge`.
+
+### 5. Integrate Provisioning Into ai-desktops
+
+Update `ai-desktops` provisioning or AMI baking to:
+
+1. Install the latest supported `ai-agent-bridge` apt package.
+2. Run `/usr/lib/ai-agent-bridge/install-provider-runtime`.
+3. Install the ai-desktops systemd drop-in.
+4. Install a rendered ai-desktops bridge config.
+5. Materialize provider credentials at boot from the platform secrets mechanism.
+6. Run `systemctl daemon-reload`.
+7. Enable and restart `ai-agent-bridge`.
+8. Run a localhost bridge health check.
+
+Credential materialization should be owned by `ai-desktops`, because it knows
+the deployment environment and secret source. `ai-agent-bridge` should only
+document and consume the env file contract.
+
+Add an `ai-desktops doctor` check that reports:
+
+- package version;
+- systemd service state;
+- localhost port `9445` state;
+- Node.js version;
+- provider runtime manifest presence;
+- configured provider IDs;
+- presence of required credential variable names without printing values;
+- `/workspace` policy and systemd write access;
+- bridge health response.
+
+Acceptance criteria:
+
+- A newly created desktop is ready for a configured provider without manual SSH
+  setup.
+- Doctor output clearly distinguishes base-package health from provider-host
+  readiness.
+- Re-running provisioning upgrades the runtime without deleting workspaces or
+  session persistence.
+
+### 6. Add Automated Tests
+
+Extend packaging and integration coverage.
+
+#### Base Apt Smoke
+
+Retain the existing assertion:
+
+- install package;
+- start provider-neutral daemon;
+- verify localhost health.
+
+#### ai-desktops Profile Smoke
+
+Add an Ubuntu 24.04 smoke scenario:
+
+1. Install the apt package.
+2. Install Node.js 24 and a test provider runtime.
+3. Apply the ai-desktops config and systemd drop-in.
+4. Create `/workspace/smoke-repo`.
+5. Start the daemon.
+6. Start a deterministic test provider session in `/workspace/smoke-repo`.
+7. Write input and verify output replay.
+8. Verify the provider can create or modify a workspace file.
+9. Restart the daemon and verify persistence remains available.
+
+Use a deterministic fixture provider in CI. Do not require external API keys for
+the package smoke test.
+
+#### Optional Live Provider Smoke
+
+Keep real Codex, Claude, OpenCode, and Gemini tests opt-in and secret-backed.
+Run them in a controlled environment after package publication.
+
+Acceptance criteria:
+
+- CI catches Node runtime root regressions.
+- CI catches `/workspace` policy regressions.
+- CI catches systemd sandbox regressions.
+- CI does not require paid provider credentials for baseline coverage.
+
+### 7. Update Documentation
+
+Add `docs/ai-desktops.md` with:
+
+- architecture and security boundary;
+- package install and provisioning flow;
+- provider runtime layout;
+- environment file contract;
+- example config;
+- systemd drop-in;
+- upgrade workflow;
+- troubleshooting commands;
+- localhost-only default and remote-exposure warning.
+
+Update:
+
+- `README.md` to link the guide;
+- `docs/README.md` to index the guide;
+- `docs/install-ubuntu.md` to distinguish the minimal package from the
+  ai-desktops agent-host profile;
+- `docs/service.md` to document `runtime.provider_root`;
+- `PRD.md` to add ai-desktops as a supported deployment target.
+
+## Implementation Sequence
+
+### Phase 1: Bridge Runtime Contract
+
+- [x] Add `runtime.provider_root` config support.
+- [x] Resolve Node validation and relative provider arguments from that root.
+- [x] Add unit tests.
+- [x] Update service reference docs.
+
+### Phase 2: Packaging
+
+- [x] Package runtime manifests (`/usr/share/ai-agent-bridge/provider-runtime/`).
+- [x] Add the idempotent provider runtime install helper (`packaging/install-provider-runtime`).
+- [x] Add the ai-desktops example config.
+- [x] Document the systemd drop-in.
+- [x] Extend apt smoke tests (profile smoke with fixture provider + `/workspace` path policy).
+
+### Documentation (§7)
+
+- [x] Add `docs/ai-desktops.md`.
+- [x] Update `README.md` to link the guide.
+- [x] Update `docs/README.md` to index the guide.
+- [x] Update `docs/install-ubuntu.md` to distinguish the minimal package from the ai-desktops profile.
+- [x] Update `docs/service.md` to document `runtime.provider_root`.
+- [x] Update `PRD.md` to add ai-desktops as a supported deployment target (§7.7).
+
+### Phase 3: ai-desktops Integration
+
+- [x] Add provisioning steps for runtime, config, credentials, and drop-in.
+- [x] Add `doctor` readiness checks (`/usr/lib/ai-agent-bridge/ai-desktops-doctor`).
+- [ ] Bake or provision the updated desktop image.
+- [ ] Validate a fresh desktop and an upgraded existing desktop.
+
+### Phase 4: Live Validation
+
+- [ ] Run deterministic profile smoke on Ubuntu 24.04.
+- [ ] Start a Codex session against `/workspace/<repo>`.
+- [ ] Verify write access, reconnect, replay, restart, and persistence.
+- [ ] Repeat for other enabled providers.
+
+## Rollout
+
+1. Merge and publish a bridge release with the explicit runtime-root contract.
+2. Validate the apt package with base and ai-desktops profile smoke tests.
+3. Update `ai-desktops` provisioning against the new bridge package version.
+4. Test on a new disposable desktop.
+5. Test upgrade behavior on an existing desktop.
+6. Bake a new desktop AMI after both paths pass.
+7. Roll out to additional desktops.
+
+## Security Notes
+
+- Keep the bridge on `127.0.0.1:9445` for ai-desktops unless a separate design
+  adds mTLS, JWT, and an explicit network path.
+- Do not log secret values or include them in doctor output.
+- Keep `/etc/ai-agent-bridge/agents.env` root-owned and mode `0600`.
+- Keep `/opt/ai-agent-bridge` immutable to the service account.
+- Grant write access only to `/workspace`, runtime state, and temporary paths.
+- Treat provider CLI upgrades as supply-chain changes: pin versions, use the
+  lockfile, verify installed versions, and validate before rollout.
+
+## Initial Target Host Evidence
+
+The first reviewed desktop was:
+
+```text
+d-7c9d2ad7.desktops.orchael.dev
+Ubuntu 24.04.4 LTS (noble)
+ai-agent-bridge 0.3.3
+Node.js v18.19.1
+workspace: /workspace/ga-gsc-analysis
+bridge: active on 127.0.0.1:9445
+providers: {}
+```
+
+This host is healthy for the provider-neutral package baseline and is the first
+candidate for upgrade-path validation after the bridge and ai-desktops changes
+land.

--- a/plans/ai-desktops-support.md
+++ b/plans/ai-desktops-support.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In progress. Phases 1 and 2 (minus runtime manifest packaging) and all documentation (§7) are complete and merged via PR #93. Phase 3 (ai-desktops-side provisioning and doctor check) is next.
+In progress. Phases 1, 2, and documentation (§7) are complete and Phase 3 provisioning/doctor items are implemented, all in PR #93 (open). Phase 3 operational steps (bake AMI, live validation) are pending.
 
 ## Context
 

--- a/scripts/ai-desktops-doctor
+++ b/scripts/ai-desktops-doctor
@@ -60,17 +60,20 @@ fi
 
 # ── 3. Localhost port 9445 ────────────────────────────────────────────────────
 
+# Check that 9445 is bound specifically on 127.0.0.1 (or ::1 for IPv6 loopback).
+# Matching on the local-address column prevents a false-positive when the
+# daemon is unexpectedly listening on 0.0.0.0 instead of loopback.
 _port_bound=0
-if ss -tlnp 2>/dev/null | grep -qE ':9445[ \t]'; then
+if ss -tlnp 2>/dev/null | grep -qE '(127\.0\.0\.1|::1):9445[ \t]'; then
   _port_bound=1
-elif netstat -tlnp 2>/dev/null | grep -qE ':9445[ \t]'; then
+elif netstat -tlnp 2>/dev/null | grep -qE '(127\.0\.0\.1|::1):9445[ \t]'; then
   _port_bound=1
 fi
 
 if [ "$_port_bound" -eq 1 ]; then
   _ok "Port 9445: bound to 127.0.0.1"
 else
-  _fail "Port 9445: not bound (is the bridge daemon running?)"
+  _fail "Port 9445: not bound on 127.0.0.1 (is the bridge daemon running?)"
 fi
 
 # ── 4. Node.js version ────────────────────────────────────────────────────────
@@ -125,18 +128,37 @@ fi
 
 if [ -f "$CONFIG_FILE" ]; then
   # Collect required_env variable names from uncommented provider blocks.
+  # Supports both the inline form:
+  #   required_env: ["VAR1", "VAR2"]
+  # and the block-list form:
+  #   required_env:
+  #     - VAR1
+  #     - VAR2
   _required_vars=$(awk '
     /^providers:/ { in_p=1; next }
     in_p && /^[^ \t]/ { in_p=0 }
-    in_p && /required_env:/ && !/^ *#/ {
-      # Handle: required_env: ["VAR1", "VAR2"]
+    in_p && /^ *#/ { next }
+    in_p && /required_env:/ {
+      in_req=1
       line=$0
       gsub(/.*required_env:[ \t]*\[/, "", line)
       gsub(/\].*/, "", line)
       gsub(/[" \t]/, "", line)
       n=split(line, vars, ",")
       for (i=1; i<=n; i++) if (vars[i] != "") print vars[i]
+      # If the line contained "[...]" we are done; otherwise block-list follows.
+      if ($0 ~ /\[/) in_req=0
+      next
     }
+    in_p && in_req && /^ *- / {
+      # Block-list item: "    - VARNAME"
+      item=$0
+      gsub(/^ *- */, "", item)
+      gsub(/[" \t]/, "", item)
+      if (item != "") print item
+      next
+    }
+    in_p && in_req && !/^ *- / { in_req=0 }
   ' "$CONFIG_FILE" | sort -u)
 
   if [ -n "$_required_vars" ]; then

--- a/scripts/ai-desktops-doctor
+++ b/scripts/ai-desktops-doctor
@@ -1,0 +1,217 @@
+#!/bin/sh
+# ai-desktops-doctor — Readiness check for an ai-desktops agent-host.
+#
+# Usage:
+#   ai-desktops-doctor
+#
+# Environment overrides (for testing):
+#   CONFIG_FILE        Bridge config path (default: /etc/ai-agent-bridge/bridge.yaml)
+#   INSTALL_DIR        Provider runtime path (default: /opt/ai-agent-bridge)
+#   CREDENTIALS_FILE   Credentials env file (default: /etc/ai-agent-bridge/agents.env)
+#   DROPIN_FILE        systemd drop-in path (default: /etc/systemd/system/ai-agent-bridge.service.d/ai-desktops.conf)
+#   BRIDGE_ADDR        Bridge listen address (default: 127.0.0.1:9445)
+#
+# Checks and their meanings:
+#   [OK]   — check passed
+#   [FAIL] — check failed; fix before using the bridge as an agent host
+#   [WARN] — informational; the bridge may still function
+
+set -eu
+
+CONFIG_FILE="${CONFIG_FILE:-/etc/ai-agent-bridge/bridge.yaml}"
+INSTALL_DIR="${INSTALL_DIR:-/opt/ai-agent-bridge}"
+CREDENTIALS_FILE="${CREDENTIALS_FILE:-/etc/ai-agent-bridge/agents.env}"
+DROPIN_FILE="${DROPIN_FILE:-/etc/systemd/system/ai-agent-bridge.service.d/ai-desktops.conf}"
+BRIDGE_ADDR="${BRIDGE_ADDR:-127.0.0.1:9445}"
+REQUIRED_NODE_MAJOR=24
+
+_pass=0
+_fail=0
+
+_ok()   { printf '[OK]   %s\n'   "$*"; _pass=$((_pass + 1)); }
+_fail() { printf '[FAIL] %s\n'   "$*" >&2; _fail=$((_fail + 1)); }
+_warn() { printf '[WARN] %s\n'   "$*"; }
+
+echo "ai-desktops bridge doctor"
+echo "========================="
+echo ""
+
+# ── 1. Package version ────────────────────────────────────────────────────────
+
+if dpkg -s ai-agent-bridge >/dev/null 2>&1; then
+  _ver=$(dpkg -s ai-agent-bridge 2>/dev/null | awk '/^Version:/{print $2}')
+  _ok "Package version: ai-agent-bridge ${_ver}"
+else
+  _fail "Package not installed: ai-agent-bridge"
+fi
+
+# ── 2. Systemd service state ──────────────────────────────────────────────────
+
+if command -v systemctl >/dev/null 2>&1; then
+  _state=$(systemctl is-active ai-agent-bridge 2>/dev/null || true)
+  case "$_state" in
+    active)     _ok   "Service state: active" ;;
+    activating) _warn "Service state: activating (not yet fully started)" ;;
+    *)          _fail "Service state: ${_state:-unknown}" ;;
+  esac
+else
+  _warn "systemctl not available; skipping service state check"
+fi
+
+# ── 3. Localhost port 9445 ────────────────────────────────────────────────────
+
+_port_bound=0
+if ss -tlnp 2>/dev/null | grep -qE ':9445[ \t]'; then
+  _port_bound=1
+elif netstat -tlnp 2>/dev/null | grep -qE ':9445[ \t]'; then
+  _port_bound=1
+fi
+
+if [ "$_port_bound" -eq 1 ]; then
+  _ok "Port 9445: bound to 127.0.0.1"
+else
+  _fail "Port 9445: not bound (is the bridge daemon running?)"
+fi
+
+# ── 4. Node.js version ────────────────────────────────────────────────────────
+
+if command -v node >/dev/null 2>&1; then
+  _node_ver=$(node --version 2>/dev/null || echo "unknown")
+  _node_major=$(printf '%s' "$_node_ver" | sed 's/v//;s/\..*//')
+  if [ "$_node_major" = "$REQUIRED_NODE_MAJOR" ]; then
+    _ok "Node.js: ${_node_ver}"
+  else
+    _fail "Node.js: ${_node_ver} (requires v${REQUIRED_NODE_MAJOR}.x.x — run install-provider-runtime)"
+  fi
+else
+  _fail "Node.js: not found (run install-provider-runtime)"
+fi
+
+# ── 5. Provider runtime manifest presence ────────────────────────────────────
+
+if [ -f "${INSTALL_DIR}/.nvmrc" ] && \
+   [ -f "${INSTALL_DIR}/package.json" ] && \
+   [ -d "${INSTALL_DIR}/node_modules" ]; then
+  _ok "Provider runtime: ${INSTALL_DIR} (node_modules present)"
+elif [ -f "${INSTALL_DIR}/.nvmrc" ] && [ -f "${INSTALL_DIR}/package.json" ]; then
+  _fail "Provider runtime: ${INSTALL_DIR} manifest present but node_modules missing (run install-provider-runtime)"
+else
+  _fail "Provider runtime: ${INSTALL_DIR} not found (run install-provider-runtime)"
+fi
+
+# ── 6. Configured provider IDs ───────────────────────────────────────────────
+
+if [ -f "$CONFIG_FILE" ]; then
+  # Extract enabled (non-commented) provider names: 2-space-indented keys directly
+  # under the `providers:` block, stopping at the next top-level key.
+  _providers=$(awk '
+    /^providers:/ { in_p=1; next }
+    in_p && /^[^ \t]/ { in_p=0 }
+    in_p && /^  [a-zA-Z][a-zA-Z0-9_]*:/ && !/^  #/ {
+      sub(/:.*/, ""); sub(/^  /, ""); printf "%s ", $0
+    }
+  ' "$CONFIG_FILE" | sed 's/ $//')
+
+  if [ -n "$_providers" ]; then
+    _ok "Configured providers: ${_providers}"
+  else
+    _warn "Configured providers: none (edit ${CONFIG_FILE} to enable one or more providers)"
+  fi
+else
+  _fail "Config not found: ${CONFIG_FILE}"
+fi
+
+# ── 7. Required credential variable presence ─────────────────────────────────
+
+if [ -f "$CONFIG_FILE" ]; then
+  # Collect required_env variable names from uncommented provider blocks.
+  _required_vars=$(awk '
+    /^providers:/ { in_p=1; next }
+    in_p && /^[^ \t]/ { in_p=0 }
+    in_p && /required_env:/ && !/^ *#/ {
+      # Handle: required_env: ["VAR1", "VAR2"]
+      line=$0
+      gsub(/.*required_env:[ \t]*\[/, "", line)
+      gsub(/\].*/, "", line)
+      gsub(/[" \t]/, "", line)
+      n=split(line, vars, ",")
+      for (i=1; i<=n; i++) if (vars[i] != "") print vars[i]
+    }
+  ' "$CONFIG_FILE" | sort -u)
+
+  if [ -n "$_required_vars" ]; then
+    _cred_ok=1
+    for _var in $_required_vars; do
+      _found=0
+      if [ -f "$CREDENTIALS_FILE" ] && grep -q "^${_var}=" "$CREDENTIALS_FILE" 2>/dev/null; then
+        _found=1
+      elif printenv "$_var" >/dev/null 2>&1; then
+        _found=1
+      fi
+      if [ "$_found" -eq 1 ]; then
+        printf '         %s: set\n' "$_var"
+      else
+        printf '         %s: MISSING\n' "$_var" >&2
+        _cred_ok=0
+      fi
+    done
+    if [ "$_cred_ok" -eq 1 ]; then
+      _ok "Credentials: all required variables present"
+    else
+      _fail "Credentials: one or more required variables missing from ${CREDENTIALS_FILE}"
+    fi
+  else
+    _warn "Credentials: no required_env variables found (are providers enabled in ${CONFIG_FILE}?)"
+  fi
+fi
+
+# ── 8. /workspace path policy ────────────────────────────────────────────────
+
+if [ -f "$CONFIG_FILE" ] && grep -q '/workspace' "$CONFIG_FILE" 2>/dev/null; then
+  _ok "/workspace: listed in bridge allowed_paths"
+else
+  _fail "/workspace: not in bridge allowed_paths — agent sessions will be denied by policy"
+fi
+
+# ── 9. systemd drop-in and /workspace write access ───────────────────────────
+
+if [ -f "$DROPIN_FILE" ]; then
+  if grep -q 'ReadWritePaths.*workspace' "$DROPIN_FILE" 2>/dev/null; then
+    _ok "systemd drop-in: ${DROPIN_FILE} (ReadWritePaths includes /workspace)"
+  else
+    _warn "systemd drop-in: ${DROPIN_FILE} exists but ReadWritePaths does not include /workspace"
+  fi
+else
+  _fail "systemd drop-in: ${DROPIN_FILE} not found — agent subprocesses cannot write to /workspace"
+fi
+
+# ── 10. Bridge health ─────────────────────────────────────────────────────────
+
+_bridge_host=$(printf '%s' "$BRIDGE_ADDR" | cut -d: -f1)
+_bridge_port=$(printf '%s' "$BRIDGE_ADDR" | cut -d: -f2)
+
+if command -v grpc-health-probe >/dev/null 2>&1; then
+  if grpc-health-probe -addr "$BRIDGE_ADDR" >/dev/null 2>&1; then
+    _ok "Bridge health: healthy (${BRIDGE_ADDR})"
+  else
+    _fail "Bridge health: UNHEALTHY (${BRIDGE_ADDR})"
+  fi
+elif command -v nc >/dev/null 2>&1; then
+  if nc -z "$_bridge_host" "$_bridge_port" 2>/dev/null; then
+    _ok "Bridge health: port reachable (${BRIDGE_ADDR})"
+  else
+    _fail "Bridge health: port not reachable (${BRIDGE_ADDR})"
+  fi
+else
+  _warn "Bridge health: skipped (grpc-health-probe and nc not available)"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+printf 'Result: %d OK, %d FAIL\n' "$_pass" "$_fail"
+
+if [ "$_fail" -gt 0 ]; then
+  echo "See docs/ai-desktops.md troubleshooting section for remediation steps."
+  exit 1
+fi

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -54,9 +54,11 @@ install -m 0644 "$ROOT_DIR/packaging/bridge.yaml" \
 install -m 0644 "$ROOT_DIR/packaging/ai-agent-bridge.service" \
   "$PKG_ROOT/lib/systemd/system/ai-agent-bridge.service"
 
-# Provider runtime install helper
+# Provider runtime install helper and doctor script
 install -m 0755 "$ROOT_DIR/packaging/install-provider-runtime" \
   "$PKG_ROOT/usr/lib/ai-agent-bridge/install-provider-runtime"
+install -m 0755 "$ROOT_DIR/scripts/ai-desktops-doctor" \
+  "$PKG_ROOT/usr/lib/ai-agent-bridge/ai-desktops-doctor"
 
 # Provider runtime manifest (used by install-provider-runtime)
 install -m 0644 "$ROOT_DIR/.nvmrc"            "$PKG_ROOT/usr/share/ai-agent-bridge/provider-runtime/.nvmrc"

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -38,15 +38,40 @@ GOARCH="$ARCH" go build -o "$ROOT_DIR/bin/ai-agent-bridge-ca" ./cmd/bridge-ca
 mkdir -p \
   "$PKG_ROOT/DEBIAN" \
   "$PKG_ROOT/usr/bin" \
+  "$PKG_ROOT/usr/lib/ai-agent-bridge" \
+  "$PKG_ROOT/usr/share/ai-agent-bridge/provider-runtime" \
+  "$PKG_ROOT/usr/share/doc/ai-agent-bridge/examples" \
   "$PKG_ROOT/etc/ai-agent-bridge" \
   "$PKG_ROOT/lib/systemd/system"
 
-install -m 0755 "$ROOT_DIR/bin/ai-agent-bridge" "$PKG_ROOT/usr/bin/ai-agent-bridge"
+# Binaries
+install -m 0755 "$ROOT_DIR/bin/ai-agent-bridge"    "$PKG_ROOT/usr/bin/ai-agent-bridge"
 install -m 0755 "$ROOT_DIR/bin/ai-agent-bridge-ca" "$PKG_ROOT/usr/bin/ai-agent-bridge-ca"
-install -m 0644 "$ROOT_DIR/packaging/bridge.yaml" "$PKG_ROOT/etc/ai-agent-bridge/bridge.yaml"
-install -m 0644 "$ROOT_DIR/packaging/ai-agent-bridge.service" "$PKG_ROOT/lib/systemd/system/ai-agent-bridge.service"
+
+# Default daemon config and systemd unit
+install -m 0644 "$ROOT_DIR/packaging/bridge.yaml" \
+  "$PKG_ROOT/etc/ai-agent-bridge/bridge.yaml"
+install -m 0644 "$ROOT_DIR/packaging/ai-agent-bridge.service" \
+  "$PKG_ROOT/lib/systemd/system/ai-agent-bridge.service"
+
+# Provider runtime install helper
+install -m 0755 "$ROOT_DIR/packaging/install-provider-runtime" \
+  "$PKG_ROOT/usr/lib/ai-agent-bridge/install-provider-runtime"
+
+# Provider runtime manifest (used by install-provider-runtime)
+install -m 0644 "$ROOT_DIR/.nvmrc"            "$PKG_ROOT/usr/share/ai-agent-bridge/provider-runtime/.nvmrc"
+install -m 0644 "$ROOT_DIR/package.json"      "$PKG_ROOT/usr/share/ai-agent-bridge/provider-runtime/package.json"
+install -m 0644 "$ROOT_DIR/package-lock.json" "$PKG_ROOT/usr/share/ai-agent-bridge/provider-runtime/package-lock.json"
+
+# Example configs and systemd drop-in
+install -m 0644 "$ROOT_DIR/packaging/examples/bridge-ai-desktops.yaml" \
+  "$PKG_ROOT/usr/share/doc/ai-agent-bridge/examples/bridge-ai-desktops.yaml"
+install -m 0644 "$ROOT_DIR/packaging/systemd/ai-desktops.conf" \
+  "$PKG_ROOT/usr/share/doc/ai-agent-bridge/examples/ai-desktops.conf"
+
+# Debian maintainer scripts
 install -m 0755 "$ROOT_DIR/packaging/debian/postinst" "$PKG_ROOT/DEBIAN/postinst"
-install -m 0755 "$ROOT_DIR/packaging/debian/prerm" "$PKG_ROOT/DEBIAN/prerm"
+install -m 0755 "$ROOT_DIR/packaging/debian/prerm"    "$PKG_ROOT/DEBIAN/prerm"
 
 cat >"$PKG_ROOT/DEBIAN/control" <<EOF
 Package: $PACKAGE_NAME

--- a/scripts/smoke-apt-profile.sh
+++ b/scripts/smoke-apt-profile.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# smoke-apt-profile.sh — apt package smoke test for the ai-desktops profile.
+#
+# Verifies that the ai-desktops deployment profile works end-to-end:
+#   1. Install the ai-agent-bridge apt package.
+#   2. Apply a fixture config that mirrors the ai-desktops profile structure:
+#      - persistence enabled
+#      - /workspace in allowed_paths
+#      - a deterministic fixture provider (cat) — no API keys required
+#   3. Create /workspace/smoke-repo.
+#   4. Start the daemon with the fixture config.
+#   5. Run the profile-smoke binary to verify:
+#      - bridge health
+#      - fixture provider registered
+#      - session start for /workspace/smoke-repo passes path policy
+#      - input written to the session is echoed back
+#   6. Restart the daemon.
+#   7. Verify health is restored (persistence not corrupted).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+GNUPGHOME="$TMP_DIR/gnupg"
+REPO_DIR="$TMP_DIR/repo"
+PACKAGES_DIR="$TMP_DIR/packages"
+HEALTHCHECK_BIN="$TMP_DIR/plain-healthcheck"
+PROFILE_SMOKE_BIN="$TMP_DIR/profile-smoke"
+SUITE="${SUITE:-noble}"
+: "${GOCACHE:=/tmp/ai-agent-bridge-go-build}"
+: "${GOFLAGS:=-buildvcs=false}"
+
+export GOCACHE
+export GOFLAGS
+
+cleanup() {
+  local rc=$?
+  docker rm -f "apt-smoke-profile-$SUITE" >/dev/null 2>&1 || true
+  rm -rf "$TMP_DIR"
+  exit "$rc"
+}
+
+trap cleanup EXIT
+
+# ── Build the .deb package ─────────────────────────────────────────────────
+mkdir -p "$GNUPGHOME"
+chmod 700 "$GNUPGHOME"
+
+gpg --batch \
+  --homedir "$GNUPGHOME" \
+  --pinentry-mode loopback \
+  --passphrase '' \
+  --quick-generate-key \
+  "AI Agent Bridge Smoke <smoke@ai-agent-bridge.local>" \
+  rsa3072 sign 0
+
+export GNUPGHOME
+VERSION="0.0.0-smoke" OUTPUT_DIR="$PACKAGES_DIR" "$ROOT_DIR/scripts/build-deb.sh"
+REPO_DIR="$REPO_DIR" PACKAGES_DIR="$PACKAGES_DIR" "$ROOT_DIR/scripts/build-apt-repo.sh"
+
+# ── Build helper binaries ─────────────────────────────────────────────────
+go build -o "$HEALTHCHECK_BIN" ./e2e/cmd/plain-healthcheck
+go build -o "$PROFILE_SMOKE_BIN" ./e2e/cmd/profile-smoke
+
+# ── Write the fixture bridge config ───────────────────────────────────────
+FIXTURE_CONFIG="$TMP_DIR/bridge-fixture.yaml"
+cat >"$FIXTURE_CONFIG" <<'EOF'
+# Fixture config for ai-desktops profile smoke test.
+# Mirrors the ai-desktops profile structure but uses /bin/cat as the
+# provider so no Node.js or API keys are required in CI.
+
+server:
+  listen: "127.0.0.1:9445"
+
+tls:
+  ca_bundle: ""
+  cert: ""
+  key: ""
+
+auth:
+  jwt_public_keys: []
+  jwt_audience: "bridge"
+  jwt_max_ttl: "5m"
+
+feature_flags:
+  provider_fallbacks: false
+
+sessions:
+  max_per_project: 5
+  max_global: 20
+  idle_timeout: "30m"
+  stop_grace_period: "5s"
+  event_buffer_size: 10000
+  max_subscribers_per_session: 10
+  subscriber_ttl: "30m"
+
+input:
+  max_size_bytes: 65536
+
+rate_limits:
+  global_rps: 50
+  global_burst: 100
+  start_session_per_client_rps: 1
+  start_session_per_client_burst: 3
+  send_input_per_session_rps: 5
+  send_input_per_session_burst: 20
+
+persistence:
+  db_path: "/var/lib/ai-agent-bridge/sessions.db"
+
+providers:
+  fixture:
+    binary: "/bin/cat"
+    args: []
+    startup_timeout: "5s"
+    validate_startup: false
+
+allowed_paths:
+  - "/workspace"
+  - "/tmp"
+
+logging:
+  level: "info"
+  format: "json"
+EOF
+
+# ── Determine Ubuntu image tag for suite ──────────────────────────────────
+case "$SUITE" in
+  noble)  IMAGE_TAG="24.04" ;;
+  plucky) IMAGE_TAG="25.04" ;;
+  *)
+    echo "smoke-apt-profile: unsupported SUITE=$SUITE" >&2
+    exit 1
+    ;;
+esac
+
+CONTAINER="apt-smoke-profile-$SUITE"
+
+docker run -d \
+  --name "$CONTAINER" \
+  --add-host=host.docker.internal:host-gateway \
+  -v "$REPO_DIR:/opt/aptrepo:ro" \
+  -v "$HEALTHCHECK_BIN:/usr/local/bin/plain-healthcheck:ro" \
+  -v "$PROFILE_SMOKE_BIN:/usr/local/bin/profile-smoke:ro" \
+  -v "$FIXTURE_CONFIG:/tmp/bridge-fixture.yaml:ro" \
+  ubuntu:"$IMAGE_TAG" \
+  bash -lc "$(cat <<'INNER'
+    set -euo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+
+    # Install package.
+    apt-get update -q
+    apt-get install -y -q ca-certificates gnupg
+    install -d /etc/apt/keyrings
+    gpg --dearmor -o /etc/apt/keyrings/ai-agent-bridge.gpg \
+      /opt/aptrepo/ai-agent-bridge-archive-keyring.asc
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/ai-agent-bridge.gpg] file:/opt/aptrepo noble main" \
+      > /etc/apt/sources.list.d/ai-agent-bridge.list
+    apt-get update -q
+    apt-get install -y -q ai-agent-bridge
+
+    # Apply fixture config.
+    cp /tmp/bridge-fixture.yaml /etc/ai-agent-bridge/bridge.yaml
+
+    # Create workspace directory.
+    mkdir -p /workspace/smoke-repo
+
+    # Start the daemon in the background.
+    /usr/bin/ai-agent-bridge --config /etc/ai-agent-bridge/bridge.yaml \
+      >/tmp/bridge.log 2>&1 &
+    BRIDGE_PID=$!
+
+    # Wait for bridge to report healthy.
+    for i in $(seq 1 30); do
+      if /usr/local/bin/plain-healthcheck -target "127.0.0.1:9445" >/dev/null 2>&1; then
+        break
+      fi
+      if ! kill -0 "$BRIDGE_PID" 2>/dev/null; then
+        echo "PROFILE SMOKE FAILED: bridge exited early"
+        cat /tmp/bridge.log >&2
+        exit 1
+      fi
+      sleep 1
+    done
+
+    # Keep container alive for external smoke probe.
+    tail -f /dev/null
+INNER
+  )" >/dev/null
+
+# ── Wait for bridge health from host ──────────────────────────────────────
+echo "==> Waiting for bridge health (suite=$SUITE)"
+for _ in $(seq 1 30); do
+  if docker exec "$CONTAINER" /usr/local/bin/plain-healthcheck \
+      -target "127.0.0.1:9445" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! docker exec "$CONTAINER" /usr/local/bin/plain-healthcheck \
+    -target "127.0.0.1:9445" >/dev/null 2>&1; then
+  docker exec "$CONTAINER" sh -c 'cat /tmp/bridge.log' >&2 || true
+  echo "APT PROFILE SMOKE FAILED: bridge not healthy suite=$SUITE" >&2
+  exit 1
+fi
+
+# ── Run profile smoke (provider session + echo test) ──────────────────────
+echo "==> Running profile smoke (provider session, workspace path, echo)"
+if ! docker exec "$CONTAINER" /usr/local/bin/profile-smoke \
+    -target "127.0.0.1:9445" \
+    -provider "fixture" \
+    -repo-path "/workspace/smoke-repo" \
+    -timeout "30s"; then
+  docker exec "$CONTAINER" sh -c 'cat /tmp/bridge.log' >&2 || true
+  echo "APT PROFILE SMOKE FAILED: profile-smoke binary failed suite=$SUITE" >&2
+  exit 1
+fi
+
+# ── Restart bridge and verify persistence ─────────────────────────────────
+echo "==> Restarting bridge to verify persistence"
+docker exec "$CONTAINER" bash -c '
+  BRIDGE_PID=$(pgrep -x ai-agent-bridge || true)
+  if [ -n "$BRIDGE_PID" ]; then
+    kill "$BRIDGE_PID"
+    for i in $(seq 1 10); do
+      pgrep -x ai-agent-bridge >/dev/null || break
+      sleep 1
+    done
+  fi
+  /usr/bin/ai-agent-bridge --config /etc/ai-agent-bridge/bridge.yaml \
+    >>/tmp/bridge.log 2>&1 &
+'
+
+for _ in $(seq 1 30); do
+  if docker exec "$CONTAINER" /usr/local/bin/plain-healthcheck \
+      -target "127.0.0.1:9445" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! docker exec "$CONTAINER" /usr/local/bin/plain-healthcheck \
+    -target "127.0.0.1:9445" >/dev/null 2>&1; then
+  docker exec "$CONTAINER" sh -c 'cat /tmp/bridge.log' >&2 || true
+  echo "APT PROFILE SMOKE FAILED: bridge did not recover after restart suite=$SUITE" >&2
+  exit 1
+fi
+
+echo "APT PROFILE SMOKE PASSED: suite=$SUITE"

--- a/scripts/smoke-apt-profile.sh
+++ b/scripts/smoke-apt-profile.sh
@@ -138,6 +138,7 @@ CONTAINER="apt-smoke-profile-$SUITE"
 docker run -d \
   --name "$CONTAINER" \
   --add-host=host.docker.internal:host-gateway \
+  -e SUITE="$SUITE" \
   -v "$REPO_DIR:/opt/aptrepo:ro" \
   -v "$HEALTHCHECK_BIN:/usr/local/bin/plain-healthcheck:ro" \
   -v "$PROFILE_SMOKE_BIN:/usr/local/bin/profile-smoke:ro" \
@@ -153,7 +154,7 @@ docker run -d \
     install -d /etc/apt/keyrings
     gpg --dearmor -o /etc/apt/keyrings/ai-agent-bridge.gpg \
       /opt/aptrepo/ai-agent-bridge-archive-keyring.asc
-    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/ai-agent-bridge.gpg] file:/opt/aptrepo noble main" \
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/ai-agent-bridge.gpg] file:/opt/aptrepo ${SUITE} main" \
       > /etc/apt/sources.list.d/ai-agent-bridge.list
     apt-get update -q
     apt-get install -y -q ai-agent-bridge


### PR DESCRIPTION
## Summary

Consolidates all work from PRs #90, #91, and the original #93 into a single cohesive feature branch. Addresses all Copilot review comments from all three PRs.

### Phase 1 — \`runtime.provider_root\` config field (was PR #90)

- Add \`runtime.provider_root\` YAML config field so operators can specify the directory where provider CLIs and \`node_modules\` are installed, independent of the daemon's working directory.
- Add \`absRoot()\` helper in \`internal/provider/stdio.go\` to absolutize a potentially-relative root before joining binary/arg paths against it, preventing silent resolution against \`cmd.Dir\` (the session repo path) at exec time.
- \`resolveBinaryPath\`: when root is set and binary contains a \`/\`, resolve against absolutized root.
- \`resolveCommandArgs\`: rewrite only standalone relative path args (\`./foo\`, \`../foo\`) against absolutized root; PATH-resolved names and embedded flag values (e.g. \`--config=./foo\`) are left unchanged.
- Update \`docs/service.md\` \`runtime\` field table with accurate scope description for each resolution rule.
- Validate \`provider_root\` is absolute at config load time.
- Unit tests for \`absRoot\`, \`resolveBinaryPath\`, \`resolveCommandArgs\`, and config validation.

### Phase 2 — packaging + apt smoke test (was PR #91)

- Add \`packaging/install-provider-runtime\` script: installs \`node_modules\` for configured providers into \`provider_root\` using a same-filesystem staging directory (\`mktemp -d -p "$INSTALL_DIR/.."\`) to prevent cross-filesystem \`mv\` failure; uses backup-then-swap pattern for atomic replacement.
- Package runtime manifests (\`.nvmrc\`, \`package.json\`, \`package-lock.json\`) into \`/usr/share/ai-agent-bridge/provider-runtime/\` via \`build-deb.sh\`.
- Inject \`SUITE\` env var into the Docker container in \`scripts/smoke-apt-profile.sh\` so the apt source list references the correct Ubuntu suite rather than a hardcoded value.
- Fix \`RequiresNodeRuntime\` in \`internal/config/node.go\` to check binary name only (\`node\`/\`nodejs\`), removing the false-positive-prone \`Args[0]\` \`.js\` suffix check.
- Add \`client_id\` field to both \`AttachSessionRequest\` and \`WriteInputRequest\` in \`e2e/cmd/profile-smoke/main.go\` (required by server's \`validateStringField\`).
- Unit tests for \`RequiresNodeRuntime\`.

### Phase 3 — documentation + doctor check (was PR #93)

- Add \`docs/ai-desktops.md\`: full provisioning, operating, and troubleshooting guide for the bridge on an ai-desktops Ubuntu 24.04 agent host with provider CLIs, \`/workspace\` access, and credential injection.
- Update \`docs/README.md\`: add \`ai-desktops.md\` to Core Guides and reading order.
- Update \`docs/install-ubuntu.md\`: add "ai-desktops Agent-Host Profile" section linking to the new guide.
- Update \`README.md\` Documentation section: add links to \`docs/install-ubuntu.md\` and \`docs/ai-desktops.md\`.
- Update \`PRD.md\` §7.7: add "ai-desktops Agent-Host Deployment Target" with provider support table and acceptance criteria.
- Add \`scripts/ai-desktops-doctor\`: POSIX shell readiness check that reports \`[OK]\`/\`[FAIL]\`/\`[WARN]\` for package version, service state, port 9445, Node.js version, provider runtime presence, configured providers, credential variable presence (names only), \`/workspace\` policy, systemd drop-in, and bridge health. Packaged into the \`.deb\` at \`/usr/lib/ai-agent-bridge/ai-desktops-doctor\`.

## Test plan

- [ ] \`make test\` passes with \`-race\` (no data races)
- [ ] \`make test-cover\` confirms ≥ 75% coverage
- [ ] \`scripts/smoke-apt-profile.sh\` passes on noble and plucky suites
- [ ] \`e2e/cmd/profile-smoke\` echo test passes against the fixture provider
- [ ] \`docs/service.md\` \`runtime.provider_root\` field description matches implementation
- [ ] \`scripts/ai-desktops-doctor\` passes syntax check (\`sh -n\`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)