### PR TITLE
fix: use minimal env for provider version probes to prevent auth-induced timeouts

### DIFF
--- a/internal/provider/stdio.go
+++ b/internal/provider/stdio.go
@@ -240,7 +240,11 @@ func (p *StdioProvider) Version(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("binary %q not found: %w", p.cfg.Binary, err)
 	}
 	cmd := exec.CommandContext(ctx, path, "--version")
-	cmd.Env = filterEnv(os.Environ())
+	// Use a minimal environment for version probes. Passing auth tokens (e.g.
+	// CLAUDE_CODE_OAUTH_TOKEN) causes some provider binaries to make network
+	// round-trips to validate credentials before printing their version, which
+	// can exceed the startup timeout.
+	cmd.Env = versionProbeEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("version check: %w", err)
@@ -345,6 +349,26 @@ func isStandaloneRelativePathArg(arg string) bool {
 		return true
 	}
 	return strings.HasPrefix(arg, "./") || strings.HasPrefix(arg, "../")
+}
+
+// versionProbeEnv returns a minimal environment for --version checks.
+// It deliberately excludes auth tokens and API keys so that provider binaries
+// that make network calls when credentials are present (e.g. token validation)
+// do not time out during the startup version probe.
+func versionProbeEnv() []string {
+	env := []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + os.Getenv("HOME"),
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	}
+	// Preserve NO_COLOR and similar display hints if set.
+	for _, key := range []string{"NO_COLOR", "TMPDIR", "TMP", "TEMP"} {
+		if v := os.Getenv(key); v != "" {
+			env = append(env, key+"="+v)
+		}
+	}
+	return env
 }
 
 // filterEnv returns a filtered environment excluding sensitive variables and

