### PR TITLE
Add configurable cert validity and renewal check interval

### DIFF
--- a/cmd/bridge-ca/main.go
+++ b/cmd/bridge-ca/main.go
@@ -126,7 +126,7 @@ func cmdIssue() {
 		sans = strings.Split(*san, ",")
 	}
 
-	certPath, keyPath, err := pki.IssueCert(ca, key, ct, *cn, sans, *out)
+	certPath, keyPath, err := pki.IssueCert(ca, key, ct, *cn, sans, *out, 0)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/cmd/bridgectl/server.go
+++ b/cmd/bridgectl/server.go
@@ -469,6 +469,7 @@ immediate renewal (e.g. when the cert has already expired).`,
 					configPath = defaultCfg
 				}
 			}
+			var certValidity time.Duration
 			if configPath != "" {
 				fileCfg, err := config.Load(configPath)
 				if err != nil {
@@ -491,6 +492,9 @@ immediate renewal (e.g. when the cert has already expired).`,
 					}
 					if len(serverSANs) == 0 && fileCfg.Server.Listen != "" {
 						serverSANs = localserver.BuildServerSANs(fileCfg.Server.Listen, nil)
+					}
+					if fileCfg.Server.CertValidity != "" {
+						certValidity = config.ParseDuration(fileCfg.Server.CertValidity, 0)
 					}
 				}
 			}
@@ -525,7 +529,7 @@ immediate renewal (e.g. when the cert has already expired).`,
 				}
 			}
 
-			if err := localserver.RenewServerCert(stateDir, serverSANs, logger, stepCA, 0); err != nil {
+			if err := localserver.RenewServerCert(stateDir, serverSANs, logger, stepCA, certValidity); err != nil {
 				return fmt.Errorf("renew cert: %w", err)
 			}
 

--- a/cmd/bridgectl/server.go
+++ b/cmd/bridgectl/server.go
@@ -88,6 +88,8 @@ func newServerStartCmd() *cobra.Command {
 		stepCARootPath                string
 		stepCAProvisioner             string
 		stepCAProvisionerPasswordFile string
+		certValidity                  time.Duration
+		certRenewalCheckInterval      time.Duration
 	)
 
 	cmd := &cobra.Command{
@@ -150,6 +152,8 @@ infrastructure (Google, GitHub, Okta, etc.) managed through Step CA.`,
 				StepCARootPath:                stepCARootPath,
 				StepCAProvisioner:             stepCAProvisioner,
 				StepCAProvisionerPasswordFile: stepCAProvisionerPasswordFile,
+				CertValidity:                  certValidity,
+				CertRenewalCheckInterval:      certRenewalCheckInterval,
 			}
 			if globalRPS > 0 {
 				cfg.RateLimits.GlobalRPS = globalRPS
@@ -194,6 +198,8 @@ infrastructure (Google, GitHub, Okta, etc.) managed through Step CA.`,
 	cmd.Flags().StringVar(&stepCARootPath, "step-ca-root", "", "path to the Step CA root certificate (required with --step-ca-url)")
 	cmd.Flags().StringVar(&stepCAProvisioner, "step-ca-provisioner", "", "Step CA provisioner name (e.g. acme, bridge-jwk); defaults to CA's default provisioner")
 	cmd.Flags().StringVar(&stepCAProvisionerPasswordFile, "step-ca-provisioner-password-file", "", "path to provisioner password file for non-interactive Step CA cert requests")
+	cmd.Flags().DurationVar(&certValidity, "cert-validity", 0, "server certificate validity duration (e.g. 30m, 24h, 2160h); default 90 days")
+	cmd.Flags().DurationVar(&certRenewalCheckInterval, "cert-renewal-check-interval", 0, "how often to check certificate expiry (e.g. 10m, 1h); default 1 hour")
 
 	return cmd
 }
@@ -519,7 +525,7 @@ immediate renewal (e.g. when the cert has already expired).`,
 				}
 			}
 
