### PR TITLE
docs: remove duplicate Smoke Tests badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # AI Agent Bridge
 
 [![CI](https://github.com/markcallen/ai-agent-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/markcallen/ai-agent-bridge/actions/workflows/ci.yml)
-[![Smoke Tests](https://github.com/markcallen/ai-agent-bridge/actions/workflows/publish.yml/badge.svg?event=workflow_dispatch)](https://github.com/markcallen/ai-agent-bridge/actions/workflows/publish.yml)
 [![Publish](https://github.com/markcallen/ai-agent-bridge/actions/workflows/publish.yml/badge.svg)](https://github.com/markcallen/ai-agent-bridge/actions/workflows/publish.yml)
 [![License](https://img.shields.io/github/license/markcallen/ai-agent-bridge)](LICENSE)
 [![GitHub Release](https://img.shields.io/github/v/release/markcallen/ai-agent-bridge)](https://github.com/markcallen/ai-agent-bridge/releases)


### PR DESCRIPTION
## Summary

- The "Smoke Tests" badge was a duplicate alias for `publish.yml` filtered to `?event=workflow_dispatch` — there is no separate smoke-test workflow
- This created two confusingly-labelled badges for the same workflow on the README
- Removing the redundant badge; the existing `Publish` badge already shows `publish.yml` status

## Test plan

- [ ] Verify README renders correctly on GitHub with the remaining CI, Publish, License, and GitHub Release badges