--- a/internal/provider/stdio.go
+++ b/internal/provider/stdio.go
@@ -356,13 +356,26 @@ func isStandaloneRelativePathArg(arg string) bool {
 // that make network calls when credentials are present (e.g. token validation)
 // do not time out during the startup version probe.
 func versionProbeEnv() []string {
+	// Use the parent PATH when set; fall back to a safe minimal default so
+	// that binaries can still locate their dynamic linker and helpers.
+	path := os.Getenv("PATH")
+	if path == "" {
+		path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	}
 	env := []string{
-		"PATH=" + os.Getenv("PATH"),
-		"HOME=" + os.Getenv("HOME"),
+		"PATH=" + path,
 		"TERM=xterm-256color",
 		"COLORTERM=truecolor",
 	}
-	// Preserve NO_COLOR and similar display hints if set.
+	// Only set HOME when non-empty; leaving it unset lets the OS fall back to
+	// the passwd database, which is preferable to forcing an empty value that
+	// can confuse CLIs expecting a writable home directory.
+	if home := os.Getenv("HOME"); home != "" {
+		env = append(env, "HOME="+home)
+	} else if home, err := os.UserHomeDir(); err == nil {
+		env = append(env, "HOME="+home)
+	}
+	// Preserve NO_COLOR and temp-dir hints if set.
 	for _, key := range []string{"NO_COLOR", "TMPDIR", "TMP", "TEMP"} {
 		if v := os.Getenv(key); v != "" {
 			env = append(env, key+"="+v)

--- a/internal/provider/stdio_additional_test.go
+++ b/internal/provider/stdio_additional_test.go
@@ -119,11 +119,11 @@ func TestVersionProbeEnvExcludesAuthTokens(t *testing.T) {
 
 	env := versionProbeEnv()
 
-	for _, item := range env {
-		for _, secret := range []string{"tok-secret", "sk-secret", "sk-open-secret"} {
-			if strings.Contains(item, secret) {
-				t.Errorf("auth token leaked into version probe env: %q", item)
-			}
+	// Assert by key name — more robust than value substring matching, and
+	// catches the case where the key is present with a different value.
+	for _, key := range []string{"CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"} {
+		if hasEnvKey(env, key) {
+			t.Errorf("auth token key %q must not appear in version probe env", key)
 		}
 	}
 	if !hasEnvKey(env, "PATH") {

--- a/internal/provider/stdio_additional_test.go
+++ b/internal/provider/stdio_additional_test.go
@@ -108,6 +108,59 @@ func TestResolveBinaryPathAndFilterEnv(t *testing.T) {
 	}
 }
 
+func TestVersionProbeEnvExcludesAuthTokens(t *testing.T) {
+	// Auth tokens present in the process environment must not appear in the
+	// version probe environment, so that provider binaries which validate
+	// credentials on startup (triggering network round-trips) do not time out
+	// during the version check.
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "tok-secret")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-secret")
+	t.Setenv("OPENAI_API_KEY", "sk-open-secret")
+
+	env := versionProbeEnv()
+
+	for _, item := range env {
+		for _, secret := range []string{"tok-secret", "sk-secret", "sk-open-secret"} {
+			if strings.Contains(item, secret) {
+				t.Errorf("auth token leaked into version probe env: %q", item)
+			}
+		}
+	}
+	if !hasEnvKey(env, "PATH") {
+		t.Error("PATH missing from version probe env")
+	}
+	if !hasEnvKey(env, "TERM") {
+		t.Error("TERM missing from version probe env")
+	}
+}
+
+func TestVersionUsesMinimalEnv(t *testing.T) {
+	// Build a script that prints its environment to stdout so we can verify
+	// that auth tokens are not passed to --version subprocesses.
+	tmp := t.TempDir()
+	script := filepath.Join(tmp, "fakebin")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nenv\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "tok-must-not-leak")
+
+	p := NewStdioProvider(StdioConfig{
+		ProviderID: "fake",
+		Binary:     script,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := p.Version(ctx)
+	if err != nil {
+		t.Fatalf("Version: %v", err)
+	}
+	if strings.Contains(out, "tok-must-not-leak") {
+		t.Errorf("auth token leaked into version probe output: %q", out)
+	}
+}
+
 func TestValidateStartupOutputAndPrompt(t *testing.T) {
 	script := filepath.Join(t.TempDir(), "probe.sh")
 	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf 'READY>\\n'\nsleep 1\n"), 0o755); err != nil {

--- a/packaging/examples/bridge-example.yaml
+++ b/packaging/examples/bridge-example.yaml
@@ -76,8 +76,8 @@ providers:
 # Uncomment to enable Claude Code (requires CLAUDE_CODE_OAUTH_TOKEN in agents.env):
 #
 #   claude:
-#     binary: "/usr/bin/node"
-#     args: ["/opt/ai-agent-bridge/node_modules/@anthropic-ai/claude-code/cli.js"]
+#     binary: "/opt/ai-agent-bridge/node_modules/@anthropic-ai/claude-code/bin/claude.exe"
+#     args: []
 #     startup_timeout: "60s"
 #     startup_probe: "output"
 #     required_env: ["CLAUDE_CODE_OAUTH_TOKEN"]


### PR DESCRIPTION
## Summary

- `claude.exe` (native binary in `@anthropic-ai/claude-code` v2.x) makes a network round-trip to validate `CLAUDE_CODE_OAUTH_TOKEN` before printing its version. The startup version probe was passing the full service environment including that token, causing the 5-second timeout to fire and logging `"failed to get provider version / signal: killed"` on every service start.
- Introduces `versionProbeEnv()` which supplies only `PATH`, `HOME`, and terminal hint vars to `--version` subprocesses — no auth tokens or API keys.
- Also updates `packaging/examples/bridge-example.yaml` to reference `bin/claude.exe` (the native binary path) instead of the defunct `cli.js` entry point removed in `@anthropic-ai/claude-code` v2.x.

## Test plan

- [ ] `TestVersionProbeEnvExcludesAuthTokens` — asserts auth tokens set in the process env are absent from `versionProbeEnv()` output
- [ ] `TestVersionUsesMinimalEnv` — asserts that a fake provider binary's env dump (as its "version" output) does not contain an auth token set in the caller's environment
- [ ] Full test suite: `go test ./...` passes with `-race`
- [ ] On a deployed server: restart `ai-agent-bridge`, confirm `"provider version","provider":"claude"` now logs cleanly without the `signal: killed` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)