### PR TITLE
fix: update agent binary paths and swap gemini for codex in e2e

### DIFF
--- a/config/bridge-dev.yaml
+++ b/config/bridge-dev.yaml
@@ -36,16 +36,16 @@ rate_limits:
 
 providers:
   claude:
-    binary: "node"
-    args: ["./node_modules/@anthropic-ai/claude-code/cli.js", "--verbose"]
+    binary: "./node_modules/@anthropic-ai/claude-code/bin/claude.exe"
+    args: ["--verbose"]
     startup_timeout: "60s"
     startup_probe: "prompt"
     required_env: ["ANTHROPIC_API_KEY"]
     fallbacks: ["codex"]
     prompt_pattern: "(?m)(❯|>\\s*$)"
   opencode:
-    binary: "node"
-    args: ["./node_modules/opencode-ai/bin/opencode"]
+    binary: "./node_modules/opencode-ai/bin/opencode.exe"
+    args: []
     startup_timeout: "45s"
     startup_probe: "output"
     required_env: ["OPENAI_API_KEY"]
@@ -60,7 +60,7 @@ providers:
     prompt_pattern: "(?m)(>\\s*$|›)"
   gemini:
     binary: "node"
-    args: ["./node_modules/@google/gemini-cli/dist/index.js"]
+    args: ["./node_modules/@google/gemini-cli/bundle/gemini.js"]
     startup_timeout: "60s"
     startup_probe: "output"
     required_env: ["GEMINI_API_KEY"]

--- a/config/bridge-docker.yaml
+++ b/config/bridge-docker.yaml
@@ -36,8 +36,8 @@ rate_limits:
 
 providers:
   claude:
-    binary: "node"
-    args: ["./node_modules/@anthropic-ai/claude-code/cli.js", "--verbose"]
+    binary: "./node_modules/@anthropic-ai/claude-code/bin/claude.exe"
+    args: ["--verbose"]
     startup_timeout: "60s"
     validate_startup: false
     startup_probe: "prompt"
@@ -45,8 +45,8 @@ providers:
     fallbacks: ["codex"]
     prompt_pattern: "(?m)(❯|>\\s*$)"
   opencode:
-    binary: "node"
-    args: ["./node_modules/opencode-ai/bin/opencode"]
+    binary: "./node_modules/opencode-ai/bin/opencode.exe"
+    args: []
     startup_timeout: "45s"
     validate_startup: false
     startup_probe: "output"
@@ -63,7 +63,7 @@ providers:
     prompt_pattern: "(?m)(>\\s*$|›)"
   gemini:
     binary: "node"
-    args: ["./node_modules/@google/gemini-cli/dist/index.js"]
+    args: ["./node_modules/@google/gemini-cli/bundle/gemini.js"]
     startup_timeout: "60s"
     validate_startup: false
     startup_probe: "output"

--- a/config/bridge.yaml
+++ b/config/bridge.yaml
@@ -36,16 +36,16 @@ rate_limits:
 
 providers:
   claude:
-    binary: "node"
-    args: ["./node_modules/@anthropic-ai/claude-code/cli.js", "--verbose"]
+    binary: "./node_modules/@anthropic-ai/claude-code/bin/claude.exe"
+    args: ["--verbose"]
     startup_timeout: "60s"
     startup_probe: "prompt"
     required_env: ["ANTHROPIC_API_KEY"]
     fallbacks: ["codex"]
     prompt_pattern: "(?m)(❯|>\\s*$)"
   opencode:
-    binary: "node"
-    args: ["./node_modules/opencode-ai/bin/opencode"]
+    binary: "./node_modules/opencode-ai/bin/opencode.exe"
+    args: []
     startup_timeout: "45s"
     startup_probe: "output"
     required_env: ["OPENAI_API_KEY"]
@@ -60,7 +60,7 @@ providers:
     prompt_pattern: "(?m)(>\\s*$|›)"
   gemini:
     binary: "node"
-    args: ["./node_modules/@google/gemini-cli/dist/index.js"]
+    args: ["./node_modules/@google/gemini-cli/bundle/gemini.js"]
     startup_timeout: "60s"
     startup_probe: "output"
     required_env: ["GEMINI_API_KEY"]

