### PR TITLE
fix: show help when an unknown bridgectl command is invoked

### DIFF
--- a/cmd/bridgectl/main.go
+++ b/cmd/bridgectl/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -29,6 +30,10 @@ across terminal windows.`,
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		if strings.HasPrefix(err.Error(), "unknown command") {
+			fmt.Fprintln(os.Stderr)
+			_ = root.Usage()
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/bridgectl/main.go
+++ b/cmd/bridgectl/main.go
@@ -32,7 +32,9 @@ across terminal windows.`,
 		fmt.Fprintln(os.Stderr, err)
 		if strings.HasPrefix(err.Error(), "unknown command") {
 			fmt.Fprintln(os.Stderr)
-			_ = root.Usage()
+			if usageErr := root.Usage(); usageErr != nil {
+				fmt.Fprintln(os.Stderr, usageErr)
+			}
 		}
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

- When `bridgectl` receives an unrecognised subcommand (e.g. `bridgectl status`), it previously only printed the bare error message with no guidance
- Now prints the error, a blank line, then the full available-commands help so users know what to run instead
- Valid commands that fail still only show their own error (no usage dump)

## Test plan

- [ ] `bridgectl status` → error message + help listing, exits 1
- [ ] `bridgectl run --help` → normal help, no double output
- [ ] `go build ./...` passes
- [ ] All pre-commit hooks pass (gofmt, golangci-lint, go-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)