### PR TITLE
fix: remove attach deadline, sort session list, and pass raw TTY input

### DIFF
--- a/cmd/bridgectl/run.go
+++ b/cmd/bridgectl/run.go
@@ -183,11 +183,10 @@ func runSession(dir, providerName, project string, timeout time.Duration) error 
 						return
 					}
 				}
-				data := normalizeTTYInput(buf[:n])
 				_, _ = client.WriteInput(context.Background(), &bridgev1.WriteInputRequest{
 					SessionId: sessionID,
 					ClientId:  stream.ClientID(),
-					Data:      data,
+					Data:      buf[:n],
 				})
 			}
 			if readErr != nil {
@@ -367,14 +366,4 @@ func currentTTYSize() (uint32, uint32) {
 		return 120, 40
 	}
 	return uint32(ws.Cols), uint32(ws.Rows)
-}
-
-func normalizeTTYInput(b []byte) []byte {
-	data := append([]byte(nil), b...)
-	for i := range data {
-		if data[i] == '\n' {
-			data[i] = '\r'
-		}
-	}
-	return data
 }

--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -63,6 +64,10 @@ func newSessionListCmd() *cobra.Command {
 				fmt.Println("No active sessions.")
 				return nil
 			}
+
+			sort.Slice(resp.Sessions, func(i, j int) bool {
+				return resp.Sessions[i].CreatedAt.AsTime().Before(resp.Sessions[j].CreatedAt.AsTime())
+			})
 
 			fmt.Printf("%-36s  %-10s  %-10s  %s\n", "SESSION ID", "PROVIDER", "STATUS", "CREATED")
 			for _, s := range resp.Sessions {
@@ -172,7 +177,7 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool) er
 		restore = func() {}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	clientID := uuid.NewString()

--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -257,11 +257,10 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool) er
 							return
 						}
 					}
-					data := normalizeTTYInput(buf[:n])
 					_, _ = client.WriteInput(context.Background(), &bridgev1.WriteInputRequest{
 						SessionId: sessionID,
 						ClientId:  stream.ClientID(),
-						Data:      data,
+						Data:      buf[:n],
 					})
 				}
 				if readErr != nil {


### PR DESCRIPTION
## Summary

- **Remove 30-minute attach deadline**: `attachSession` was using `context.WithTimeout` with a 30-minute deadline, causing any session longer than 30 minutes to terminate with `DeadlineExceeded`. Replaced with `context.WithCancel` so attach lifetime is driven by signals, the detach key, or the session ending naturally.
- **Sort session list by creation time**: `bridgectl session list` now outputs sessions in chronological order (oldest first).
- **Pass raw TTY bytes to `WriteInput`**: Removed the `normalizeTTYInput` helper that remapped LF (0x0A) to CR (0x0D). `bridgectl` uses `term.MakeRaw()`, which clears `ICRNL`, so Enter already arrives as `\r` — the normalization was a no-op for Enter but incorrectly made Ctrl-J indistinguishable from Enter. Bytes are now forwarded unchanged.

## Test plan

- [ ] Attach to a session and leave it running past 30 minutes — confirm it no longer drops with `session ended: rpc error: code = DeadlineExceeded`
- [ ] Confirm Ctrl-C and the detach key still cleanly end the session
- [ ] Confirm `bridgectl session list` output is sorted oldest-first
- [ ] Confirm Enter still submits input and Ctrl-J sends a literal newline (LF) to the remote session

🤖 Generated with [Claude Code](https://claude.com/claude-code)