### PR TITLE
feat: add --version flag to ai-agent-bridge and ai-agent-bridge-ca

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
 
   - id: bridge-ca
     binary: ai-agent-bridge-ca
@@ -24,6 +26,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
 
   - id: bridgectl
     binary: bridgectl

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ BIN_DIR := bin
 BRIDGE := $(BIN_DIR)/ai-agent-bridge
 BRIDGE_CA := $(BIN_DIR)/ai-agent-bridge-ca
 BRIDGE_CLI := $(BIN_DIR)/bridgectl
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 CONFIG ?= config/bridge.yaml
 DEV_CONFIG ?= config/bridge-dev.yaml
 CHAT_TARGET ?= bridge.local:9445
@@ -13,9 +15,9 @@ CHAT_REPO ?= /repos/penduin
 CHAT_JWT_KEY ?= ../../certs/jwt-signing.key
 build: proto
 	@mkdir -p $(BIN_DIR)
-	go build -o $(BRIDGE) ./cmd/bridge
-	go build -o $(BRIDGE_CA) ./cmd/bridge-ca
-	go build -o $(BRIDGE_CLI) ./cmd/bridgectl
+	go build $(LDFLAGS) -o $(BRIDGE) ./cmd/bridge
+	go build $(LDFLAGS) -o $(BRIDGE_CA) ./cmd/bridge-ca
+	go build $(LDFLAGS) -o $(BRIDGE_CLI) ./cmd/bridgectl
 
 build-cli:
 	@mkdir -p $(BIN_DIR)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build: proto
 
 build-cli:
 	@mkdir -p $(BIN_DIR)
-	go build -o $(BRIDGE_CLI) ./cmd/bridgectl
+	go build $(LDFLAGS) -o $(BRIDGE_CLI) ./cmd/bridgectl
 
 proto:
 	protoc \

--- a/cmd/bridge-ca/main.go
+++ b/cmd/bridge-ca/main.go
@@ -9,6 +9,8 @@ import (
 	"github.com/markcallen/ai-agent-bridge/internal/pki"
 )
 
+var version = "dev"
+
 func main() {
 	if len(os.Args) < 2 {
 		usage()
@@ -33,6 +35,9 @@ func main() {
 		cmdVerify()
 	case "help", "--help", "-h":
 		usage()
+	case "--version", "-version":
+		fmt.Printf("ai-agent-bridge-ca %s\n", version)
+		os.Exit(0)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)
 		usage()
@@ -50,6 +55,9 @@ Commands:
   bundle       Build a trust bundle from multiple CA certs
   jwt-keygen   Generate Ed25519 keypair for JWT signing
   verify       Verify a certificate against a trust bundle
+
+Flags:
+  --version    Print version and exit
 
 Run 'ai-agent-bridge-ca <command> --help' for details.
 `)

--- a/cmd/bridge-ca/version_test.go
+++ b/cmd/bridge-ca/version_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVersionFlag(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "ai-agent-bridge-ca")
+
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = "."
+	build.Stdout = os.Stdout
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+
+	var out bytes.Buffer
+	cmd := exec.Command(bin, "--version")
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("--version exited non-zero: %v\n%s", err, out.String())
+	}
+	if !strings.HasPrefix(out.String(), "ai-agent-bridge-ca ") {
+		t.Errorf("unexpected --version output: %q", out.String())
+	}
+}

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -25,9 +25,17 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+var version = "dev"
+
 func main() {
 	configPath := flag.String("config", "config/bridge.yaml", "Path to configuration file")
+	showVersion := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("ai-agent-bridge %s\n", version)
+		os.Exit(0)
+	}
 
 	bootstrapLogger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 

--- a/cmd/bridge/version_test.go
+++ b/cmd/bridge/version_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVersionFlag(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "ai-agent-bridge")
+
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = "."
+	build.Stdout = os.Stdout
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+
+	var out bytes.Buffer
+	cmd := exec.Command(bin, "--version")
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("--version exited non-zero: %v\n%s", err, out.String())
+	}
+	if !strings.HasPrefix(out.String(), "ai-agent-bridge ") {
+		t.Errorf("unexpected --version output: %q", out.String())
+	}
+}

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -32,9 +32,10 @@ fi
 mkdir -p "$OUTPUT_DIR"
 
 mkdir -p "$ROOT_DIR/bin"
-GOARCH="$ARCH" go build -o "$ROOT_DIR/bin/ai-agent-bridge" ./cmd/bridge
-GOARCH="$ARCH" go build -o "$ROOT_DIR/bin/ai-agent-bridge-ca" ./cmd/bridge-ca
-GOARCH="$ARCH" go build -o "$ROOT_DIR/bin/bridgectl" ./cmd/bridgectl
+LDFLAGS="-X main.version=${VERSION}"
+GOARCH="$ARCH" go build -ldflags "$LDFLAGS" -o "$ROOT_DIR/bin/ai-agent-bridge" ./cmd/bridge
+GOARCH="$ARCH" go build -ldflags "$LDFLAGS" -o "$ROOT_DIR/bin/ai-agent-bridge-ca" ./cmd/bridge-ca
+GOARCH="$ARCH" go build -ldflags "$LDFLAGS" -o "$ROOT_DIR/bin/bridgectl" ./cmd/bridgectl
 
 mkdir -p \
   "$PKG_ROOT/DEBIAN" \


### PR DESCRIPTION
## Summary

- Adds `--version` flag to `ai-agent-bridge` (exits 0, prints `ai-agent-bridge <version>`)
- Adds `--version` flag to `ai-agent-bridge-ca` (exits 0, prints `ai-agent-bridge-ca <version>`)
- Version is injected at build time via `-ldflags "-X main.version=<version>"`
- `Makefile`: adds `VERSION` (defaults to `git describe --tags`) and `LDFLAGS` variables, passes them to all three `go build` calls
- `scripts/build-deb.sh`: passes `-ldflags "-X main.version=${VERSION}"` for all binaries
- `.goreleaser.yaml`: adds `ldflags: [-s -w -X main.version={{.Version}}]` to `bridge` and `bridge-ca` builds (was already present for `bridgectl`)

## Test plan

- [ ] `ai-agent-bridge --version` prints `ai-agent-bridge v0.6.1` and exits 0
- [ ] `ai-agent-bridge-ca --version` prints `ai-agent-bridge-ca v0.6.1` and exits 0
- [ ] `make build` compiles with version from latest git tag
- [ ] All existing tests pass (`make test`)
- [ ] CI is green

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)