### PR TITLE
fix: prevent PTY crash from causing OS hang via rate-limit flood

### DIFF
--- a/cmd/bridgectl/server.go
+++ b/cmd/bridgectl/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -15,6 +16,38 @@ import (
 
 	"github.com/markcallen/ai-agent-bridge/internal/localserver"
 )
+
+// sdNotify sends a notification to the systemd service manager via
+// $NOTIFY_SOCKET. It is a no-op when the socket is not set (i.e. when not
+// running under systemd).
+func sdNotify(state string) {
+	socket := os.Getenv("NOTIFY_SOCKET")
+	if socket == "" {
+		return
+	}
+	addr := &net.UnixAddr{Name: socket, Net: "unixgram"}
+	conn, err := net.DialUnix("unixgram", nil, addr)
+	if err != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+	_, _ = conn.Write([]byte(state))
+}
+
+// sdWatchdog sends periodic WATCHDOG=1 pings until done is closed.
+// WatchdogSec must be set in the systemd unit for these to be effective.
+func sdWatchdog(interval time.Duration, done <-chan struct{}) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			sdNotify("WATCHDOG=1")
+		case <-done:
+			return
+		}
+	}
+}
 
 func newServerCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -102,11 +135,18 @@ auto-generated on first start and stored in ~/.ai-agent-bridge/certs/.`,
 			}
 			fmt.Fprintf(os.Stderr, "ai-agent-bridge server listening — %s (pid %d)\n", mode, os.Getpid())
 
+			// Notify systemd that the server is ready and start the watchdog
+			// heartbeat. Both are no-ops when not running under systemd.
+			sdNotify("READY=1\nSTATUS=listening")
+			watchdogDone := make(chan struct{})
+			go sdWatchdog(15*time.Second, watchdogDone)
+
 			// Block until signal.
 			sigCh := make(chan os.Signal, 1)
 			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 			sig := <-sigCh
 			fmt.Fprintf(os.Stderr, "\nReceived %s, shutting down...\n", sig)
+			close(watchdogDone)
 			srv.Stop()
 			return nil
 		},

--- a/cmd/bridgectl/server.go
+++ b/cmd/bridgectl/server.go
@@ -20,10 +20,17 @@ import (
 // sdNotify sends a notification to the systemd service manager via
 // $NOTIFY_SOCKET. It is a no-op when the socket is not set (i.e. when not
 // running under systemd).
+//
+// systemd uses abstract Unix domain sockets whose path begins with '@'; the
+// kernel API requires the leading '@' to be replaced with a NUL byte.
 func sdNotify(state string) {
 	socket := os.Getenv("NOTIFY_SOCKET")
 	if socket == "" {
 		return
+	}
+	// Translate abstract socket notation: '@' prefix → '\0' prefix.
+	if len(socket) > 0 && socket[0] == '@' {
+		socket = "\x00" + socket[1:]
 	}
 	addr := &net.UnixAddr{Name: socket, Net: "unixgram"}
 	conn, err := net.DialUnix("unixgram", nil, addr)

--- a/internal/bridge/supervisor.go
+++ b/internal/bridge/supervisor.go
@@ -547,6 +547,14 @@ func (s *Supervisor) readLoop(ms *managedSession) {
 					ms.info.Error = err.Error()
 				}
 				ms.mu.Unlock()
+				// Force-terminate the process so any pending WriteInput calls see
+				// SessionNotFound rather than writing to a dead PTY file descriptor.
+				sessionID := ms.info.SessionID
+				go func() {
+					if stopErr := s.Stop(sessionID, true); stopErr != nil {
+						slog.Debug("stop after PTY read error", "session_id", sessionID, "error", stopErr)
+					}
+				}()
 			}
 			return
 		}

--- a/internal/bridge/supervisor_test.go
+++ b/internal/bridge/supervisor_test.go
@@ -1212,3 +1212,64 @@ func TestControlEventSeqIsZero(t *testing.T) {
 		t.Fatal("timed out waiting for control chunk")
 	}
 }
+
+// TestPTYReadErrorTerminatesSession verifies that a non-EOF PTY read error
+// causes the supervisor to force-stop the session. This exercises the fix for
+// the issue where a dead PTY left the session alive so clients could flood
+// WriteInput against it indefinitely.
+func TestPTYReadErrorTerminatesSession(t *testing.T) {
+	registry := NewRegistry()
+	// Use a provider whose process exits immediately; the PTY will then return
+	// an I/O error on the next Read, which is exactly the failure mode we want
+	// to handle.
+	if err := registry.Register(&testProvider{id: "fake"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// Use a fast-exit command: "true" finishes instantly, closing the PTY.
+	trueProv := &exitImmediateTestProvider{testProvider: testProvider{id: "exit-immediate"}}
+	if err := registry.Register(trueProv); err != nil {
+		t.Fatalf("Register exit-immediate: %v", err)
+	}
+
+	sup := NewSupervisor(registry, DefaultPolicy(), 1024, time.Minute)
+	defer sup.Close()
+
+	_, err := sup.Start(context.Background(), SessionConfig{
+		ProjectID:   "proj-pty-err",
+		SessionID:   "pty-err-1",
+		RepoPath:    t.TempDir(),
+		Options:     map[string]string{"provider": "exit-immediate"},
+		InitialCols: 80,
+		InitialRows: 24,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// After the process exits the PTY read will error; the session should
+	// transition to Stopped or Failed without manual intervention.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		info, getErr := sup.Get("pty-err-1")
+		if getErr == nil && (info.State == SessionStateStopped || info.State == SessionStateFailed) {
+			return // session cleaned up as expected
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	info, _ := sup.Get("pty-err-1")
+	t.Fatalf("session did not terminate after PTY closed: state=%v", info.State)
+}
+
+// exitImmediateTestProvider runs "true" (exits immediately) via PTY.
+type exitImmediateTestProvider struct {
+	testProvider
+}
+
+func (p *exitImmediateTestProvider) ID() string { return "exit-immediate" }
+func (p *exitImmediateTestProvider) BuildCommand(ctx context.Context, cfg SessionConfig) (*exec.Cmd, error) {
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		truePath = "/usr/bin/true"
+	}
+	return exec.CommandContext(ctx, truePath), nil
+}

--- a/internal/bridge/supervisor_test.go
+++ b/internal/bridge/supervisor_test.go
@@ -1247,17 +1247,29 @@ func TestPTYReadErrorTerminatesSession(t *testing.T) {
 	}
 
 	// After the process exits the PTY read will error; the session should
-	// transition to Stopped or Failed without manual intervention.
+	// transition to Stopped or Failed without manual intervention. The
+	// force-stop path may also remove the session from the live map, so
+	// ErrSessionNotFound is also a valid termination signal.
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		info, getErr := sup.Get("pty-err-1")
+		if errors.Is(getErr, ErrSessionNotFound) {
+			return // session force-removed after PTY error
+		}
 		if getErr == nil && (info.State == SessionStateStopped || info.State == SessionStateFailed) {
 			return // session cleaned up as expected
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	info, _ := sup.Get("pty-err-1")
-	t.Fatalf("session did not terminate after PTY closed: state=%v", info.State)
+	info, getErr := sup.Get("pty-err-1")
+	if errors.Is(getErr, ErrSessionNotFound) {
+		return
+	}
+	var state SessionState
+	if info != nil {
+		state = info.State
+	}
+	t.Fatalf("session did not terminate after PTY closed: state=%v getErr=%v", state, getErr)
 }
 
 // exitImmediateTestProvider runs "true" (exits immediately) via PTY.

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -5,12 +5,25 @@ import (
 	"time"
 )
 
+// circuitBreakerThreshold is the number of consecutive rate-limit violations
+// that trips the circuit breaker for a single key.
+const circuitBreakerThreshold = 100
+
+// circuitBreakerBanDuration is how long a key stays banned after the breaker
+// trips. During the ban, allow() returns false and banned() returns true so
+// callers can take stronger action (e.g. terminate the session).
+const circuitBreakerBanDuration = 5 * time.Minute
+
 type tokenBucket struct {
 	rate     float64
 	burst    float64
 	tokens   float64
 	last     time.Time
 	lastSeen time.Time
+
+	// circuit breaker fields
+	consecutiveViolations int
+	bannedUntil           time.Time
 }
 
 func newTokenBucket(rate float64, burst int, now time.Time) *tokenBucket {
@@ -23,7 +36,16 @@ func newTokenBucket(rate float64, burst int, now time.Time) *tokenBucket {
 	}
 }
 
+// allow returns true when the request is within the rate limit. It also tracks
+// consecutive violations and sets bannedUntil when the circuit breaker trips.
 func (b *tokenBucket) allow(now time.Time) bool {
+	b.lastSeen = now
+
+	// While banned, every call counts as a denial.
+	if now.Before(b.bannedUntil) {
+		return false
+	}
+
 	elapsed := now.Sub(b.last).Seconds()
 	if elapsed > 0 {
 		b.tokens += elapsed * b.rate
@@ -32,12 +54,23 @@ func (b *tokenBucket) allow(now time.Time) bool {
 		}
 		b.last = now
 	}
-	b.lastSeen = now
+
 	if b.tokens < 1 {
+		b.consecutiveViolations++
+		if b.consecutiveViolations >= circuitBreakerThreshold {
+			b.bannedUntil = now.Add(circuitBreakerBanDuration)
+			b.consecutiveViolations = 0
+		}
 		return false
 	}
 	b.tokens--
+	b.consecutiveViolations = 0
 	return true
+}
+
+// isBanned returns true when the circuit breaker is active for the bucket.
+func (b *tokenBucket) isBanned(now time.Time) bool {
+	return now.Before(b.bannedUntil)
 }
 
 type keyedLimiter struct {
@@ -73,6 +106,23 @@ func (l *keyedLimiter) allow(key string) bool {
 	allowed := b.allow(now)
 	l.cleanupLocked(now)
 	return allowed
+}
+
+// banned returns true when the circuit breaker for key is currently active.
+// Must be called after allow() returns false to distinguish a ban from ordinary
+// throttling.
+func (l *keyedLimiter) banned(key string) bool {
+	if l == nil {
+		return false
+	}
+	now := time.Now()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	b := l.buckets[key]
+	if b == nil {
+		return false
+	}
+	return b.isBanned(now)
 }
 
 func (l *keyedLimiter) cleanupLocked(now time.Time) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -324,6 +324,16 @@ func (s *BridgeServer) WriteInput(ctx context.Context, req *bridgev1.WriteInputR
 		return nil, err
 	}
 	if !s.writeRL.allow(req.SessionId) {
+		if s.writeRL.banned(req.SessionId) {
+			// Circuit breaker tripped: the client has sent too many requests while
+			// rate-limited. Force-terminate the session so the client can no longer
+			// write to it, then return Unavailable (distinct from ResourceExhausted)
+			// so a well-behaved client stops retrying entirely.
+			slog.Warn("write input circuit breaker tripped, terminating session",
+				"session_id", req.SessionId, "client_id", req.ClientId)
+			go func() { _ = s.supervisor.Stop(req.SessionId, true) }()
+			return nil, status.Error(codes.Unavailable, "write input circuit breaker: session terminated due to sustained rate limit violations")
+		}
 		return nil, status.Error(codes.ResourceExhausted, "write input rate limit exceeded for session")
 	}
 	if err := s.authorizeSession(claims, req.SessionId); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -323,21 +323,21 @@ func (s *BridgeServer) WriteInput(ctx context.Context, req *bridgev1.WriteInputR
 	if err := validateByteField("data", req.Data, 1<<20); err != nil {
 		return nil, err
 	}
+	if err := s.authorizeSession(claims, req.SessionId); err != nil {
+		return nil, err
+	}
 	if !s.writeRL.allow(req.SessionId) {
 		if s.writeRL.banned(req.SessionId) {
 			// Circuit breaker tripped: the client has sent too many requests while
 			// rate-limited. Force-terminate the session so the client can no longer
 			// write to it, then return Unavailable (distinct from ResourceExhausted)
 			// so a well-behaved client stops retrying entirely.
-			slog.Warn("write input circuit breaker tripped, terminating session",
+			s.logger.Warn("write input circuit breaker tripped, terminating session",
 				"session_id", req.SessionId, "client_id", req.ClientId)
 			go func() { _ = s.supervisor.Stop(req.SessionId, true) }()
 			return nil, status.Error(codes.Unavailable, "write input circuit breaker: session terminated due to sustained rate limit violations")
 		}
 		return nil, status.Error(codes.ResourceExhausted, "write input rate limit exceeded for session")
-	}
-	if err := s.authorizeSession(claims, req.SessionId); err != nil {
-		return nil, err
 	}
 	n, err := s.supervisor.WriteInput(req.SessionId, req.ClientId, req.Data)
 	if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -126,13 +126,22 @@ func TestCircuitBreaker(t *testing.T) {
 	}
 
 	// keyedLimiter.banned() mirrors the bucket state.
+	// Drive the underlying bucket directly with a fixed timestamp to avoid
+	// token refills from wall-clock progression making the test flaky.
 	limiter := newKeyedLimiter(1, 1)
 	if limiter.banned("x") {
 		t.Fatal("banned returned true for unknown key")
 	}
-	limiter.allow("x") // drain
+	// Insert a pre-drained bucket so all subsequent allow calls are violations.
+	limiter.mu.Lock()
+	drained := newTokenBucket(1, 1, now)
+	drained.allow(now) // consume the single token
+	limiter.buckets["x"] = drained
+	limiter.mu.Unlock()
 	for i := 0; i < circuitBreakerThreshold; i++ {
-		limiter.allow("x")
+		limiter.mu.Lock()
+		limiter.buckets["x"].allow(now)
+		limiter.mu.Unlock()
 	}
 	if !limiter.banned("x") {
 		t.Fatal("limiter.banned returned false after threshold violations")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -95,6 +95,50 @@ func TestRateLimiters(t *testing.T) {
 	}
 }
 
+func TestCircuitBreaker(t *testing.T) {
+	now := time.Now()
+	// Bucket with rate=1/s, burst=1; use an empty bucket so every call is a violation.
+	bucket := newTokenBucket(1, 1, now)
+	bucket.allow(now) // drain the one token
+
+	// Drive consecutive violations up to the threshold.
+	for i := 0; i < circuitBreakerThreshold-1; i++ {
+		bucket.allow(now)
+		if bucket.isBanned(now) {
+			t.Fatalf("circuit breaker tripped too early at violation %d", i+1)
+		}
+	}
+	// The next violation should trip the breaker.
+	bucket.allow(now)
+	if !bucket.isBanned(now) {
+		t.Fatal("circuit breaker did not trip after threshold violations")
+	}
+	// Violations reset after the ban expires.
+	afterBan := now.Add(circuitBreakerBanDuration + time.Second)
+	if bucket.isBanned(afterBan) {
+		t.Fatal("bucket still banned after ban duration elapsed")
+	}
+	// A successful allow resets the consecutive violation counter.
+	bucket2 := newTokenBucket(10, 10, now)
+	bucket2.allow(now) // succeeds, resets counter
+	if bucket2.consecutiveViolations != 0 {
+		t.Fatal("consecutive violations not reset after successful allow")
+	}
+
+	// keyedLimiter.banned() mirrors the bucket state.
+	limiter := newKeyedLimiter(1, 1)
+	if limiter.banned("x") {
+		t.Fatal("banned returned true for unknown key")
+	}
+	limiter.allow("x") // drain
+	for i := 0; i < circuitBreakerThreshold; i++ {
+		limiter.allow("x")
+	}
+	if !limiter.banned("x") {
+		t.Fatal("limiter.banned returned false after threshold violations")
+	}
+}
+
 func TestBridgeHelpersAndProviderResponses(t *testing.T) {
 	registry := bridge.NewRegistry()
 	if err := registry.Register(&serverTestProvider{id: "healthy", version: "v1.2.3"}); err != nil {

--- a/packaging/bridge.user.service
+++ b/packaging/bridge.user.service
@@ -4,11 +4,19 @@ Documentation=https://github.com/markcallen/ai-agent-bridge
 After=default.target
 
 [Service]
-Type=simple
+Type=notify
 ExecStart=/usr/bin/bridgectl server start
 Restart=on-failure
 RestartSec=5s
 Environment=HOME=%h
+
+# Watchdog: restart if the process stops sending heartbeats for 30s.
+WatchdogSec=30s
+
+# Resource caps to prevent a runaway RPC flood from taking down the OS.
+LimitNOFILE=65536
+MemoryMax=512M
+CPUQuota=50%
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary

Fixes #143. Three layered defences against the crash-then-flood scenario:

- **PTY error → immediate session termination**: `readLoop` now calls `Stop(sessionID, true)` in a goroutine when it receives a non-EOF PTY read error. Previously the session stayed alive in the map, so a reconnecting client could flood `WriteInput` against a dead file descriptor.

- **`WriteInput` circuit breaker**: `keyedLimiter` now tracks consecutive violations per key. After 100 consecutive `ResourceExhausted` responses the bucket is banned for 5 minutes. `WriteInput` checks `banned()` when `allow()` fails and, if the breaker has tripped, force-stops the session and returns `codes.Unavailable` — a signal a well-behaved client should treat as terminal rather than retrying.

- **Systemd watchdog + resource caps**: `bridge.user.service` is upgraded to `Type=notify` with `WatchdogSec=30s`. The server sends `READY=1` on startup and `WATCHDOG=1` every 15 s, so systemd can detect and restart a hung process automatically. `LimitNOFILE`, `MemoryMax`, and `CPUQuota` cap the blast radius of a runaway flood so it cannot take down the OS.

## Test plan

- [ ] `TestPTYReadErrorTerminatesSession` — new test: starts a session whose process exits immediately, verifies supervisor transitions to Stopped/Failed without manual intervention
- [ ] `TestCircuitBreaker` — new test: drives a token bucket to the violation threshold, confirms ban activates and expires correctly, confirms `keyedLimiter.banned()` mirrors bucket state
- [ ] `make test` — full suite passes with `-race`
- [ ] Manually deploy updated service unit to EC2 and confirm `systemctl --user status bridgectl` shows `Type=notify` and watchdog active

## Files changed

| File | Change |
|------|--------|
| `internal/bridge/supervisor.go` | `readLoop`: on non-EOF error, goroutine-call `Stop(id, true)` |
| `internal/server/ratelimit.go` | Add consecutive-violation counter + ban to `tokenBucket`; add `banned()` to `keyedLimiter` |
| `internal/server/server.go` | `WriteInput`: check `banned()` → force-stop session + return `Unavailable` |
| `cmd/bridgectl/server.go` | `sdNotify` / `sdWatchdog` helpers; send `READY=1` + heartbeat on start |
| `packaging/bridge.user.service` | `Type=notify`, `WatchdogSec=30s`, resource limits |
| `internal/server/server_test.go` | `TestCircuitBreaker` |
| `internal/bridge/supervisor_test.go` | `TestPTYReadErrorTerminatesSession` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)