### PR TITLE
Add startup Step CA client registry

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -241,7 +241,7 @@ Acceptance criteria:
 
 - `step_ca.clients` entries identify a JWT `issuer` and an optional `key_path` for that issuer's Ed25519 public key.
 - If `key_path` is omitted, the server checks `certs/jwt-clients/<issuer>.pub` under the bridge state directory.
-- Missing optional client public keys are logged and skipped so servers can start before every client has enrolled.
+- Optional client public keys that are missing, unreadable, or invalid are logged and skipped so servers can start before every client has enrolled.
 - Entries marked `required: true` fail startup if their public key is missing or invalid.
 - Startup-loaded client keys are added to the same JWT verifier used by normal RPC authentication.
 - Step CA certificate trust does not replace JWT trust; every configured client still needs a bridge JWT public key.

--- a/PRD.md
+++ b/PRD.md
@@ -233,6 +233,19 @@ ai-agent-bridge-ca (root)
 - Certificate rotation: certs expire after 90 days; automated renewal via `ai-agent-bridge-ca renew`.
 - Revocation: CRL distribution point served by bridge daemon.
 
+#### Startup Client Registry
+
+When a bridge server is configured for Step CA-backed remote access, operators may declare known client issuers in the YAML config so the server attempts to trust their JWT public keys during startup.
+
+Acceptance criteria:
+
+- `step_ca.clients` entries identify a JWT `issuer` and an optional `key_path` for that issuer's Ed25519 public key.
+- If `key_path` is omitted, the server checks `certs/jwt-clients/<issuer>.pub` under the bridge state directory.
+- Missing optional client public keys are logged and skipped so servers can start before every client has enrolled.
+- Entries marked `required: true` fail startup if their public key is missing or invalid.
+- Startup-loaded client keys are added to the same JWT verifier used by normal RPC authentication.
+- Step CA certificate trust does not replace JWT trust; every configured client still needs a bridge JWT public key.
+
 ### 7.5 Defense in Depth
 
 - Bridge binds to configurable interface (default: private/localhost).

--- a/config/bridge-smoke.yaml
+++ b/config/bridge-smoke.yaml
@@ -1,6 +1,12 @@
 server:
   listen: "0.0.0.0:9445"
 
+step_ca:
+  clients:
+    - issuer: "smoke-step-client"
+      key_path: "/run/bridge-certs/jwt-signing.pub"
+      required: true
+
 tls:
   ca_bundle: "/run/bridge-certs/ca-bundle.crt"
   cert: "/run/bridge-certs/bridge.local.crt"

--- a/docs/service.md
+++ b/docs/service.md
@@ -115,6 +115,15 @@ auth:
   jwt_audience: "bridge"
   jwt_max_ttl:  "5m"
 
+step_ca:
+  url: "https://step-ca.example.internal"
+  root: "certs/step-ca-root.crt"
+  clients:
+    - issuer: "laptop-a"
+      key_path: "certs/jwt-clients/laptop-a.pub"
+    - issuer: "build-runner"
+      required: true
+
 sessions:
   max_per_project:   5
   max_global:        20
@@ -173,6 +182,19 @@ logging:
 | `jwt_public_keys` | List of `{issuer, key_path}` entries. Multiple issuers are supported for key rotation. |
 | `jwt_audience` | Required `aud` claim value |
 | `jwt_max_ttl` | Maximum accepted token lifetime |
+
+#### `step_ca`
+| Field | Description |
+|-------|-------------|
+| `url` | Step CA URL used by server certificate issuance and renewal flows |
+| `root` | Step CA root certificate used for Step CA requests |
+| `provisioner` | Optional Step CA provisioner name |
+| `provisioner_password_file` | Optional file containing a JWK provisioner password for non-interactive issuance |
+| `clients` | Optional startup client registry. Each entry declares an `issuer`, optional `key_path`, and optional `required` flag. |
+
+`step_ca.clients` is for known clients whose mTLS certificates are issued by Step CA but whose bridge JWT public keys are already present on the server. The server loads these JWT public keys during secure startup. If `key_path` is omitted, the server checks `certs/jwt-clients/<issuer>.pub` under the bridge state directory. Missing optional entries are logged and skipped; entries with `required: true` fail startup if the public key is missing or invalid.
+
+Step CA certificate trust and bridge JWT trust are separate. A Step CA-issued client certificate can satisfy mTLS, but the client still needs a configured or enrolled Ed25519 JWT public key before it can call authenticated RPCs.
 
 #### `feature_flags`
 | Field | Default | Description |

