### PR TITLE
fix: index all package versions in apt repository

### DIFF
--- a/scripts/build-apt-repo.sh
+++ b/scripts/build-apt-repo.sh
@@ -49,7 +49,7 @@ for suite in $SUITES; do
   for arch in $ARCHES; do
     binary_dir="dists/$suite/$COMPONENT/binary-$arch"
     mkdir -p "$binary_dir"
-    dpkg-scanpackages --arch "$arch" "pool/$COMPONENT" >"$binary_dir/Packages"
+    dpkg-scanpackages --multiversion --arch "$arch" "pool/$COMPONENT" >"$binary_dir/Packages"
     gzip -9c "$binary_dir/Packages" >"$binary_dir/Packages.gz"
   done
 


### PR DESCRIPTION
## Summary

- `dpkg-scanpackages` without `--multiversion` silently drops all but the highest version of each package from the `Packages` index, even when older `.deb` files are physically present in the pool
- This is why `v0.7.1` is accessible at its pool URL (HTTP 200) but absent from the `Packages` index — only `v0.7.3` appears
- Adding `--multiversion` causes all accumulated versions to be indexed, enabling `apt-get install ai-agent-bridge=0.7.1`

## Root cause trace

1. The restore step correctly pulls old `.deb` files from `gh-pages` into the pool before each publish
2. New debs are copied alongside them
3. `dpkg-scanpackages --arch amd64 pool/main` runs — but without `--multiversion` it only emits the newest version per package name
4. The older versions vanish from the index despite being in the pool

## Test plan

- [ ] Trigger a patch release after merge
- [ ] Verify the `Packages` index contains entries for both the new and previous versions
- [ ] Confirm `apt-get install ai-agent-bridge=<previous-version>` resolves correctly