-			if err := localserver.RenewServerCert(stateDir, serverSANs, logger, stepCA); err != nil {
+			if err := localserver.RenewServerCert(stateDir, serverSANs, logger, stepCA, 0); err != nil {
 				return fmt.Errorf("renew cert: %w", err)
 			}
 

--- a/e2e/bridgectl/cli_test.go
+++ b/e2e/bridgectl/cli_test.go
@@ -1567,7 +1567,7 @@ func TestStepCADualCAArchitecture(t *testing.T) {
 		URL:      "https://ca.example.internal:443",
 		RootPath: rootPEM,
 	}
-	mat, err := localserver.EnsurePKI(stateDir, []string{"10.0.0.1"}, logger, stepCfg)
+	mat, err := localserver.EnsurePKI(stateDir, []string{"10.0.0.1"}, logger, stepCfg, 0)
 	require.NoError(t, err)
 
 	// 1. ca-bundle.crt should contain the Step CA root first, then the local CA.
@@ -1627,7 +1627,7 @@ func TestStepCAIdempotency(t *testing.T) {
 	}
 
 	// First call — generates everything.
-	mat1, err := localserver.EnsurePKI(stateDir, []string{"10.0.0.1"}, logger, stepCfg)
+	mat1, err := localserver.EnsurePKI(stateDir, []string{"10.0.0.1"}, logger, stepCfg, 0)
 	require.NoError(t, err)
 	bundle1, err := os.ReadFile(mat1.CABundlePath)
 	require.NoError(t, err)
@@ -1636,7 +1636,7 @@ func TestStepCAIdempotency(t *testing.T) {
 	require.NoError(t, os.WriteFile(rootPEM, []byte("changed-root"), 0o644))
 
 	// Second call — should be no-op; bundle should retain original content.
-	mat2, err := localserver.EnsurePKI(stateDir, []string{"10.0.0.1"}, logger, stepCfg)
+	mat2, err := localserver.EnsurePKI(stateDir, []string{"10.0.0.1"}, logger, stepCfg, 0)
 	require.NoError(t, err)
 	bundle2, err := os.ReadFile(mat2.CABundlePath)
 	require.NoError(t, err)
@@ -1673,7 +1673,7 @@ func TestStepCATier1ClientIssuance(t *testing.T) {
 	}
 
 	// Initialize PKI with Step CA.
-	_, err := localserver.EnsurePKI(stateDir, []string{"10.0.0.1"}, logger, stepCfg)
+	_, err := localserver.EnsurePKI(stateDir, []string{"10.0.0.1"}, logger, stepCfg, 0)
 	require.NoError(t, err)
 
 	// Issue a Tier-1 client cert (signed by local CA, not Step CA).

--- a/internal/auth/interceptors_additional_test.go
+++ b/internal/auth/interceptors_additional_test.go
@@ -182,11 +182,11 @@ func TestAuditInterceptorsAndTLSConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InitCA: %v", err)
 	}
-	serverCert, serverKey, err := pki.IssueCert(mustLoadCA(t, caCert, caKey), mustLoadCAKey(t, caCert, caKey), pki.CertTypeServer, "bridge.local", []string{"bridge.local", "127.0.0.1"}, dir)
+	serverCert, serverKey, err := pki.IssueCert(mustLoadCA(t, caCert, caKey), mustLoadCAKey(t, caCert, caKey), pki.CertTypeServer, "bridge.local", []string{"bridge.local", "127.0.0.1"}, dir, 0)
 	if err != nil {
 		t.Fatalf("Issue server cert: %v", err)
 	}
-	clientCert, clientKey, err := pki.IssueCert(mustLoadCA(t, caCert, caKey), mustLoadCAKey(t, caCert, caKey), pki.CertTypeClient, "client-a", nil, dir)
+	clientCert, clientKey, err := pki.IssueCert(mustLoadCA(t, caCert, caKey), mustLoadCAKey(t, caCert, caKey), pki.CertTypeClient, "client-a", nil, dir, 0)
 	if err != nil {
 		t.Fatalf("Issue client cert: %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -260,13 +260,21 @@ func validate(cfg *Config) error {
 		return fmt.Errorf("config: auth.jwt_max_ttl: %w", err)
 	}
 	if cfg.Server.CertValidity != "" {
-		if _, err := time.ParseDuration(cfg.Server.CertValidity); err != nil {
+		d, err := time.ParseDuration(cfg.Server.CertValidity)
+		if err != nil {
 			return fmt.Errorf("config: server.cert_validity: %w", err)
+		}
+		if d < 0 {
+			return fmt.Errorf("config: server.cert_validity must not be negative")
 		}
 	}
 	if cfg.Server.CertRenewalCheckInterval != "" {
-		if _, err := time.ParseDuration(cfg.Server.CertRenewalCheckInterval); err != nil {
+		d, err := time.ParseDuration(cfg.Server.CertRenewalCheckInterval)
+		if err != nil {
 			return fmt.Errorf("config: server.cert_renewal_check_interval: %w", err)
+		}
+		if d < 0 {
+			return fmt.Errorf("config: server.cert_renewal_check_interval must not be negative")
 		}
 	}
 	if _, err := time.ParseDuration(cfg.Sessions.IdleTimeout); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,8 +37,10 @@ type RuntimeConfig struct {
 }
 
 type ServerConfig struct {
-	Listen string   `yaml:"listen"`
-	SANs   []string `yaml:"san"`
+	Listen                   string   `yaml:"listen"`
+	SANs                     []string `yaml:"san"`
+	CertValidity             string   `yaml:"cert_validity"`
+	CertRenewalCheckInterval string   `yaml:"cert_renewal_check_interval"`
 }
 
 // StepCAYAMLConfig holds Step CA settings from the YAML config file.
@@ -256,6 +258,16 @@ func validate(cfg *Config) error {
 	}
 	if _, err := time.ParseDuration(cfg.Auth.JWTMaxTTL); err != nil {
 		return fmt.Errorf("config: auth.jwt_max_ttl: %w", err)
+	}
+	if cfg.Server.CertValidity != "" {
+		if _, err := time.ParseDuration(cfg.Server.CertValidity); err != nil {
+			return fmt.Errorf("config: server.cert_validity: %w", err)
+		}
+	}
+	if cfg.Server.CertRenewalCheckInterval != "" {
+		if _, err := time.ParseDuration(cfg.Server.CertRenewalCheckInterval); err != nil {
+			return fmt.Errorf("config: server.cert_renewal_check_interval: %w", err)
+		}
 	}
 	if _, err := time.ParseDuration(cfg.Sessions.IdleTimeout); err != nil {
 		return fmt.Errorf("config: sessions.idle_timeout: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -358,3 +358,79 @@ sessions:
 		})
 	}
 }
+
+func TestLoadValidateCertDurations(t *testing.T) {
+	base := `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+providers:
+  echo:
+    binary: "cat"
+`
+
+	tests := []struct {
+		name    string
+		extra   string
+		wantErr string
+	}{
+		{
+			name:  "valid cert_validity",
+			extra: "  cert_validity: \"30m\"\n",
+		},
+		{
+			name:  "valid cert_renewal_check_interval",
+			extra: "  cert_renewal_check_interval: \"10m\"\n",
+		},
+		{
+			name:    "invalid cert_validity",
+			extra:   "  cert_validity: \"not-a-duration\"\n",
+			wantErr: "server.cert_validity",
+		},
+		{
+			name:    "invalid cert_renewal_check_interval",
+			extra:   "  cert_renewal_check_interval: \"bad\"\n",
+			wantErr: "server.cert_renewal_check_interval",
+		},
+		{
+			name:    "negative cert_validity",
+			extra:   "  cert_validity: \"-5m\"\n",
+			wantErr: "must not be negative",
+		},
+		{
+			name:    "negative cert_renewal_check_interval",
+			extra:   "  cert_renewal_check_interval: \"-1h\"\n",
+			wantErr: "must not be negative",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Insert extra fields under the server: block.
+			content := strings.Replace(base, "  listen:", tc.extra+"  listen:", 1)
+			dir := t.TempDir()
+			path := filepath.Join(dir, "bridge.yaml")
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			_, err := Load(path)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+		})
+	}
+}

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -75,10 +75,12 @@ type Server struct {
 	stopped    bool
 
 	// Certificate renewal (secure mode only).
-	renewCancel context.CancelFunc // cancels the renewal goroutine
-	serverSANs  []string           // SANs for cert re-issuance
-	stepCA      *StepCAConfig      // nil for auto-PKI mode
-	pkiMat      *PKIMaterial       // paths to cert/key files
+	renewCancel              context.CancelFunc // cancels the renewal goroutine
+	serverSANs               []string           // SANs for cert re-issuance
+	stepCA                   *StepCAConfig      // nil for auto-PKI mode
+	pkiMat                   *PKIMaterial       // paths to cert/key files
+	certValidity             time.Duration      // server cert validity for auto-PKI renewal
+	certRenewalCheckInterval time.Duration      // how often to check cert expiry
 }
 
 // ServerMode represents how the server is running.
@@ -196,6 +198,13 @@ type Config struct {
 	// JWK provisioner password. When set, `step ca certificate` runs
 	// non-interactively (required in Docker/headless environments).
 	StepCAProvisionerPasswordFile string
+
+	// CertValidity overrides the server certificate validity duration.
+	// Zero uses the default (90 days). Useful for testing renewal flows.
+	CertValidity time.Duration
+	// CertRenewalCheckInterval overrides how often the renewal loop checks
+	// certificate expiry. Zero uses the default (1 hour).
+	CertRenewalCheckInterval time.Duration
 }
 
 // Start launches a local bridge gRPC server. In local mode (default) it
@@ -266,6 +275,12 @@ func Start(cfg Config) (*Server, error) {
 			}
 			if len(cfg.ServerSANs) == 0 && len(fileCfg.Server.SANs) > 0 {
 				cfg.ServerSANs = fileCfg.Server.SANs
+			}
+			if cfg.CertValidity == 0 && fileCfg.Server.CertValidity != "" {
+				cfg.CertValidity = config.ParseDuration(fileCfg.Server.CertValidity, 0)
+			}
+			if cfg.CertRenewalCheckInterval == 0 && fileCfg.Server.CertRenewalCheckInterval != "" {
+				cfg.CertRenewalCheckInterval = config.ParseDuration(fileCfg.Server.CertRenewalCheckInterval, 0)
 			}
 			if cfg.StepCAURL == "" && fileCfg.StepCA.URL != "" {
 				cfg.StepCAURL = fileCfg.StepCA.URL
@@ -497,7 +512,7 @@ func Start(cfg Config) (*Server, error) {
 				}
 			}
 			var pkiErr error
-			mat, pkiErr = EnsurePKI(stateDir, serverSANs, logger, stepCAConfig)
+			mat, pkiErr = EnsurePKI(stateDir, serverSANs, logger, stepCAConfig, cfg.CertValidity)
 			if pkiErr != nil {
 				sup.Close()
 				if store != nil {
@@ -596,6 +611,8 @@ func Start(cfg Config) (*Server, error) {
 		s.serverSANs = serverSANs
 		s.stepCA = stepCAConfig
 		s.pkiMat = pkiMat
+		s.certValidity = cfg.CertValidity
+		s.certRenewalCheckInterval = cfg.CertRenewalCheckInterval
 		renewCtx, renewCancel := context.WithCancel(context.Background())
 		s.renewCancel = renewCancel
 		go s.certRenewalLoop(renewCtx)
@@ -777,8 +794,8 @@ func (s *Server) Stop() {
 	_ = os.Remove(filepath.Join(s.stateDir, "server.lock"))
 }
 
-// certRenewalCheckInterval is how often the renewal loop checks cert expiry.
-const certRenewalCheckInterval = 1 * time.Hour
+// defaultCertRenewalCheckInterval is how often the renewal loop checks cert expiry.
+const defaultCertRenewalCheckInterval = 1 * time.Hour
 
 // certRenewalLoop periodically checks the server certificate's expiry and
 // renews it when less than 1/3 of the certificate's total lifetime remains.
@@ -789,7 +806,11 @@ func (s *Server) certRenewalLoop(ctx context.Context) {
 	// Check once at startup to handle already-expired certs.
 	s.checkAndRenew()
 
-	ticker := time.NewTicker(certRenewalCheckInterval)
+	interval := s.certRenewalCheckInterval
+	if interval <= 0 {
+		interval = defaultCertRenewalCheckInterval
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
@@ -833,7 +854,7 @@ func (s *Server) checkAndRenew() {
 		)
 	}
 
-	if err := RenewServerCert(s.stateDir, s.serverSANs, s.logger, s.stepCA); err != nil {
+	if err := RenewServerCert(s.stateDir, s.serverSANs, s.logger, s.stepCA, s.certValidity); err != nil {
 		s.logger.Error("cert renewal: failed to renew server certificate", "error", err)
 		return
 	}

--- a/internal/localserver/pki.go
+++ b/internal/localserver/pki.go
@@ -110,7 +110,7 @@ func LoadPKIMaterial(stateDir string) *PKIMaterial {
 // Step CA via the `step` CLI. The JWT keypair is still generated locally.
 //
 // If the CA bundle already exists, this is a no-op and returns existing paths.
-func EnsurePKI(stateDir string, serverSANs []string, logger *slog.Logger, stepCA *StepCAConfig) (*PKIMaterial, error) {
+func EnsurePKI(stateDir string, serverSANs []string, logger *slog.Logger, stepCA *StepCAConfig, certValidity time.Duration) (*PKIMaterial, error) {
 	mat := LoadPKIMaterial(stateDir)
 	certsDir := CertsDir(stateDir)
 
@@ -140,13 +140,13 @@ func EnsurePKI(stateDir string, serverSANs []string, logger *slog.Logger, stepCA
 	}
 
 	if stepCA != nil && stepCA.URL != "" {
-		return ensurePKIStepCA(stateDir, serverSANs, logger, stepCA, mat, certsDir)
+		return ensurePKIStepCA(stateDir, serverSANs, logger, stepCA, mat, certsDir, certValidity)
 	}
-	return ensurePKIAutoGen(stateDir, serverSANs, logger, mat, certsDir)
+	return ensurePKIAutoGen(stateDir, serverSANs, logger, mat, certsDir, certValidity)
 }
 
 // ensurePKIAutoGen generates a self-signed CA and all derived material.
-func ensurePKIAutoGen(stateDir string, serverSANs []string, logger *slog.Logger, mat *PKIMaterial, certsDir string) (*PKIMaterial, error) {
+func ensurePKIAutoGen(stateDir string, serverSANs []string, logger *slog.Logger, mat *PKIMaterial, certsDir string, certValidity time.Duration) (*PKIMaterial, error) {
 	logger.Info("generating PKI material", "dir", certsDir)
 
 	// 1. Generate CA.
@@ -165,7 +165,7 @@ func ensurePKIAutoGen(stateDir string, serverSANs []string, logger *slog.Logger,
 	}
 
 	// 2. Issue server certificate with SANs.
-	serverCert, serverKey, err := pki.IssueCert(caCert, caKey, pki.CertTypeServer, "server", serverSANs, certsDir)
+	serverCert, serverKey, err := pki.IssueCert(caCert, caKey, pki.CertTypeServer, "server", serverSANs, certsDir, certValidity)
 	if err != nil {
 		return nil, fmt.Errorf("issue server cert: %w", err)
 	}
@@ -174,7 +174,7 @@ func ensurePKIAutoGen(stateDir string, serverSANs []string, logger *slog.Logger,
 	logger.Info("generated server cert", "cert", serverCert, "sans", serverSANs)
 
 	// 3. Issue local-client certificate for CLI connections.
-	clientCert, clientKey, err := pki.IssueCert(caCert, caKey, pki.CertTypeClient, "local-client", nil, certsDir)
+	clientCert, clientKey, err := pki.IssueCert(caCert, caKey, pki.CertTypeClient, "local-client", nil, certsDir, 0)
 	if err != nil {
 		return nil, fmt.Errorf("issue local-client cert: %w", err)
 	}
@@ -208,7 +208,7 @@ func ensurePKIAutoGen(stateDir string, serverSANs []string, logger *slog.Logger,
 // ensurePKIStepCA uses the Step CA CLI to obtain a server certificate.
 // The Step CA root cert is copied to ca-bundle.crt; JWT material is generated
 // locally as in auto-PKI mode (tokens are still validated per-client).
-func ensurePKIStepCA(stateDir string, serverSANs []string, logger *slog.Logger, stepCA *StepCAConfig, mat *PKIMaterial, certsDir string) (*PKIMaterial, error) {
+func ensurePKIStepCA(stateDir string, serverSANs []string, logger *slog.Logger, stepCA *StepCAConfig, mat *PKIMaterial, certsDir string, certValidity time.Duration) (*PKIMaterial, error) {
 	logger.Info("using Step CA for PKI", "url", stepCA.URL)
 
 	// 1. Copy Step CA root cert to ca-bundle.crt so clients can verify the server.
@@ -284,7 +284,7 @@ func ensurePKIStepCA(stateDir string, serverSANs []string, logger *slog.Logger, 
 		return nil, fmt.Errorf("load local CA: %w", err)
 	}
 
-	clientCert, clientKey, err := pki.IssueCert(localCA, localKey, pki.CertTypeClient, "local-client", nil, certsDir)
+	clientCert, clientKey, err := pki.IssueCert(localCA, localKey, pki.CertTypeClient, "local-client", nil, certsDir, 0)
 	if err != nil {
 		return nil, fmt.Errorf("issue local-client cert: %w", err)
 	}
@@ -317,23 +317,23 @@ func ensurePKIStepCA(stateDir string, serverSANs []string, logger *slog.Logger, 
 // re-signs using the existing CA; for Step CA it requests a new cert from the
 // CA server. The new cert is written to the same file paths so the
 // CertReloader picks it up on the next TLS handshake without a server restart.
-func RenewServerCert(stateDir string, serverSANs []string, logger *slog.Logger, stepCA *StepCAConfig) error {
+func RenewServerCert(stateDir string, serverSANs []string, logger *slog.Logger, stepCA *StepCAConfig, certValidity time.Duration) error {
 	mat := LoadPKIMaterial(stateDir)
 
 	if stepCA != nil && stepCA.URL != "" {
 		return renewServerCertStepCA(mat, serverSANs, logger, stepCA)
 	}
-	return renewServerCertAutoGen(mat, serverSANs, logger)
+	return renewServerCertAutoGen(mat, serverSANs, logger, certValidity)
 }
 
-func renewServerCertAutoGen(mat *PKIMaterial, serverSANs []string, logger *slog.Logger) error {
+func renewServerCertAutoGen(mat *PKIMaterial, serverSANs []string, logger *slog.Logger, certValidity time.Duration) error {
 	caCert, caKey, err := pki.LoadCA(mat.CACertPath, mat.CAKeyPath)
 	if err != nil {
 		return fmt.Errorf("load CA: %w", err)
 	}
 
 	certsDir := filepath.Dir(mat.ServerCertPath)
-	_, _, err = pki.IssueCert(caCert, caKey, pki.CertTypeServer, "server", serverSANs, certsDir)
+	_, _, err = pki.IssueCert(caCert, caKey, pki.CertTypeServer, "server", serverSANs, certsDir, certValidity)
 	if err != nil {
 		return fmt.Errorf("re-issue server cert: %w", err)
 	}
@@ -383,7 +383,7 @@ func IssueClientCert(stateDir, clientName string, logger *slog.Logger) (certPath
 	}
 
 	outDir := filepath.Join(CertsDir(stateDir), "clients", clientName)
-	certPath, keyPath, err = pki.IssueCert(caCert, caKey, pki.CertTypeClient, clientName, nil, outDir)
+	certPath, keyPath, err = pki.IssueCert(caCert, caKey, pki.CertTypeClient, clientName, nil, outDir, 0)
 	if err != nil {
 		return "", "", fmt.Errorf("issue client cert: %w", err)
 	}

--- a/internal/localserver/pki_test.go
+++ b/internal/localserver/pki_test.go
@@ -48,7 +48,7 @@ func TestEnsurePKI(t *testing.T) {
 	stateDir := t.TempDir()
 	sans := []string{"10.0.0.1", "bridge.local"}
 
-	mat, err := EnsurePKI(stateDir, sans, testLogger(), nil)
+	mat, err := EnsurePKI(stateDir, sans, testLogger(), nil, 0)
 	require.NoError(t, err)
 
 	// Verify all files exist.
@@ -118,7 +118,7 @@ func TestEnsurePKI_Idempotent(t *testing.T) {
 	stateDir := t.TempDir()
 	sans := []string{"10.0.0.1"}
 
-	mat1, err := EnsurePKI(stateDir, sans, testLogger(), nil)
+	mat1, err := EnsurePKI(stateDir, sans, testLogger(), nil, 0)
 	require.NoError(t, err)
 
 	// Read the CA cert bytes from first run.
@@ -126,7 +126,7 @@ func TestEnsurePKI_Idempotent(t *testing.T) {
 	require.NoError(t, err)
 
 	// Second call should be a no-op.
-	mat2, err := EnsurePKI(stateDir, sans, testLogger(), nil)
+	mat2, err := EnsurePKI(stateDir, sans, testLogger(), nil, 0)
 	require.NoError(t, err)
 
 	// CA cert should be identical (not regenerated).
@@ -140,7 +140,7 @@ func TestIssueClientCert(t *testing.T) {
 	logger := testLogger()
 
 	// First generate the CA via EnsurePKI.
-	mat, err := EnsurePKI(stateDir, []string{"127.0.0.1"}, logger, nil)
+	mat, err := EnsurePKI(stateDir, []string{"127.0.0.1"}, logger, nil, 0)
 	require.NoError(t, err)
 
 	// Issue a client cert.
@@ -191,7 +191,7 @@ func TestIssueClientCert_RejectsPathTraversal(t *testing.T) {
 	logger := testLogger()
 
 	// Generate PKI first.
-	_, err := EnsurePKI(stateDir, []string{"127.0.0.1"}, logger, nil)
+	_, err := EnsurePKI(stateDir, []string{"127.0.0.1"}, logger, nil, 0)
 	require.NoError(t, err)
 
 	badNames := []string{"../escape", "foo/bar", ".hidden", "", "a b c"}
@@ -228,7 +228,7 @@ func TestEnsurePKI_StepCASkipsAutoGen(t *testing.T) {
 		URL:      "https://ca.example.internal:443",
 		RootPath: rootPEM,
 	}
-	_, err := EnsurePKI(stateDir, []string{"127.0.0.1"}, testLogger(), stepCfg)
+	_, err := EnsurePKI(stateDir, []string{"127.0.0.1"}, testLogger(), stepCfg, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Step CA")
 
@@ -243,7 +243,7 @@ func TestEnsurePKI_StepCASkipsAutoGen(t *testing.T) {
 func TestEnsurePKI_StepCAMissingRoot(t *testing.T) {
 	stateDir := t.TempDir()
 	stepCfg := &StepCAConfig{URL: "https://ca.example.internal:443"}
-	_, err := EnsurePKI(stateDir, []string{"127.0.0.1"}, testLogger(), stepCfg)
+	_, err := EnsurePKI(stateDir, []string{"127.0.0.1"}, testLogger(), stepCfg, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "step-ca-root")
 }
@@ -268,7 +268,7 @@ func TestEnsurePKI_StepCAHappyPath(t *testing.T) {
 		URL:      "https://ca.example.internal:443",
 		RootPath: rootPEM,
 	}
-	mat, err := EnsurePKI(stateDir, []string{"10.0.0.1"}, testLogger(), stepCfg)
+	mat, err := EnsurePKI(stateDir, []string{"10.0.0.1"}, testLogger(), stepCfg, 0)
 	require.NoError(t, err)
 
 	// ca-bundle.crt should start with the Step CA root, followed by the local CA.
@@ -313,13 +313,13 @@ func TestEnsurePKI_StepCAIdempotent(t *testing.T) {
 	t.Cleanup(func() { requestCertJWKFn = oldJWK })
 
 	stepCfg := &StepCAConfig{URL: "https://ca.example.internal:443", RootPath: rootPEM}
-	_, err := EnsurePKI(stateDir, []string{"10.0.0.1"}, testLogger(), stepCfg)
+	_, err := EnsurePKI(stateDir, []string{"10.0.0.1"}, testLogger(), stepCfg, 0)
 	require.NoError(t, err)
 
 	// Overwrite root file with different content.
 	require.NoError(t, os.WriteFile(rootPEM, []byte("changed-root"), 0o644))
 	// Second call should be no-op: bundle should still have the original content.
-	mat2, err := EnsurePKI(stateDir, []string{"10.0.0.1"}, testLogger(), stepCfg)
+	mat2, err := EnsurePKI(stateDir, []string{"10.0.0.1"}, testLogger(), stepCfg, 0)
 	require.NoError(t, err)
 	bundle, _ := os.ReadFile(mat2.CABundlePath)
 	assert.True(t, strings.HasPrefix(string(bundle), "fake-root-cert"), "bundle should start with original Step CA root, not overwritten")
@@ -573,7 +573,7 @@ func TestEnsurePKI_ACMEKeepsServerSAN(t *testing.T) {
 		RootPath:    rootPEM,
 		Provisioner: "acme",
 	}
-	_, err := EnsurePKI(stateDir, []string{"server", "localhost", "127.0.0.1", "bridge.local"}, testLogger(), stepCfg)
+	_, err := EnsurePKI(stateDir, []string{"server", "localhost", "127.0.0.1", "bridge.local"}, testLogger(), stepCfg, 0)
 	require.NoError(t, err)
 
 	assert.Contains(t, capturedSANs, "server", "ACME path must keep 'server' SAN for client TLS verification")
@@ -590,7 +590,7 @@ func TestEnsurePKI_ModeChangeTriggerRegeneration(t *testing.T) {
 	logger := testLogger()
 
 	// First call: auto-PKI.
-	_, err := EnsurePKI(stateDir, []string{"127.0.0.1"}, logger, nil)
+	_, err := EnsurePKI(stateDir, []string{"127.0.0.1"}, logger, nil, 0)
 	require.NoError(t, err)
 
 	// Capture the auto-PKI CA bundle content.
@@ -614,7 +614,7 @@ func TestEnsurePKI_ModeChangeTriggerRegeneration(t *testing.T) {
 	stepCfg := &StepCAConfig{URL: "https://ca.example.internal:443", RootPath: rootPEM}
 
 	// Second call: Step CA mode — must regenerate despite existing files.
-	mat, err := EnsurePKI(stateDir, []string{"127.0.0.1"}, logger, stepCfg)
+	mat, err := EnsurePKI(stateDir, []string{"127.0.0.1"}, logger, stepCfg, 0)
 	require.NoError(t, err)
 
 	bundle, err := os.ReadFile(mat.CABundlePath)

--- a/internal/localserver/stepca_native_test.go
+++ b/internal/localserver/stepca_native_test.go
@@ -59,7 +59,7 @@ func TestProvisionerRouting_ACME(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	// "server" must be kept because clients verify TLS with ServerName "server".
 	// Loopback entries ("localhost", "127.0.0.1") are still stripped.
-	mat, err := EnsurePKI(stateDir, []string{"server", "server.example.com"}, logger, stepCfg)
+	mat, err := EnsurePKI(stateDir, []string{"server", "server.example.com"}, logger, stepCfg, 0)
 	require.NoError(t, err)
 
 	assert.Contains(t, *acmeSANs, "server", "ACME must keep 'server' SAN for client TLS verification")
@@ -101,7 +101,7 @@ func TestProvisionerRouting_ACME_CaseInsensitive(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	_, err := EnsurePKI(stateDir, []string{"server"}, logger, stepCfg)
+	_, err := EnsurePKI(stateDir, []string{"server"}, logger, stepCfg, 0)
 	require.NoError(t, err)
 	assert.True(t, acmeCalled, "ACME function should have been called")
 }
@@ -141,7 +141,7 @@ func TestProvisionerRouting_JWK(t *testing.T) {
 			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 			// Pass "server" explicitly — JWK must NOT strip it (clients verify
 			// ServerName "server" against the issued cert).
-			_, err := EnsurePKI(stateDir, []string{"server", "my-host.example.com"}, logger, stepCfg)
+			_, err := EnsurePKI(stateDir, []string{"server", "my-host.example.com"}, logger, stepCfg, 0)
 			require.NoError(t, err)
 			assert.Contains(t, *jwkSANs, "server", "JWK must preserve 'server' SAN for client TLS verification")
 			assert.Contains(t, *jwkSANs, "my-host.example.com")

--- a/internal/pki/ca_test.go
+++ b/internal/pki/ca_test.go
@@ -42,7 +42,7 @@ func TestIssueCert(t *testing.T) {
 		t.Fatalf("LoadCA: %v", err)
 	}
 
-	certPath, _, err := IssueCert(caCert, caKey, CertTypeServer, "bridge.local", []string{"bridge.local", "127.0.0.1"}, dir)
+	certPath, _, err := IssueCert(caCert, caKey, CertTypeServer, "bridge.local", []string{"bridge.local", "127.0.0.1"}, dir, 0)
 	if err != nil {
 		t.Fatalf("IssueCert: %v", err)
 	}

--- a/internal/pki/issue.go
+++ b/internal/pki/issue.go
@@ -23,7 +23,8 @@ const (
 )
 
 // IssueCert generates a new ECDSA P-384 keypair and certificate signed by the given CA.
-func IssueCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, ct CertType, cn string, sans []string, outDir string) (certPath, keyPath string, err error) {
+// When validity is zero the default (90 days) is used.
+func IssueCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, ct CertType, cn string, sans []string, outDir string, validity time.Duration) (certPath, keyPath string, err error) {
 	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
 		return "", "", fmt.Errorf("generate key: %w", err)
@@ -34,6 +35,10 @@ func IssueCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, ct CertType, c
 		return "", "", err
 	}
 
+	if validity <= 0 {
+		validity = time.Duration(certValidityDays) * 24 * time.Hour
+	}
+
 	now := time.Now()
 	tmpl := &x509.Certificate{
 		SerialNumber: serial,
@@ -41,7 +46,7 @@ func IssueCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, ct CertType, c
 			CommonName: cn,
 		},
 		NotBefore: now,
-		NotAfter:  now.AddDate(0, 0, certValidityDays),
+		NotAfter:  now.Add(validity),
 	}
 
 	switch ct {

--- a/internal/pki/issue.go
+++ b/internal/pki/issue.go
@@ -23,7 +23,7 @@ const (
 )
 
 // IssueCert generates a new ECDSA P-384 keypair and certificate signed by the given CA.
-// When validity is zero the default (90 days) is used.
+// When validity is zero or negative the default (90 days) is used.
 func IssueCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, ct CertType, cn string, sans []string, outDir string, validity time.Duration) (certPath, keyPath string, err error) {
 	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {

--- a/pkg/bridgeclient/auth_additional_test.go
+++ b/pkg/bridgeclient/auth_additional_test.go
@@ -44,7 +44,7 @@ func TestJWTCredentialsAndTransportTLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadCA: %v", err)
 	}
-	clientCert, clientKey, err := pki.IssueCert(ca, key, pki.CertTypeClient, "client-a", nil, dir)
+	clientCert, clientKey, err := pki.IssueCert(ca, key, pki.CertTypeClient, "client-a", nil, dir, 0)
 	if err != nil {
 		t.Fatalf("IssueCert client: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Add `--cert-validity` and `--cert-renewal-check-interval` CLI flags to `bridgectl server start`
- Add corresponding YAML config fields (`server.cert_validity`, `server.cert_renewal_check_interval`)
- Thread configurable validity through `pki.IssueCert`, `EnsurePKI`, and `RenewServerCert`
- Defaults remain 90 days (cert validity) and 1 hour (renewal check interval)

Enables practical testing of certificate renewal flows without waiting for the 30-day renewal threshold of a 90-day cert. Example:

```bash
bridgectl server start --listen 10.0.0.1:9445   --cert-validity 30m   --cert-renewal-check-interval 10m
```

## Test coverage

| Package | Coverage |
|---------|----------|
| `internal/pki` | 64.6% |
| `internal/localserver` | 64.7% |
| `internal/config` | 76.2% |

## Test plan

- [x] All unit tests pass with `-race`
- [x] Pre-commit hooks pass (gofmt, goimports, golangci-lint)
- [x] `make fmt` clean
- [ ] CI passes
- [ ] Manual test: start server with `--cert-validity 30m --cert-renewal-check-interval 10m` and verify renewal triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)