--- a/e2e/cmd/e2e-test/main.go
+++ b/e2e/cmd/e2e-test/main.go
@@ -45,11 +45,11 @@ var scenarios = []providerScenario{
 		questionCheck: regexp.MustCompile(`\?`),
 	},
 	{
-		name:          "gemini",
-		requiredEnv:   "GEMINI_API_KEY",
-		promptRe:      regexp.MustCompile(`(?m)>\s*$`),
-		startTimeout:  120 * time.Second,
-		turnTimeout:   240 * time.Second,
+		name:          "codex",
+		requiredEnv:   "OPENAI_API_KEY",
+		promptRe:      regexp.MustCompile(`(?m)(>\s*$|›)`),
+		startTimeout:  90 * time.Second,
+		turnTimeout:   180 * time.Second,
 		questionCheck: regexp.MustCompile(`\?`),
 	},
 }
@@ -80,7 +80,7 @@ func main() {
 	jwtIssuer := flag.String("jwt-issuer", "e2e", "JWT issuer")
 	repo := flag.String("repo", "/tmp/ai-agent-bridge", "repo path")
 	timeout := flag.Duration("timeout", 15*time.Minute, "overall timeout")
-	only := flag.String("only", "all", "test subset: all, claude, opencode, gemini")
+	only := flag.String("only", "all", "test subset: all, claude, opencode, codex")
 	flag.Parse()
 
 	client, err := bridgeclient.New(

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@anthropic-ai/claude-code": "2.1.162",
         "@google/gemini-cli": "0.45.0",
         "@openai/codex": "0.136.0",
-        "opencode-ai": "1.15.13"
+        "opencode-ai": "1.16.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.24.0",
@@ -1679,9 +1679,9 @@
       "optional": true
     },
     "node_modules/opencode-ai": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.15.13.tgz",
-      "integrity": "sha512-9LvgcILITiYPsKrBYSHQYR4ur/WBQYMHN5jEnboa/NVboPyl+WBGgvDHQ2SJasPpBmCAd2YTTorz2uMbcF7Hhw==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.16.2.tgz",
+      "integrity": "sha512-70w3KxB0tKEA0Fy66McSXY3v5qv3AOX76PXdc0WxQBzEzizCpJtNBp3frMd5VJ+ASwrSe4DxmY3Ve/OByzriMw==",
       "cpu": [
         "arm64",
         "x64"
@@ -1697,24 +1697,24 @@
         "opencode": "bin/opencode.exe"
       },
       "optionalDependencies": {
-        "opencode-darwin-arm64": "1.15.13",
-        "opencode-darwin-x64": "1.15.13",
-        "opencode-darwin-x64-baseline": "1.15.13",
-        "opencode-linux-arm64": "1.15.13",
-        "opencode-linux-arm64-musl": "1.15.13",
-        "opencode-linux-x64": "1.15.13",
-        "opencode-linux-x64-baseline": "1.15.13",
-        "opencode-linux-x64-baseline-musl": "1.15.13",
-        "opencode-linux-x64-musl": "1.15.13",
-        "opencode-windows-arm64": "1.15.13",
-        "opencode-windows-x64": "1.15.13",
-        "opencode-windows-x64-baseline": "1.15.13"
+        "opencode-darwin-arm64": "1.16.2",
+        "opencode-darwin-x64": "1.16.2",
+        "opencode-darwin-x64-baseline": "1.16.2",
+        "opencode-linux-arm64": "1.16.2",
+        "opencode-linux-arm64-musl": "1.16.2",
+        "opencode-linux-x64": "1.16.2",
+        "opencode-linux-x64-baseline": "1.16.2",
+        "opencode-linux-x64-baseline-musl": "1.16.2",
+        "opencode-linux-x64-musl": "1.16.2",
+        "opencode-windows-arm64": "1.16.2",
+        "opencode-windows-x64": "1.16.2",
+        "opencode-windows-x64-baseline": "1.16.2"
       }
     },
     "node_modules/opencode-darwin-arm64": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.15.13.tgz",
-      "integrity": "sha512-/6LSBPUdhNdev0JwOOZePOS8QSrH5XPj2bCkZUeoSyab3i0VMFlbW1hyi93pvsyEFd68OwThoAcy9I4f6TGslQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.16.2.tgz",
+      "integrity": "sha512-oJu1SSaXK1GZr14JWvLt9C+CH8+enonfuNerJG7jQcxkMxZCgS36Y4YJNMKYda7N+0u02j02b1y21/StQpo3xQ==",
       "cpu": [
         "arm64"
       ],
