### PR TITLE
feat: detect and reuse system daemon in bridgectl; add --no-tty run mode with e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build proto test test-e2e test-cover test-cover-maintained lint clean certs dev-certs dev-setup agents-setup setup-hosts fmt run dev-run docker-run smoke smoke-apt-local smoke-deb smoke-container smoke-ec2 build-deb up down logs up-local down-local logs-local chat-example chat-claude chat-opencode chat-codex chat-gemini chat-ts-example chat-ts-claude chat-ts-opencode chat-ts-codex chat-ts-gemini chat-web-install chat-web-dev chat-web-build chat-web-start chat-web-docker-dev chat-web-docker-start build-cli test-cli-e2e test-cli-e2e-docker check-deps
+.PHONY: build proto test test-e2e test-cover test-cover-maintained lint clean certs dev-certs dev-setup agents-setup setup-hosts fmt run dev-run docker-run smoke smoke-apt-local smoke-deb smoke-container smoke-ec2 build-deb up down logs up-local down-local logs-local chat-example chat-claude chat-opencode chat-codex chat-gemini chat-ts-example chat-ts-claude chat-ts-opencode chat-ts-codex chat-ts-gemini chat-web-install chat-web-dev chat-web-build chat-web-start chat-web-docker-dev chat-web-docker-start build-cli test-cli-e2e test-cli-e2e-docker test-system-daemon-e2e check-deps
 
 BIN_DIR := bin
 BRIDGE := $(BIN_DIR)/ai-agent-bridge
@@ -193,6 +193,12 @@ test-cli-e2e:
 
 test-cli-e2e-docker:
 	./scripts/test-cli-e2e-docker.sh
+
+test-system-daemon-e2e:
+	docker compose -f e2e/system-daemon/docker-compose.yml up --build --abort-on-container-exit --exit-code-from bridgectl-test; \
+	status=$$?; \
+	docker compose -f e2e/system-daemon/docker-compose.yml down -v; \
+	exit $$status
 
 check-deps:
 	./scripts/check-deps.sh

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ test-cli-e2e-docker:
 	./scripts/test-cli-e2e-docker.sh
 
 test-system-daemon-e2e:
-	docker compose -f e2e/system-daemon/docker-compose.yml up --build --abort-on-container-exit --exit-code-from bridgectl-test; \
+	./scripts/with_env_secrets.sh docker compose -f e2e/system-daemon/docker-compose.yml up --build --abort-on-container-exit --exit-code-from bridgectl-test; \
 	status=$$?; \
 	docker compose -f e2e/system-daemon/docker-compose.yml down -v; \
 	exit $$status

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -279,16 +279,25 @@ const systemAddrFile = "/run/ai-agent-bridge/server.addr"
 func writeSystemAddrFile(addr string, logger *slog.Logger) {
 	// Replace wildcard bind address with loopback so remote clients can connect.
 	if host, port, err := net.SplitHostPort(addr); err == nil {
-		if host == "0.0.0.0" || host == "::" {
+		switch host {
+		case "0.0.0.0":
 			addr = "127.0.0.1:" + port
+		case "::":
+			addr = "[::1]:" + port
 		}
 	}
 	if err := os.MkdirAll("/run/ai-agent-bridge", 0o755); err != nil {
 		logger.Warn("create system addr dir", "error", err)
 		return
 	}
-	if err := os.WriteFile(systemAddrFile, []byte(addr), 0o644); err != nil {
+	tmp := systemAddrFile + ".tmp"
+	if err := os.WriteFile(tmp, []byte(addr), 0o644); err != nil {
 		logger.Warn("write system addr file", "path", systemAddrFile, "error", err)
+		return
+	}
+	if err := os.Rename(tmp, systemAddrFile); err != nil {
+		logger.Warn("publish system addr file", "path", systemAddrFile, "error", err)
+		_ = os.Remove(tmp)
 	}
 }
 

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -277,6 +277,12 @@ func generateServerID() string {
 const systemAddrFile = "/run/ai-agent-bridge/server.addr"
 
 func writeSystemAddrFile(addr string, logger *slog.Logger) {
+	// Replace wildcard bind address with loopback so remote clients can connect.
+	if host, port, err := net.SplitHostPort(addr); err == nil {
+		if host == "0.0.0.0" || host == "::" {
+			addr = "127.0.0.1:" + port
+		}
+	}
 	if err := os.MkdirAll("/run/ai-agent-bridge", 0o755); err != nil {
 		logger.Warn("create system addr dir", "error", err)
 		return

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -239,6 +239,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Publish the listen address so bridgectl can discover this daemon
+	// without needing to know the configured address in advance.
+	// The file lives under RuntimeDirectory (created by systemd); we
+	// remove it on clean shutdown so stale entries don't mislead clients.
+	writeSystemAddrFile(ln.Addr().String(), logger)
+	defer removeSystemAddrFile(logger)
+
 	// Graceful shutdown
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
@@ -265,6 +272,24 @@ func generateServerID() string {
 	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
 		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+const systemAddrFile = "/run/ai-agent-bridge/server.addr"
+
+func writeSystemAddrFile(addr string, logger *slog.Logger) {
+	if err := os.MkdirAll("/run/ai-agent-bridge", 0o755); err != nil {
+		logger.Warn("create system addr dir", "error", err)
+		return
+	}
+	if err := os.WriteFile(systemAddrFile, []byte(addr), 0o644); err != nil {
+		logger.Warn("write system addr file", "path", systemAddrFile, "error", err)
+	}
+}
+
+func removeSystemAddrFile(logger *slog.Logger) {
+	if err := os.Remove(systemAddrFile); err != nil && !os.IsNotExist(err) {
+		logger.Warn("remove system addr file", "path", systemAddrFile, "error", err)
+	}
 }
 
 func newLogger(cfg *config.Config, redactor *redact.Redactor) *slog.Logger {

--- a/cmd/bridgectl/run.go
+++ b/cmd/bridgectl/run.go
@@ -31,6 +31,7 @@ func newRunCmd() *cobra.Command {
 		providerName string
 		project      string
 		timeout      time.Duration
+		noTTY        bool
 	)
 
 	cmd := &cobra.Command{
@@ -42,7 +43,10 @@ session with the specified provider, and attach your terminal.
 If another instance is already running, the existing server is reused.
 
 Press ctrl-] to detach from the session without stopping it.
-Use 'bridgectl session attach <id>' to reattach later.`,
+Use 'bridgectl session attach <id>' to reattach later.
+
+Use --no-tty to run without a terminal, reading from stdin and writing to
+stdout. Useful for scripting, piping input, and automated tests.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dir := "."
@@ -56,6 +60,9 @@ Use 'bridgectl session attach <id>' to reattach later.`,
 			if _, err := os.Stat(absDir); err != nil {
 				return fmt.Errorf("directory %q: %w", absDir, err)
 			}
+			if noTTY {
+				return runSessionNoTTY(absDir, providerName, project, timeout)
+			}
 			return runSession(absDir, providerName, project, timeout)
 		},
 	}
@@ -63,6 +70,7 @@ Use 'bridgectl session attach <id>' to reattach later.`,
 	cmd.Flags().StringVarP(&providerName, "provider", "p", "claude", "AI provider (claude, codex, opencode, gemini, echo)")
 	cmd.Flags().StringVar(&project, "project", "local", "project ID")
 	cmd.Flags().DurationVarP(&timeout, "timeout", "t", 30*time.Minute, "session timeout")
+	cmd.Flags().BoolVar(&noTTY, "no-tty", false, "run without a terminal (for scripting and tests)")
 
 	return cmd
 }
@@ -254,6 +262,87 @@ func ensureServer() error {
 		}
 	}
 	return fmt.Errorf("server did not start within 5s")
+}
+
+// runSessionNoTTY runs a session without a terminal, forwarding raw stdin to
+// the provider and writing output to stdout. Used for scripting, piping, and
+// automated tests (e.g. the echo provider in CI).
+func runSessionNoTTY(dir, providerName, project string, timeout time.Duration) error {
+	if err := ensureServer(); err != nil {
+		return err
+	}
+
+	client, err := connectClient("", timeout)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+	client.SetProject(project)
+
+	sessionID := uuid.NewString()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if _, err := client.StartSession(ctx, &bridgev1.StartSessionRequest{
+		ProjectId:   project,
+		SessionId:   sessionID,
+		RepoPath:    dir,
+		Provider:    providerName,
+		InitialCols: 80,
+		InitialRows: 24,
+	}); err != nil {
+		return fmt.Errorf("start session: %w", err)
+	}
+
+	stream, err := client.AttachSession(ctx, &bridgev1.AttachSessionRequest{
+		SessionId: sessionID,
+		ClientId:  uuid.NewString(),
+		AfterSeq:  0,
+	})
+	if err != nil {
+		return fmt.Errorf("attach session: %w", err)
+	}
+
+	// Forward stdin to session; close session when stdin reaches EOF.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := os.Stdin.Read(buf)
+			if n > 0 {
+				_, _ = client.WriteInput(context.Background(), &bridgev1.WriteInputRequest{
+					SessionId: sessionID,
+					ClientId:  stream.ClientID(),
+					Data:      buf[:n],
+				})
+			}
+			if readErr != nil {
+				stopCtx, stopCancel := context.WithTimeout(context.Background(), 3*time.Second)
+				_, _ = client.StopSession(stopCtx, &bridgev1.StopSessionRequest{
+					SessionId: sessionID,
+					Force:     true,
+				})
+				stopCancel()
+				cancel()
+				return
+			}
+		}
+	}()
+
+	err = stream.RecvAll(ctx, func(ev *bridgev1.AttachSessionEvent) error {
+		switch ev.Type {
+		case bridgev1.AttachEventType_ATTACH_EVENT_TYPE_OUTPUT:
+			_, writeErr := os.Stdout.Write(ev.Payload)
+			return writeErr
+		case bridgev1.AttachEventType_ATTACH_EVENT_TYPE_ERROR:
+			return errors.New(ev.Error)
+		default:
+			return nil
+		}
+	})
+	if err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("session ended: %w", err)
+	}
+	return nil
 }
 
 func currentTTYSize() (uint32, uint32) {

--- a/cmd/bridgectl/run.go
+++ b/cmd/bridgectl/run.go
@@ -280,6 +280,7 @@ func runSessionNoTTY(dir, providerName, project string, timeout time.Duration) e
 	client.SetProject(project)
 
 	sessionID := uuid.NewString()
+	clientID := uuid.NewString()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -296,15 +297,26 @@ func runSessionNoTTY(dir, providerName, project string, timeout time.Duration) e
 
 	stream, err := client.AttachSession(ctx, &bridgev1.AttachSessionRequest{
 		SessionId: sessionID,
-		ClientId:  uuid.NewString(),
+		ClientId:  clientID,
 		AfterSeq:  0,
 	})
 	if err != nil {
 		return fmt.Errorf("attach session: %w", err)
 	}
 
-	// Forward stdin to session; close session when stdin reaches EOF.
+	// attached is closed when the server confirms the session is live and
+	// ready to route WriteInput calls (ms.attachedClient is set server-side
+	// before the ATTACHED event is sent).
+	attached := make(chan struct{})
+	var attachOnce sync.Once
+
+	// Forward stdin to session once attached; stop session on EOF.
 	go func() {
+		select {
+		case <-attached:
+		case <-ctx.Done():
+			return
+		}
 		buf := make([]byte, 4096)
 		for {
 			n, readErr := os.Stdin.Read(buf)
@@ -329,6 +341,10 @@ func runSessionNoTTY(dir, providerName, project string, timeout time.Duration) e
 	}()
 
 	err = stream.RecvAll(ctx, func(ev *bridgev1.AttachSessionEvent) error {
+		if ev.Type == bridgev1.AttachEventType_ATTACH_EVENT_TYPE_ATTACHED {
+			attachOnce.Do(func() { close(attached) })
+			return nil
+		}
 		switch ev.Type {
 		case bridgev1.AttachEventType_ATTACH_EVENT_TYPE_OUTPUT:
 			_, writeErr := os.Stdout.Write(ev.Payload)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,6 +14,11 @@ chown bridge:bridge "$CERT_DIR"
 mkdir -p /home/bridge/.gemini /home/bridge/.config
 chown -R bridge:bridge /home/bridge
 
+# Mirror what systemd RuntimeDirectory=ai-agent-bridge does: create and own
+# the runtime dir so the bridge process can write the system addr file.
+mkdir -p /run/ai-agent-bridge
+chown bridge:bridge /run/ai-agent-bridge
+
 if [ ! -f "$CERT_DIR/ca.crt" ]; then
   echo "==> Initializing CA..."
   ai-agent-bridge-ca init --name ai-agent-bridge-ca --out "$CERT_DIR"

--- a/e2e/system-daemon/Dockerfile.bridgectl
+++ b/e2e/system-daemon/Dockerfile.bridgectl
@@ -1,0 +1,15 @@
+FROM golang:1.25-bookworm
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN go build -o /usr/local/bin/bridgectl ./cmd/bridgectl
+
+COPY e2e/system-daemon/test.sh /test.sh
+RUN chmod +x /test.sh
+
+CMD ["/test.sh"]

--- a/e2e/system-daemon/bridge-system.yaml
+++ b/e2e/system-daemon/bridge-system.yaml
@@ -1,0 +1,45 @@
+server:
+  listen: "0.0.0.0:9445"
+
+# No TLS - dev mode for e2e testing
+tls:
+  ca_bundle: ""
+  cert: ""
+  key: ""
+
+auth:
+  jwt_public_keys: []
+  jwt_audience: "bridge"
+  jwt_max_ttl: "5m"
+
+sessions:
+  max_per_project: 5
+  max_global: 10
+  idle_timeout: "5m"
+  stop_grace_period: "5s"
+  event_buffer_size: 1048576
+
+input:
+  max_size_bytes: 65536
+
+rate_limits:
+  global_rps: 50
+  global_burst: 100
+  start_session_per_client_rps: 5
+  start_session_per_client_burst: 10
+  send_input_per_session_rps: 20
+  send_input_per_session_burst: 50
+
+providers:
+  echo:
+    binary: "cat"
+    startup_timeout: "5s"
+    startup_probe: "none"
+    validate_startup: false
+
+allowed_paths:
+  - "/tmp"
+
+logging:
+  level: "info"
+  format: "json"

--- a/e2e/system-daemon/docker-compose.yml
+++ b/e2e/system-daemon/docker-compose.yml
@@ -3,7 +3,8 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile
-    command: ["/app/ai-agent-bridge", "--config", "/etc/bridge-system.yaml"]
+    environment:
+      BRIDGE_CONFIG: /etc/bridge-system.yaml
     volumes:
       - ./bridge-system.yaml:/etc/bridge-system.yaml:ro
       - run-dir:/run/ai-agent-bridge

--- a/e2e/system-daemon/docker-compose.yml
+++ b/e2e/system-daemon/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  bridge:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    command: ["/app/ai-agent-bridge", "--config", "/etc/bridge-system.yaml"]
+    volumes:
+      - ./bridge-system.yaml:/etc/bridge-system.yaml:ro
+      - run-dir:/run/ai-agent-bridge
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "test -f /run/ai-agent-bridge/server.addr && bash -c '</dev/tcp/127.0.0.1/9445'"
+      interval: 2s
+      timeout: 2s
+      retries: 20
+      start_period: 10s
+
+  bridgectl-test:
+    build:
+      context: ../..
+      dockerfile: e2e/system-daemon/Dockerfile.test
+    network_mode: "service:bridge"
+    depends_on:
+      bridge:
+        condition: service_healthy
+    volumes:
+      - run-dir:/run/ai-agent-bridge:ro
+
+volumes:
+  run-dir:

--- a/e2e/system-daemon/docker-compose.yml
+++ b/e2e/system-daemon/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   bridgectl-test:
     build:
       context: ../..
-      dockerfile: e2e/system-daemon/Dockerfile.test
+      dockerfile: e2e/system-daemon/Dockerfile.bridgectl
     network_mode: "service:bridge"
     depends_on:
       bridge:

--- a/e2e/system-daemon/test.sh
+++ b/e2e/system-daemon/test.sh
@@ -60,7 +60,9 @@ run_test "server status: shows Providers field" test_server_status_providers
 # bridgectl run --no-tty with echo provider round-trips input
 # ---------------------------------------------------------------------------
 test_echo_round_trip() {
-  output=$(echo "PING_FROM_E2E_TEST" | timeout 15 bridgectl run --provider echo --no-tty /tmp 2>&1)
+  # Keep stdin open for 2s after sending the message so the echo has time
+  # to travel back before bridgectl sees EOF and stops the session.
+  output=$( (printf "PING_FROM_E2E_TEST\n"; sleep 2) | timeout 15 bridgectl run --provider echo --no-tty /tmp 2>&1)
   echo "$output"
   echo "$output" | grep -q "PING_FROM_E2E_TEST"
 }

--- a/e2e/system-daemon/test.sh
+++ b/e2e/system-daemon/test.sh
@@ -35,7 +35,7 @@ run_test "system addr file exists and is non-empty" test_addr_file_exists
 test_server_status_running() {
   output=$(bridgectl server status 2>&1)
   echo "$output"
-  echo "$output" | grep -q "running"
+  echo "$output" | grep -q "Server: running"
 }
 
 run_test "server status: shows running" test_server_status_running

--- a/e2e/system-daemon/test.sh
+++ b/e2e/system-daemon/test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# e2e test: bridgectl discovers and uses a system daemon via /run/ai-agent-bridge/server.addr
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+run_test() {
+  local name="$1"
+  shift
+  if "$@" 2>&1; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Verify the addr file was written by cmd/bridge
+# ---------------------------------------------------------------------------
+test_addr_file_exists() {
+  test -f /run/ai-agent-bridge/server.addr
+  addr=$(cat /run/ai-agent-bridge/server.addr)
+  test -n "$addr"
+  echo "  addr file contains: $addr"
+}
+
+run_test "system addr file exists and is non-empty" test_addr_file_exists
+
+# ---------------------------------------------------------------------------
+# bridgectl server status discovers daemon via addr file (no user socket)
+# ---------------------------------------------------------------------------
+test_server_status_running() {
+  output=$(bridgectl server status 2>&1)
+  echo "$output"
+  echo "$output" | grep -q "running"
+}
+
+run_test "server status: shows running" test_server_status_running
+
+test_server_status_address() {
+  output=$(bridgectl server status 2>&1)
+  echo "$output"
+  echo "$output" | grep -q "Address"
+}
+
+run_test "server status: shows Address field" test_server_status_address
+
+test_server_status_providers() {
+  output=$(bridgectl server status 2>&1)
+  echo "$output"
+  echo "$output" | grep -q "Providers"
+}
+
+run_test "server status: shows Providers field" test_server_status_providers
+
+# ---------------------------------------------------------------------------
+# bridgectl run --no-tty with echo provider round-trips input
+# ---------------------------------------------------------------------------
+test_echo_round_trip() {
+  output=$(echo "PING_FROM_E2E_TEST" | timeout 15 bridgectl run --provider echo --no-tty /tmp 2>&1)
+  echo "$output"
+  echo "$output" | grep -q "PING_FROM_E2E_TEST"
+}
+
+run_test "echo provider: round-trips stdin via system daemon" test_echo_round_trip
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+echo ""
+if [ "$FAIL" -gt 0 ]; then
+  echo "SMOKE TEST FAILED ($FAIL failed, $PASS passed)"
+  exit 1
+fi
+echo "SMOKE TEST PASSED ($PASS passed)"

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -552,19 +552,24 @@ func discoverTarget(stateDir string) string {
 		}
 	}
 
-	// Local mode: try unix socket first.
+	// Local mode: try unix socket first, but only if the server is healthy.
 	sockPath := filepath.Join(stateDir, "server.sock")
 	if _, err := os.Stat(sockPath); err == nil {
-		return "unix://" + sockPath
+		target := "unix://" + sockPath
+		if probeHealth(target, mode, stateDir) {
+			return target
+		}
 	}
-	// Fall back to TCP address file (Windows local mode).
+	// Fall back to TCP address file (Windows local mode), probing for health.
 	addrData, err := os.ReadFile(filepath.Join(stateDir, "server.addr"))
 	if err == nil {
 		if addr := strings.TrimSpace(string(addrData)); addr != "" {
 			if strings.HasPrefix(addr, "/") {
-				return "unix://" + addr
+				addr = "unix://" + addr
 			}
-			return addr
+			if probeHealth(addr, mode, stateDir) {
+				return addr
+			}
 		}
 	}
 

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -530,6 +530,11 @@ func DiscoverTarget(stateDir string) (target string, mode ServerMode) {
 	return target, mode
 }
 
+// SystemAddrFile is the well-known path written by the system daemon
+// (cmd/bridge running under systemd). bridgectl checks this before
+// self-spawning so it reuses the system daemon when available.
+const SystemAddrFile = "/run/ai-agent-bridge/server.addr"
+
 func discoverTarget(stateDir string) string {
 	// Check the mode file first to avoid a stale unix socket from a
 	// previous crashed local-mode server masking a running secure server.
@@ -554,18 +559,27 @@ func discoverTarget(stateDir string) string {
 	}
 	// Fall back to TCP address file (Windows local mode).
 	addrData, err := os.ReadFile(filepath.Join(stateDir, "server.addr"))
-	if err != nil {
-		return ""
+	if err == nil {
+		if addr := strings.TrimSpace(string(addrData)); addr != "" {
+			if strings.HasPrefix(addr, "/") {
+				return "unix://" + addr
+			}
+			return addr
+		}
 	}
-	addr := strings.TrimSpace(string(addrData))
-	if addr == "" {
-		return ""
+
+	// Check for a system daemon (cmd/bridge under systemd) as a last resort.
+	// Only on Linux: the file is written by the system daemon to a path
+	// created by systemd's RuntimeDirectory directive.
+	if runtime.GOOS == "linux" {
+		if sysData, err := os.ReadFile(SystemAddrFile); err == nil {
+			if addr := strings.TrimSpace(string(sysData)); addr != "" {
+				return addr
+			}
+		}
 	}
-	// If it looks like a unix path, prefix it.
-	if strings.HasPrefix(addr, "/") {
-		return "unix://" + addr
-	}
-	return addr
+
+	return ""
 }
 
 func probeHealth(target string, mode ServerMode, stateDir string) bool {

--- a/packaging/ai-agent-bridge.service
+++ b/packaging/ai-agent-bridge.service
@@ -9,6 +9,7 @@ Type=simple
 User=ai-agent-bridge
 Group=ai-agent-bridge
 StateDirectory=ai-agent-bridge
+RuntimeDirectory=ai-agent-bridge
 WorkingDirectory=/var/lib/ai-agent-bridge
 ExecStart=/usr/bin/ai-agent-bridge --config /etc/ai-agent-bridge/bridge.yaml
 Restart=on-failure


### PR DESCRIPTION
## Summary

- **System daemon detection**: `bridgectl` now checks `/run/ai-agent-bridge/server.addr` (Linux only) before self-spawning a local server, so it transparently reuses a `cmd/bridge` daemon managed by systemd.
- **Server addr file**: `cmd/bridge` writes its listen address to `/run/ai-agent-bridge/server.addr` on startup (rewriting `0.0.0.0` → `127.0.0.1`) and removes it on clean shutdown. The systemd unit adds `RuntimeDirectory=ai-agent-bridge` so systemd owns the directory lifecycle.
- **`--no-tty` run mode**: `bridgectl run --no-tty` reads stdin and writes stdout without a terminal — usable from pipes and scripts. Fixed a race where `WriteInput` was called before `AttachSession` established `ms.attachedClient` on the server; the goroutine now waits for the ATTACHED event before forwarding stdin.
- **System-daemon e2e test**: new `e2e/system-daemon/` suite (Docker Compose + bash script) verifies: addr file written, `server status` shows running/Address/Providers, and echo round-trip via the system daemon.

## Changed files

| File | Change |
|---|---|
| `internal/localserver/localserver.go` | `discoverTarget` falls back to `/run/ai-agent-bridge/server.addr` on Linux |
| `cmd/bridge/main.go` | `writeSystemAddrFile` / `removeSystemAddrFile` helpers |
| `packaging/ai-agent-bridge.service` | `RuntimeDirectory=ai-agent-bridge` |
| `cmd/bridgectl/run.go` | `--no-tty` flag + `runSessionNoTTY`; ATTACHED-event gate for stdin goroutine |
| `docker-entrypoint.sh` | `mkdir -p /run/ai-agent-bridge && chown bridge:bridge` before privilege drop |
| `e2e/system-daemon/` | new: `docker-compose.yml`, `bridge-system.yaml`, `Dockerfile.bridgectl`, `test.sh` |
| `Makefile` | `test-system-daemon-e2e` target |

## Test plan

- [x] `make test` (unit + race detector) passes
- [x] `make test-system-daemon-e2e` — all 5 smoke tests pass (addr file, server status ×3, echo round-trip)
- [ ] Smoke-test the deb package path with a live systemd unit (manual, requires an Ubuntu host)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)