### PR TITLE
fix: retain previously published .deb packages in apt pool

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -354,6 +354,15 @@ jobs:
           gpg --batch --import /tmp/apt-signing.key
           echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
 
+      - name: Restore existing apt pool from gh-pages
+        run: |
+          if git ls-remote --exit-code origin refs/heads/gh-pages >/dev/null 2>&1; then
+            git fetch origin gh-pages
+            mkdir -p dist/gh-pages/apt/pool/main
+            git archive origin/gh-pages -- apt/pool/main/ \
+              | tar -x -C dist/gh-pages/ 2>/dev/null || true
+          fi
+
       - name: Build apt repository
         env:
           GPG_PASSPHRASE: ${{ secrets.APT_REPO_GPG_PASSPHRASE }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -358,9 +358,10 @@ jobs:
         run: |
           if git ls-remote --exit-code origin refs/heads/gh-pages >/dev/null 2>&1; then
             git fetch origin gh-pages
-            mkdir -p dist/gh-pages/apt/pool/main
-            git archive origin/gh-pages -- apt/pool/main/ \
-              | tar -x -C dist/gh-pages/ 2>/dev/null || true
+            if git ls-tree origin/gh-pages -- apt/pool/main/ | grep -q .; then
+              mkdir -p dist/gh-pages/apt/pool/main
+              git archive origin/gh-pages -- apt/pool/main/ | tar -x -C dist/gh-pages/
+            fi
           fi
 
       - name: Build apt repository


### PR DESCRIPTION
## Summary

- The apt publishing workflow was replacing the entire `pool/main/` directory with only the latest release's `.deb` files, silently dropping all older versions
- Added a "Restore existing apt pool from gh-pages" step that uses `git archive` to extract existing `.deb` files from the `gh-pages` branch before the index is regenerated
- `dpkg-scanpackages` now indexes **all** packages in the pool (old + new), so `apt-get install ai-agent-bridge=<pinned-version>` continues to resolve after newer releases are published

## How it works

1. `git ls-remote` checks whether `gh-pages` exists (no-op on first publish)
2. `git archive origin/gh-pages -- apt/pool/main/` extracts only the pool `.deb` files — no checkout, no merge conflicts
3. New `.deb` files are copied alongside restored ones; `build-apt-repo.sh` regenerates the `Packages`, `Packages.gz`, `Release`, and `InRelease` files to include every version present

## Test plan

- [ ] Trigger a publish run and verify the new version appears in `pool/main/`
- [ ] Confirm the previous version's `.deb` is still present in `pool/main/` after the new publish
- [ ] Confirm `apt-get install ai-agent-bridge=<previous-version>` resolves without a 404
- [ ] Verify first-time publish (no existing `gh-pages` branch) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)