@@ -1724,9 +1724,9 @@
       ]
     },
     "node_modules/opencode-darwin-x64": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.15.13.tgz",
-      "integrity": "sha512-Qzthj88M8ieMhzuhOi1al6MU0SVyBWWKLtKkmjDabotn+XSlg1dfA2T1Pap5RqV9Z8rH+6LEt4hP4SNFrJGaew==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.16.2.tgz",
+      "integrity": "sha512-uqY+FPzJ/bT18eNuDYrR5TTA7VMMLbfX4lmFrJLCqUKnwBI/ePEdf0cbxQ4cF16figixb8NjR7VMncR9oFZ7FA==",
       "cpu": [
         "x64"
       ],
@@ -1736,9 +1736,9 @@
       ]
     },
     "node_modules/opencode-darwin-x64-baseline": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.15.13.tgz",
-      "integrity": "sha512-8m+1YWHYWyL9/uCZdaSNqPfWIQGxXN0KFUIFFFa/Qa0U8SlJdQd3mjtfxXJ1dJ0oqTMscXiWhHxoNHorANxC1w==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.16.2.tgz",
+      "integrity": "sha512-51vuOj6DpbkaR9UIYs0r/9QQrSuJuAabKU1JXIBINOXDbam4hquF9ppeW7Nbh4KTdrsxK7dt277tVn6zDoar6g==",
       "cpu": [
         "x64"
       ],
@@ -1748,9 +1748,9 @@
       ]
     },
     "node_modules/opencode-linux-arm64": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.15.13.tgz",
-      "integrity": "sha512-+2FNiJZgINnJwR/+JKM2i4/BUJAqeVxcLK8z1smkBVjZ45u5m5S/cWijNunPvgETxP6ps1J410KQg1ci2OaixQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.16.2.tgz",
+      "integrity": "sha512-BwW0K+fAkf4iI+WbBwskct2LcDEZVxS5K+dNER6HcAqOkljVmTlqW/rnXw3/9ZFgKDMieZAi2J7wYhkMXV9z4g==",
       "cpu": [
         "arm64"
       ],
@@ -1760,11 +1760,14 @@
       ]
     },
     "node_modules/opencode-linux-arm64-musl": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.15.13.tgz",
-      "integrity": "sha512-gj6Iv6Aui980vh3pXPijhvbAqfnEqjfnVUVGcjoBN5cUgQLt+gndMChlyMF47gnHuwsVAqQ5tKitYLhWl+iNuQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.16.2.tgz",
+      "integrity": "sha512-0DDPAgfegptm3pzJGcoh/8Iv/Lq7Ew/GR0FHofpKEi71H5sNElzu2Qx2XOPfBxqLfEP3ReaIYKvFYroJXtHhdQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "optional": true,
       "os": [
@@ -1772,9 +1775,9 @@
       ]
     },
     "node_modules/opencode-linux-x64": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.15.13.tgz",
-      "integrity": "sha512-gZrioSPE/aWPAZlaipWEN7GEhAzNEQAogikvbcvVP78nabzkzzl4UKBXemf1YzLG9nRWiWvvWX7uC2hcZGQ1iQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.16.2.tgz",
+      "integrity": "sha512-O+EKhZ0xGrmxP0v1UuW62FbMborzrYnQ3rKy/ulYWfz9TGhUxu7gSWceBcASXx00T6HM94ob8atE8MnfEzZ0Qg==",
       "cpu": [
         "x64"
       ],
@@ -1784,9 +1787,9 @@
       ]
     },
     "node_modules/opencode-linux-x64-baseline": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.15.13.tgz",
-      "integrity": "sha512-2iqNlqtYLUp4ccmhEOAR8OkJnCyUp1AoJGRVkkYFhKIaPwx+kWdmkrr3V9j6uLO5KoPQmJf4M3m6jib+nMbH+w==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.16.2.tgz",
+      "integrity": "sha512-6ethaqt1i/eSE7HaKxabo3K0rfE8JYYFQmBDvCXF0Du32irmpXX7CrA+3qQ1/6j/gg0epFhDq/b0HSFMAoCDWw==",
       "cpu": [
         "x64"
       ],
@@ -1796,11 +1799,14 @@
       ]
     },
     "node_modules/opencode-linux-x64-baseline-musl": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.15.13.tgz",
