### PR TITLE
Fix garbled output in session watch

### DIFF
--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -211,11 +211,12 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 	fd := int(os.Stdin.Fd())
 	isObserver := role == bridgev1.AttachRole_ATTACH_ROLE_OBSERVER && !takeOver
 	var restore func()
-	if !isObserver {
-		// Writers need raw mode for interactive input; observers do not.
-		if !term.IsTerminal(fd) {
-			return fmt.Errorf("stdin is not a terminal")
-		}
+	if term.IsTerminal(fd) {
+		// Raw mode is required for both writers and observers. Writers need
+		// it for interactive input. Observers need it so that the terminal's
+		// output post-processing (OPOST/ONLCR) does not corrupt ANSI escape
+		// sequences from the session PTY — without raw mode, every \n in the
+		// PTY stream gets an extra \r prepended, garbling TUI output.
 		oldState, err := term.MakeRaw(fd)
 		if err != nil {
 			return fmt.Errorf("set raw terminal: %w", err)
@@ -227,6 +228,8 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 			})
 		}
 		defer restore()
+	} else if !isObserver {
+		return fmt.Errorf("stdin is not a terminal")
 	} else {
 		restore = func() {}
 	}
@@ -316,6 +319,24 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 						ClientId:  stream.ClientID(),
 						Data:      buf[:n],
 					})
+				}
+				if readErr != nil {
+					return
+				}
+			}
+		}()
+	} else if term.IsTerminal(fd) {
+		// In raw mode ISIG is disabled, so the terminal won't generate
+		// SIGINT for Ctrl+C. Read stdin and handle it manually.
+		go func() {
+			buf := make([]byte, 256)
+			for {
+				n, readErr := os.Stdin.Read(buf)
+				for i := 0; i < n; i++ {
+					if buf[i] == 0x03 || buf[i] == detachKey { // Ctrl+C or Ctrl+]
+						cancel()
+						return
+					}
 				}
 				if readErr != nil {
 					return

--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -212,11 +212,12 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 	isObserver := role == bridgev1.AttachRole_ATTACH_ROLE_OBSERVER && !takeOver
 	var restore func()
 	if term.IsTerminal(fd) {
-		// Raw mode is required for both writers and observers. Writers need
-		// it for interactive input. Observers need it so that the terminal's
-		// output post-processing (OPOST/ONLCR) does not corrupt ANSI escape
-		// sequences from the session PTY — without raw mode, every \n in the
-		// PTY stream gets an extra \r prepended, garbling TUI output.
+		// When stdin is a TTY, enable raw mode for both writers and observers.
+		// Writers need it for interactive input. Observers need it so that
+		// the terminal's output post-processing (OPOST/ONLCR) does not
+		// corrupt ANSI escape sequences from the session PTY — without raw
+		// mode, every \n in the PTY stream gets an extra \r prepended,
+		// garbling TUI output. Non-TTY observers skip raw mode entirely.
 		oldState, err := term.MakeRaw(fd)
 		if err != nil {
 			return fmt.Errorf("set raw terminal: %w", err)
@@ -334,6 +335,7 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 				n, readErr := os.Stdin.Read(buf)
 				for i := 0; i < n; i++ {
 					if buf[i] == 0x03 || buf[i] == detachKey { // Ctrl+C or Ctrl+]
+						detached.Store(true)
 						cancel()
 						return
 					}


### PR DESCRIPTION
## Summary

- **Root cause**: session watch (and attach --observe) did not enable raw terminal mode, so the kernel OPOST/ONLCR output post-processing converted every newline in the PTY stream to CR+NL. Since the session PTY already produced CR+NL, observers saw CR+CR+NL, corrupting ANSI escape sequences and garbling TUI output from agents like Claude Code.
- **Fix**: Enable term.MakeRaw for observers (writers already had it). Add a stdin reader goroutine for observers so Ctrl-C and Ctrl-] still work in raw mode (ISIG is disabled). Non-TTY observers (piped stdin) continue to work without raw mode.
- session attach was unaffected because writers already used raw mode.

## Test plan

- [x] make fmt passes
- [x] make test passes (pre-existing localserver port-conflict failures only)
- [x] Pre-commit hooks (gofmt, goimports, golangci-lint) all pass
- [ ] Manual: bridgectl session watch on a running Claude Code session renders cleanly
- [ ] Manual: Ctrl-C exits the watch session
- [ ] Manual: Ctrl-] exits the watch session
- [ ] Manual: piped stdin (echo test | bridgectl session watch) still works

Generated with [Claude Code](https://claude.com/claude-code)