--- a/docs/service.md
+++ b/docs/service.md
@@ -192,7 +192,7 @@ logging:
 | `provisioner_password_file` | Optional file containing a JWK provisioner password for non-interactive issuance |
 | `clients` | Optional startup client registry. Each entry declares an `issuer`, optional `key_path`, and optional `required` flag. |
 
-`step_ca.clients` is for known clients whose mTLS certificates are issued by Step CA but whose bridge JWT public keys are already present on the server. The server loads these JWT public keys during secure startup. If `key_path` is omitted, the server checks `certs/jwt-clients/<issuer>.pub` under the bridge state directory. Missing optional entries are logged and skipped; entries with `required: true` fail startup if the public key is missing or invalid.
+`step_ca.clients` is for known clients whose mTLS certificates are issued by Step CA but whose bridge JWT public keys are already present on the server. The server loads these JWT public keys during secure startup. If `key_path` is omitted, the server checks `certs/jwt-clients/<issuer>.pub` under the bridge state directory. Optional entries whose keys are missing, unreadable, or invalid are logged and skipped; entries with `required: true` fail startup if the public key is missing or invalid.
 
 Step CA certificate trust and bridge JWT trust are separate. A Step CA-issued client certificate can satisfy mTLS, but the client still needs a configured or enrolled Ed25519 JWT public key before it can call authenticated RPCs.
 

--- a/e2e/cmd/smoke/main.go
+++ b/e2e/cmd/smoke/main.go
@@ -18,6 +18,7 @@ func main() {
 	cert := flag.String("cert", "", "client cert path")
 	key := flag.String("key", "", "client key path")
 	jwtKey := flag.String("jwt-key", "", "JWT signing key path")
+	issuer := flag.String("issuer", "dev", "JWT issuer")
 	timeout := flag.Duration("timeout", 90*time.Second, "overall timeout")
 	flag.Parse()
 
@@ -32,7 +33,7 @@ func main() {
 		}),
 		bridgeclient.WithJWT(bridgeclient.JWTConfig{
 			PrivateKeyPath: *jwtKey,
-			Issuer:         "dev",
+			Issuer:         *issuer,
 			Audience:       "bridge",
 		}),
 	)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,10 +45,19 @@ type ServerConfig struct {
 
 // StepCAYAMLConfig holds Step CA settings from the YAML config file.
 type StepCAYAMLConfig struct {
-	URL                     string `yaml:"url"`
-	Root                    string `yaml:"root"`
-	Provisioner             string `yaml:"provisioner"`
-	ProvisionerPasswordFile string `yaml:"provisioner_password_file"`
+	URL                     string               `yaml:"url"`
+	Root                    string               `yaml:"root"`
+	Provisioner             string               `yaml:"provisioner"`
+	ProvisionerPasswordFile string               `yaml:"provisioner_password_file"`
+	Clients                 []StepCAClientConfig `yaml:"clients"`
+}
+
+// StepCAClientConfig declares a Step CA-authenticated client whose bridge JWT
+// public key should be loaded at startup when available.
+type StepCAClientConfig struct {
+	Issuer   string `yaml:"issuer"`
+	KeyPath  string `yaml:"key_path"`
+	Required bool   `yaml:"required"`
 }
 
 type TLSConfig struct {
@@ -277,6 +286,11 @@ func validate(cfg *Config) error {
 			return fmt.Errorf("config: server.cert_renewal_check_interval must not be negative")
 		}
 	}
+	for i, client := range cfg.StepCA.Clients {
+		if !safeIssuerName(client.Issuer) {
+			return fmt.Errorf("config: step_ca.clients[%d].issuer must be alphanumeric with hyphens, underscores, or dots", i)
+		}
+	}
 	if _, err := time.ParseDuration(cfg.Sessions.IdleTimeout); err != nil {
 		return fmt.Errorf("config: sessions.idle_timeout: %w", err)
 	}
@@ -326,4 +340,24 @@ func validate(cfg *Config) error {
 		}
 	}
 	return nil