-      "integrity": "sha512-qPrKsLg6mO3bkKAOiT4t3AstmOsjm4nNU/7M0dO0xWh61aNQyJOvRPks/bKD6SHqCRkdpRh1Y7ULSoXFsjArUQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.16.2.tgz",
+      "integrity": "sha512-LqQ8rzUc35i2Ey6JsTu/vwTqlHWMk6DcTvCdj9RPyHHz9bzTgfwpvKqXMLYQr74rhaSWkSaSaSi+iELakWlg7Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "optional": true,
       "os": [
@@ -1808,11 +1814,14 @@
       ]
     },
     "node_modules/opencode-linux-x64-musl": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.15.13.tgz",
-      "integrity": "sha512-cU2eBXxn3Ols6lH5VaLaay03SpM7T63L0S/JGXOm1OsYdAjOpw2euziI14sXbWM1z7mkhsUTm/CKfSHyRaWEDA==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.16.2.tgz",
+      "integrity": "sha512-oPHAOptdQ0d346AoiBZ5/TIJS3QqMV7uUFSIFcH7AHisx7EBNNfVmZ+Qcq7oJmNNXaHlV2Uf/vkL5H4aX3E9Ww==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "optional": true,
       "os": [
@@ -1820,9 +1829,9 @@
       ]
     },
     "node_modules/opencode-windows-arm64": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.15.13.tgz",
-      "integrity": "sha512-DUBCUL/l5oYHuiUEghYRVsrkMkEKtv9uJViwH+YYX/YA/tR+1WuLO+dss0sGyQOPh5NCzYDuPlkjUpFNKuNFkA==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.16.2.tgz",
+      "integrity": "sha512-yS/Tzmci60z5JVqyCTdDxvAwgM5gAhL4uAkNpZ8bqNy8gXK7QIrLIH4waiHyOFYwg0cWPS/nwUP4R+0o170wew==",
       "cpu": [
         "arm64"
       ],
@@ -1832,9 +1841,9 @@
       ]
     },
     "node_modules/opencode-windows-x64": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.15.13.tgz",
-      "integrity": "sha512-xGpnwI9QKG0p2BjJ/RGa8ZtTTa5crHfMhc/7RyC1K9Z8hGNA5w0Nl2KOMihzMDsj0vmc7TfTv1He5CIUdaC/oQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.16.2.tgz",
+      "integrity": "sha512-QSfFS6dA62s6PWLHSQflZ7aFtSaRL/F4XIHDDdZi/m8Uu6/6dlqTVuDY2kInztEgz+c1r8WJwyhOcSBDjgoOUg==",
       "cpu": [
         "x64"
       ],
@@ -1844,9 +1853,9 @@
       ]
     },
     "node_modules/opencode-windows-x64-baseline": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.15.13.tgz",
-      "integrity": "sha512-tAuDGdrHU+ycmjk0kATf5xBKq/Y/4RmWToYbwXA0pE6/D9yObmvzIb1Qt2IShNC2zQujNCnTGRze2M9kXjBpzA==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.16.2.tgz",
+      "integrity": "sha512-GsqlwlU05rWqGU6Qxx9tDqR/EJtY08/PryjFXdLu5tLuNPNELhMLoVsgfXeZgo3lp0gA+RPqmW15Py48tbFEQA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "@anthropic-ai/claude-code": "2.1.162",
     "@google/gemini-cli": "0.45.0",
     "@openai/codex": "0.136.0",
-    "opencode-ai": "1.15.13"
+    "opencode-ai": "1.16.2"
   }
 }


### PR DESCRIPTION
## Summary

- **opencode-ai 1.15.13 → 1.16.2**: The 1.15.13 Bun binary crashes with SIGILL on Linux 5.15 kernels; 1.16.2 ships a fixed binary.
- **claude provider**: `@anthropic-ai/claude-code` no longer ships `cli.js`; updated all three configs to invoke the native `bin/claude.exe` directly.
- **opencode provider**: Updated config to use native `bin/opencode.exe` (previously pointed to non-existent `bin/opencode`).
- **gemini provider**: Entry point moved from `dist/index.js` to `bundle/gemini.js`.
- **e2e tests**: Replaced gemini scenario with codex (`OPENAI_API_KEY`, prompt pattern `(?m)(>\s*$|›)`).

## Test plan

- [x] `make dev-run` starts successfully with all four providers passing startup validation
- [x] `go build ./e2e/cmd/e2e-test/` compiles cleanly
- [ ] `make test-e2e` passes with claude, opencode, and codex scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)