+}
+
+func safeIssuerName(issuer string) bool {
+	if issuer == "" {
+		return false
+	}
+	for i, r := range issuer {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return false
+		}
+		if i == 0 && (r == '-' || r == '_' || r == '.') {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -288,7 +288,7 @@ func validate(cfg *Config) error {
 	}
 	for i, client := range cfg.StepCA.Clients {
 		if !safeIssuerName(client.Issuer) {
-			return fmt.Errorf("config: step_ca.clients[%d].issuer must be alphanumeric with hyphens, underscores, or dots", i)
+			return fmt.Errorf("config: step_ca.clients[%d].issuer must start with an alphanumeric character and contain only alphanumerics, hyphens, underscores, or dots", i)
 		}
 	}
 	if _, err := time.ParseDuration(cfg.Sessions.IdleTimeout); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -250,6 +250,72 @@ sessions:
 	}
 }
 
+func TestLoadStepCAClients(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bridge.yaml")
+	content := `
+server:
+  listen: "127.0.0.1:9445"
+step_ca:
+  url: "https://step-ca.example.internal"
+  root: "/etc/bridge/step-root.crt"
+  clients:
+    - issuer: "do-dev2"
+      key_path: "/etc/bridge/jwt-clients/do-dev2.pub"
+    - issuer: "laptop-a"
+      required: true
+providers:
+  echo:
+    binary: "cat"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := len(cfg.StepCA.Clients); got != 2 {
+		t.Fatalf("len(StepCA.Clients)=%d want 2", got)
+	}
+	if cfg.StepCA.Clients[0].Issuer != "do-dev2" {
+		t.Fatalf("first issuer=%q want do-dev2", cfg.StepCA.Clients[0].Issuer)
+	}
+	if cfg.StepCA.Clients[0].KeyPath != "/etc/bridge/jwt-clients/do-dev2.pub" {
+		t.Fatalf("first key_path=%q", cfg.StepCA.Clients[0].KeyPath)
+	}
+	if !cfg.StepCA.Clients[1].Required {
+		t.Fatal("second client should be required")
+	}
+}
+
+func TestLoadStepCAClientsValidateIssuer(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bridge.yaml")
+	content := `
+server:
+  listen: "127.0.0.1:9445"
+step_ca:
+  clients:
+    - issuer: "../bad"
+providers:
+  echo:
+    binary: "cat"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "step_ca.clients[0].issuer") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadRejectsDeprecatedPTYField(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bridge.yaml")

--- a/internal/localserver/jwt_clients.go
+++ b/internal/localserver/jwt_clients.go
@@ -2,10 +2,8 @@ package localserver
 
 import (
 	"crypto/ed25519"
-	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
 
 	"github.com/markcallen/ai-agent-bridge/internal/auth"
@@ -31,9 +29,9 @@ func loadConfiguredJWTClients(verifier *auth.JWTVerifier, stateDir string, logge
 		}
 		pub, err := pki.LoadEd25519PublicKey(keyPath)
 		if err != nil {
-			if !client.Required && errors.Is(err, os.ErrNotExist) {
+			if !client.Required {
 				if logger != nil {
-					logger.Warn("configured Step CA client JWT key not available", "issuer", client.Issuer, "path", keyPath)
+					logger.Warn("configured Step CA client JWT key not available", "issuer", client.Issuer, "path", keyPath, "error", err)
 				}
 				continue
 			}

--- a/internal/localserver/jwt_clients.go
+++ b/internal/localserver/jwt_clients.go
@@ -1,0 +1,48 @@
+package localserver
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/markcallen/ai-agent-bridge/internal/auth"
+	"github.com/markcallen/ai-agent-bridge/internal/pki"
+)
+
+// ConfiguredJWTClient declares a client JWT public key that should be loaded
+// during secure startup when present.
+type ConfiguredJWTClient struct {
+	Issuer   string
+	KeyPath  string
+	Required bool
+}
+
+func loadConfiguredJWTClients(verifier *auth.JWTVerifier, stateDir string, logger *slog.Logger, clients []ConfiguredJWTClient) error {
+	if verifier == nil || len(clients) == 0 {
+		return nil
+	}
+	for _, client := range clients {
+		keyPath := client.KeyPath
+		if keyPath == "" {
+			keyPath = filepath.Join(CertsDir(stateDir), "jwt-clients", client.Issuer+".pub")
+		}
+		pub, err := pki.LoadEd25519PublicKey(keyPath)
+		if err != nil {
+			if !client.Required && errors.Is(err, os.ErrNotExist) {
+				if logger != nil {
+					logger.Warn("configured Step CA client JWT key not available", "issuer", client.Issuer, "path", keyPath)
+				}
+				continue
+			}
+			return fmt.Errorf("load configured Step CA client JWT key for issuer %q: %w", client.Issuer, err)
+		}
+		verifier.AddKey(client.Issuer, ed25519.PublicKey(pub))
+		if logger != nil {
+			logger.Info("loaded configured Step CA client JWT key", "issuer", client.Issuer, "path", keyPath)
+		}
+	}
+	return nil
+}

--- a/internal/localserver/jwt_clients_test.go
+++ b/internal/localserver/jwt_clients_test.go
@@ -79,6 +79,24 @@ func TestLoadConfiguredJWTClientsRequiredMissing(t *testing.T) {
 	require.Contains(t, err.Error(), "required-client")
 }
 
+func TestLoadConfiguredJWTClientsOptionalInvalid(t *testing.T) {
+	stateDir := t.TempDir()
+	keyPath := filepath.Join(stateDir, "invalid.pub")
+	require.NoError(t, os.WriteFile(keyPath, []byte("not a public key"), 0o644))
+
+	verifier := &auth.JWTVerifier{
+		Keys:     map[string]ed25519.PublicKey{},
+		Audience: "bridge",
+		MaxTTL:   10 * time.Minute,
+	}
+
+	err := loadConfiguredJWTClients(verifier, stateDir, testLogger(), []ConfiguredJWTClient{
+		{Issuer: "invalid-optional", KeyPath: keyPath},
+	})
+	require.NoError(t, err)
+	require.False(t, verifier.HasKey("invalid-optional"))
+}
+
 func TestBuildSecureGRPCOptsLoadsConfiguredJWTClients(t *testing.T) {
 	stateDir := t.TempDir()
 	logger := testLogger()

--- a/internal/localserver/jwt_clients_test.go
+++ b/internal/localserver/jwt_clients_test.go
@@ -1,0 +1,96 @@
+package localserver
+
+import (
+	"crypto/ed25519"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/markcallen/ai-agent-bridge/internal/auth"
+	"github.com/markcallen/ai-agent-bridge/internal/pki"
+	"github.com/stretchr/testify/require"
+)
+
+func writeTestJWTPubKey(t *testing.T, path string) ed25519.PublicKey {
+	t.Helper()
+	pubPath, _, err := pki.GenerateJWTKeypair(filepath.Dir(path), "generated")
+	require.NoError(t, err)
+	data, err := os.ReadFile(pubPath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+	pub, err := pki.LoadEd25519PublicKey(path)
+	require.NoError(t, err)
+	return pub
+}
+
+func TestLoadConfiguredJWTClients(t *testing.T) {
+	stateDir := t.TempDir()
+	keyPath := filepath.Join(stateDir, "custom", "do-dev2.pub")
+	require.NoError(t, os.MkdirAll(filepath.Dir(keyPath), 0o700))
+	writeTestJWTPubKey(t, keyPath)
+
+	verifier := &auth.JWTVerifier{
+		Keys:     map[string]ed25519.PublicKey{},
+		Audience: "bridge",
+		MaxTTL:   10 * time.Minute,
+	}
+
+	err := loadConfiguredJWTClients(verifier, stateDir, testLogger(), []ConfiguredJWTClient{
+		{Issuer: "do-dev2", KeyPath: keyPath},
+		{Issuer: "missing-optional"},
+	})
+	require.NoError(t, err)
+	require.True(t, verifier.HasKey("do-dev2"))
+	require.False(t, verifier.HasKey("missing-optional"))
+}
+
+func TestLoadConfiguredJWTClientsDefaultPath(t *testing.T) {
+	stateDir := t.TempDir()
+	defaultPath := filepath.Join(CertsDir(stateDir), "jwt-clients", "laptop-a.pub")
+	require.NoError(t, os.MkdirAll(filepath.Dir(defaultPath), 0o700))
+	writeTestJWTPubKey(t, defaultPath)
+
+	verifier := &auth.JWTVerifier{
+		Keys:     map[string]ed25519.PublicKey{},
+		Audience: "bridge",
+		MaxTTL:   10 * time.Minute,
+	}
+
+	err := loadConfiguredJWTClients(verifier, stateDir, testLogger(), []ConfiguredJWTClient{
+		{Issuer: "laptop-a"},
+	})
+	require.NoError(t, err)
+	require.True(t, verifier.HasKey("laptop-a"))
+}
+
+func TestLoadConfiguredJWTClientsRequiredMissing(t *testing.T) {
+	stateDir := t.TempDir()
+	verifier := &auth.JWTVerifier{
+		Keys:     map[string]ed25519.PublicKey{},
+		Audience: "bridge",
+		MaxTTL:   10 * time.Minute,
+	}
+
+	err := loadConfiguredJWTClients(verifier, stateDir, testLogger(), []ConfiguredJWTClient{
+		{Issuer: "required-client", Required: true},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "required-client")
+}
+
+func TestBuildSecureGRPCOptsLoadsConfiguredJWTClients(t *testing.T) {
+	stateDir := t.TempDir()
+	logger := testLogger()
+	mat, err := EnsurePKI(stateDir, []string{"server", "127.0.0.1"}, logger, nil, 0)
+	require.NoError(t, err)
+
+	keyPath := filepath.Join(stateDir, "configured.pub")
+	writeTestJWTPubKey(t, keyPath)
+
+	_, verifier, err := buildSecureGRPCOpts(mat, stateDir, logger, nil, []ConfiguredJWTClient{
+		{Issuer: "configured-client", KeyPath: keyPath},
+	})
+	require.NoError(t, err)
+	require.True(t, verifier.HasKey("configured-client"))
+}

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -179,6 +179,10 @@ type Config struct {
 	// verification in explicit-cert mode. Populated from auth.jwt_public_keys
 	// in the config file.
 	JWTPublicKeys map[string]string
+	// StepCAClients declares Step CA-authenticated clients whose JWT public
+	// keys should be loaded at startup if present. Missing optional clients are
+	// logged and skipped; missing required clients fail secure startup.
+	StepCAClients []ConfiguredJWTClient
 
 	// StepCAURL enables Step CA integration. When set, auto-PKI generation is
 	// skipped and server certificates are obtained from the Step CA instance
@@ -271,6 +275,16 @@ func Start(cfg Config) (*Server, error) {
 				cfg.JWTPublicKeys = make(map[string]string, len(fileCfg.Auth.JWTPublicKeys))
 				for _, k := range fileCfg.Auth.JWTPublicKeys {
 					cfg.JWTPublicKeys[k.Issuer] = k.KeyPath
+				}
+			}
+			if cfg.StepCAClients == nil && len(fileCfg.StepCA.Clients) > 0 {
+				cfg.StepCAClients = make([]ConfiguredJWTClient, 0, len(fileCfg.StepCA.Clients))
+				for _, c := range fileCfg.StepCA.Clients {
+					cfg.StepCAClients = append(cfg.StepCAClients, ConfiguredJWTClient{
+						Issuer:   c.Issuer,
+						KeyPath:  c.KeyPath,
+						Required: c.Required,
+					})
 				}
 			}
 			if len(cfg.ServerSANs) == 0 && len(fileCfg.Server.SANs) > 0 {
@@ -523,7 +537,7 @@ func Start(cfg Config) (*Server, error) {
 		}
 		pkiMat = mat
 
-		secureOpts, verifier, err := buildSecureGRPCOpts(mat, stateDir, logger, cfg.JWTPublicKeys)
+		secureOpts, verifier, err := buildSecureGRPCOpts(mat, stateDir, logger, cfg.JWTPublicKeys, cfg.StepCAClients)
 		if err != nil {
 			sup.Close()
 			if store != nil {
@@ -630,7 +644,7 @@ func Start(cfg Config) (*Server, error) {
 // buildSecureGRPCOpts returns gRPC server options for mTLS + JWT mode.
 // extraKeys maps issuer name to public key file path for JWT verification
 // when using pre-issued certificates instead of auto-PKI.
-func buildSecureGRPCOpts(mat *PKIMaterial, stateDir string, logger *slog.Logger, extraKeys map[string]string) ([]grpc.ServerOption, *auth.JWTVerifier, error) {
+func buildSecureGRPCOpts(mat *PKIMaterial, stateDir string, logger *slog.Logger, extraKeys map[string]string, stepCAClients []ConfiguredJWTClient) ([]grpc.ServerOption, *auth.JWTVerifier, error) {
 	// TLS credentials with client cert verification.
 	tlsCfg, err := auth.ServerTLSConfig(auth.TLSConfig{
 		CABundlePath: mat.CABundlePath,
@@ -683,6 +697,9 @@ func buildSecureGRPCOpts(mat *PKIMaterial, stateDir string, logger *slog.Logger,
 		Keys:     keys,
 		Audience: "bridge",
 		MaxTTL:   10 * time.Minute,
+	}
+	if err := loadConfiguredJWTClients(verifier, stateDir, logger, stepCAClients); err != nil {
+		return nil, nil, err
 	}
 
 	return []grpc.ServerOption{

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -19,4 +19,5 @@ go run ./e2e/cmd/smoke \
   -cacert certs/ca-bundle.crt \
   -cert certs/dev-client.crt \
   -key certs/dev-client.key \
-  -jwt-key certs/jwt-signing.key
+  -jwt-key certs/jwt-signing.key \
+  -issuer smoke-step-client

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -105,6 +105,7 @@ Evidence:
 - `go test ./...`
 - `GOCACHE=/home/marka/.cache/go-build GOMODCACHE=/home/marka/go/pkg/mod scripts/check-go-coverage.sh` -> coverage 78.3%, threshold 75.0%.
 - `make smoke` -> passed using `-issuer smoke-step-client`, which is loaded from `step_ca.clients` in `config/bridge-smoke.yaml`.
+- Copilot review comments addressed: optional configured clients now skip any key load error unless `required: true`; issuer validation error text now mentions the leading alphanumeric requirement.
 
 Note:
 - `scripts/test-go-coverage.sh` initially failed under sandboxed `/tmp` caches due blocked module downloads, then failed under elevated network because the filesystem was full. The maintained coverage gate passed after pruning Docker build cache and using existing home Go caches.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -75,3 +75,36 @@
 
 - [ ] **GoReleaser Windows target**: `.goreleaser.yaml` includes `windows` for the CLI but `internal/provider/stdio.go` uses Unix-only APIs (`syscall.Kill`, `creack/pty`). Either add Windows build tags to the provider package or remove the Windows release target. (Pre-existing on parent branch.)
 - [ ] **Docker E2E cleanup trap**: `scripts/test-cli-e2e-docker.sh` doesn't install a trap for Ctrl-C — compose stack can be left behind on interrupt.
+# Startup Step CA Client Registry
+
+Mode: Approval-Required, approved by user request on 2026-08-09.
+
+Governing PRD section: `7.3 Authentication Layers` and `7.4 Key Management`.
+
+Scope:
+- Add startup configuration for Step CA-backed client issuers whose JWT public keys may already be present on the server.
+- Keep mTLS trust and JWT trust separate; Step CA verifies client certificates, bridge config loads JWT public keys.
+- Preserve existing `auth.jwt_public_keys` behavior for required explicit keys.
+- Add tests, documentation, and smoke coverage.
+
+Plan:
+- [x] Update PRD with startup client registry acceptance criteria.
+- [x] Add config parsing and validation tests for `step_ca.clients`.
+- [x] Add startup key-loading tests for optional and required clients.
+- [x] Implement config and server startup loading.
+- [x] Document the operator workflow.
+- [x] Extend smoke coverage.
+- [x] Run formatting, unit tests, coverage, smoke tests.
+- [x] Open PR and assign Copilot.
+
+Rollback:
+- Remove `step_ca.clients` entries from config. Existing `auth.jwt_public_keys` and `certs/jwt-clients/*.pub` startup loading continue to work.
+
+Evidence:
+- `go test ./internal/config ./internal/localserver ./e2e/cmd/smoke`
+- `go test ./...`
+- `GOCACHE=/home/marka/.cache/go-build GOMODCACHE=/home/marka/go/pkg/mod scripts/check-go-coverage.sh` -> coverage 78.3%, threshold 75.0%.
+- `make smoke` -> passed using `-issuer smoke-step-client`, which is loaded from `step_ca.clients` in `config/bridge-smoke.yaml`.
+
+Note:
+- `scripts/test-go-coverage.sh` initially failed under sandboxed `/tmp` caches due blocked module downloads, then failed under elevated network because the filesystem was full. The maintained coverage gate passed after pruning Docker build cache and using existing home Go caches.


### PR DESCRIPTION
## Summary
- add step_ca.clients config for startup loading of existing client JWT public keys
- load optional configured clients when keys are available, fail startup for required missing or invalid keys
- document the operator workflow and extend smoke coverage to authenticate with a configured Step CA client issuer

## Tests
- go test ./internal/config ./internal/localserver ./e2e/cmd/smoke
- go test ./...
- GOCACHE=/home/marka/.cache/go-build GOMODCACHE=/home/marka/go/pkg/mod scripts/check-go-coverage.sh -> 78.3% coverage, threshold 75.0%
- make smoke

## Config / operational impact
- new optional step_ca.clients entries accept issuer, optional key_path, and optional required
- default key path is certs/jwt-clients/<issuer>.pub under the server state directory
- optional missing client keys warn and skip; required missing or invalid keys fail secure startup
- Step CA certificate trust remains separate from bridge JWT trust