### PR TITLE
Fix bridgectl remote config discovery

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -136,6 +136,12 @@ The bridge runs as the login user inside an interactive or graphical session. Th
 
 **Remote access model**: when `--listen` is set, the server binds to the specified TCP address and generates PKI material in `~/.ai-agent-bridge/certs/` on first start. SDK clients authenticate with mTLS + JWT. Human operators authenticate using OIDC via `bridgectl server issue-client --oidc` (see Security Architecture). The server must be reachable via WireGuard or Tailscale; it must not be exposed to the public internet.
 
+Remote operator CLI acceptance criteria:
+- `bridgectl session` remote subcommands allow operators to override the TLS server name when a bridge server certificate is issued for a DNS name that differs from the dial address.
+- Remote credential discovery prefers the current host's client certificate before falling back to other client certificates in the cert directory.
+- `bridgectl server start` auto-loads the first available per-user config from `~/.ai-agent-bridge/bridge.yaml` or `$XDG_CONFIG_HOME/bridgectl/config.yaml` when `--config` is omitted, so local and remote operator commands target the same configured daemon.
+- `bridgectl client renew` handles Step CA deployments where the HTTPS serving certificate chain differs from the Step CA root used for bridge certificate issuance, while rejecting expired client certificates before attempting renewal.
+
 **Session persistence**: with `--db-path`, the server writes session metadata and PTY output chunks to a BoltDB file. On restart, `LoadHistory()` rehydrates sessions so SDK clients can reconnect and replay events they missed.
 
 #### Human Interjection

--- a/cmd/bridgectl/client.go
+++ b/cmd/bridgectl/client.go
@@ -5,7 +5,9 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -28,12 +30,13 @@ func newClientCmd() *cobra.Command {
 
 func newClientEnrollCmd() *cobra.Command {
 	var (
-		target   string
-		caBundle string
-		cert     string
-		key      string
-		name     string
-		outDir   string
+		target     string
+		caBundle   string
+		cert       string
+		key        string
+		name       string
+		outDir     string
+		serverName string
 	)
 
 	cmd := &cobra.Command{
@@ -72,6 +75,9 @@ with a cert signed by the server's trusted CA can enroll.`,
 			if outDir == "" {
 				outDir = "."
 			}
+			if serverName == "" {
+				serverName = defaultServerNameFromTarget(target)
+			}
 
 			// Generate JWT keypair locally.
 			pubPath, privPath, err := pki.GenerateJWTKeypair(outDir, "jwt-signing")
@@ -93,15 +99,13 @@ with a cert signed by the server's trusted CA can enroll.`,
 			}
 
 			// Connect with mTLS only (no JWT — we're enrolling to get JWT auth).
-			// ServerName "server" matches the SAN that buildServerSANs always
-			// adds to every bridge server cert regardless of PKI mode.
 			client, err := bridgeclient.New(
 				bridgeclient.WithTarget(target),
 				bridgeclient.WithMTLS(bridgeclient.MTLSConfig{
 					CABundlePath: caBundle,
 					CertPath:     cert,
 					KeyPath:      key,
-					ServerName:   "server",
+					ServerName:   serverName,
 				}),
 				bridgeclient.WithTimeout(10*time.Second),
 			)
@@ -130,7 +134,7 @@ with a cert signed by the server's trusted CA can enroll.`,
 			fmt.Printf("      CABundlePath: %q,\n", caBundle)
 			fmt.Printf("      CertPath:     %q,\n", cert)
 			fmt.Printf("      KeyPath:      %q,\n", key)
-			fmt.Printf("      ServerName:   \"server\",\n")
+			fmt.Printf("      ServerName:   %q,\n", serverName)
 			fmt.Printf("    }),\n")
 			fmt.Printf("    bridgeclient.WithJWT(bridgeclient.JWTConfig{\n")
 			fmt.Printf("      PrivateKeyPath: %q,\n", privPath)
@@ -153,8 +157,23 @@ with a cert signed by the server's trusted CA can enroll.`,
 	_ = cmd.MarkFlagRequired("key")
 	cmd.Flags().StringVar(&name, "name", "", "issuer name for JWT tokens (defaults to cert CN)")
 	cmd.Flags().StringVar(&outDir, "out", "", "output directory for JWT keypair (defaults to current directory)")
+	cmd.Flags().StringVar(&serverName, "server-name", "", "TLS server name to verify (defaults to host from --target)")
 
 	return cmd
+}
+
+func defaultServerNameFromTarget(target string) string {
+	if strings.HasPrefix(target, "unix://") {
+		return "server"
+	}
+	host, _, err := net.SplitHostPort(target)
+	if err == nil {
+		return strings.Trim(host, "[]")
+	}
+	if strings.Contains(target, ":") && !strings.Contains(target, "://") {
+		return "server"
+	}
+	return target
 }
 
 // extractCN reads a PEM certificate file and returns its Common Name.

--- a/cmd/bridgectl/client_renew.go
+++ b/cmd/bridgectl/client_renew.go
@@ -1,17 +1,34 @@
 package main
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
 
+	ca "github.com/smallstep/certificates/ca"
 	"github.com/spf13/cobra"
+	"go.step.sm/crypto/jose"
 
 	"github.com/markcallen/ai-agent-bridge/internal/localserver"
+)
+
+type renewMode int
+
+const (
+	renewModeStepCLI renewMode = iota
+	renewModeNativeInsecureTLS
 )
 
 func newClientRenewCmd() *cobra.Command {
@@ -37,7 +54,7 @@ making this safe to call from a cron job or systemd timer:
 
   bridgectl client renew --step-ca-url https://step-ca.example.com --before 2h`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runClientRenew(stepCAURL, rootPath, certPath, keyPath, before)
+			return runClientRenew(stepCAURL, rootPath, cmd.Flags().Changed("step-ca-root"), certPath, keyPath, before)
 		},
 	}
 
@@ -46,7 +63,7 @@ making this safe to call from a cron job or systemd timer:
 
 	cmd.Flags().StringVar(&stepCAURL, "step-ca-url", "", "Step CA server URL (e.g. https://step-ca-dev.example.com)")
 	_ = cmd.MarkFlagRequired("step-ca-url")
-	cmd.Flags().StringVar(&rootPath, "step-ca-root", filepath.Join(certsDir, "step-ca-root.crt"), "path to Step CA root certificate")
+	cmd.Flags().StringVar(&rootPath, "step-ca-root", filepath.Join(certsDir, "step-ca-root.crt"), "path to Step CA HTTPS root certificate")
 	cmd.Flags().StringVar(&certPath, "cert", "", "path to client certificate to renew (default: <state-dir>/certs/<hostname>.crt)")
 	cmd.Flags().StringVar(&keyPath, "key", "", "path to client private key (default: <state-dir>/certs/<hostname>.key)")
 	cmd.Flags().DurationVar(&before, "before", 0, "only renew if the cert expires within this duration (e.g. 2h); 0 always renews")
@@ -54,7 +71,7 @@ making this safe to call from a cron job or systemd timer:
 	return cmd
 }
 
-func runClientRenew(stepCAURL, rootPath, certPath, keyPath string, before time.Duration) error {
+func runClientRenew(stepCAURL, rootPath string, rootExplicit bool, certPath, keyPath string, before time.Duration) error {
 	stateDir := localserver.StateDir()
 	certsDir := filepath.Join(stateDir, "certs")
 
@@ -82,6 +99,15 @@ func runClientRenew(stepCAURL, rootPath, certPath, keyPath string, before time.D
 	fmt.Printf("  CN:      %s\n", existing.Subject.CommonName)
 	fmt.Printf("  Expires: %s (%s)\n", existing.NotAfter.Format(time.RFC3339), timeUntil(existing.NotAfter))
 
+	if time.Now().After(existing.NotAfter) {
+		nameFlag := ""
+		if existing.Subject.CommonName != "" {
+			nameFlag = fmt.Sprintf(" --name %s", existing.Subject.CommonName)
+		}
+		return fmt.Errorf("certificate expired on %s; Step CA renewal requires an unexpired certificate. Re-issue it with: bridgectl client init --step-ca-url %s%s",
+			existing.NotAfter.Format(time.RFC3339), stepCAURL, nameFlag)
+	}
+
 	// --before: skip if not expiring soon enough.
 	if before > 0 && time.Until(existing.NotAfter) > before {
 		fmt.Printf("\nCert not due for renewal (expires in %s, threshold %s). Nothing to do.\n",
@@ -89,24 +115,39 @@ func runClientRenew(stepCAURL, rootPath, certPath, keyPath string, before time.D
 		return nil
 	}
 
+	fmt.Printf("\nRenewing certificate from %s...\n", stepCAURL)
+
+	rootArg, mode, err := renewRootArg(stepCAURL, rootPath, rootExplicit)
+	if err != nil {
+		return err
+	}
+	if mode == renewModeNativeInsecureTLS {
+		if err := renewClientCertNative(stepCAURL, certPath, keyPath, true); err != nil {
+			return fmt.Errorf("native token renew: %w", err)
+		}
+		return printRenewedCert(certPath)
+	}
+
 	stepBin, err := exec.LookPath("step")
 	if err != nil {
 		return fmt.Errorf("'step' CLI not found on PATH — required for certificate renewal; install from https://smallstep.com/cli/: %w", err)
 	}
 
-	fmt.Printf("\nRenewing certificate from %s...\n", stepCAURL)
-
-	// step ca renew uses a signed token (not mTLS) by default, which works
-	// regardless of whether the Step CA server requests client certs at the
-	// TLS level.
+	// Force signed-token renewal instead of mTLS. This works through layer-7
+	// HTTPS front doors such as Tailscale Serve/Funnel.
 	args := []string{
 		"ca", "renew",
 		"--ca-url", stepCAURL,
-		"--root", rootPath,
+		"--mtls=false",
+	}
+	if rootArg != "" {
+		args = append(args, "--root", rootArg)
+	}
+	args = append(args,
 		"--force",
 		certPath,
 		keyPath,
-	}
+	)
 	cmd := exec.Command(stepBin, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -114,6 +155,10 @@ func runClientRenew(stepCAURL, rootPath, certPath, keyPath string, before time.D
 		return fmt.Errorf("step ca renew: %w", err)
 	}
 
+	return printRenewedCert(certPath)
+}
+
+func printRenewedCert(certPath string) error {
 	renewed, err := loadLeafCert(certPath)
 	if err != nil {
 		return fmt.Errorf("read renewed cert: %w", err)
@@ -124,6 +169,153 @@ func runClientRenew(stepCAURL, rootPath, certPath, keyPath string, before time.D
 	fmt.Printf("  Expires: %s (%s)\n", renewed.NotAfter.Format(time.RFC3339), timeUntil(renewed.NotAfter))
 
 	return nil
+}
+
+func renewRootArg(stepCAURL, rootPath string, rootExplicit bool) (string, renewMode, error) {
+	if rootExplicit {
+		if _, err := os.Stat(rootPath); err != nil {
+			return "", renewModeStepCLI, fmt.Errorf("read Step CA root %s: %w", rootPath, err)
+		}
+		return rootPath, renewModeStepCLI, nil
+	}
+
+	if rootPath == "" {
+		return "", renewModeStepCLI, nil
+	}
+
+	if _, err := os.Stat(rootPath); os.IsNotExist(err) {
+		fmt.Printf("Fetching root cert from %s...\n", stepCAURL)
+		if err := fetchStepCARoot(stepCAURL, rootPath); err != nil {
+			return "", renewModeStepCLI, fmt.Errorf("fetch Step CA root cert: %w", err)
+		}
+		fmt.Printf("  Saved to %s\n", rootPath)
+	} else if err != nil {
+		return "", renewModeStepCLI, fmt.Errorf("read Step CA root %s: %w", rootPath, err)
+	}
+
+	if err := verifyStepCARoot(stepCAURL, rootPath); err == nil {
+		return rootPath, renewModeStepCLI, nil
+	}
+
+	fmt.Printf("Cached root cert does not verify %s; refreshing...\n", stepCAURL)
+	if err := fetchStepCARoot(stepCAURL, rootPath); err != nil {
+		return "", renewModeStepCLI, fmt.Errorf("fetch Step CA root cert: %w", err)
+	}
+	fmt.Printf("  Updated root cert saved to %s\n", rootPath)
+
+	if err := verifyStepCARoot(stepCAURL, rootPath); err == nil {
+		return rootPath, renewModeStepCLI, nil
+	}
+
+	fmt.Printf("Step CA root does not verify the HTTPS endpoint; using native token renewal for %s.\n", stepCAURL)
+	return "", renewModeNativeInsecureTLS, nil
+}
+
+func renewClientCertNative(stepCAURL, certPath, keyPath string, insecureTLS bool) error {
+	token, err := renewalToken(stepCAURL, certPath, keyPath)
+	if err != nil {
+		return fmt.Errorf("create renewal token: %w", err)
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: insecureTLS, //nolint:gosec // fallback only after fetching the CA root from this endpoint and finding it is not the HTTPS serving root.
+		},
+	}
+	client, err := ca.NewClient(stepCAURL, ca.WithTransport(tr))
+	if err != nil {
+		return fmt.Errorf("create Step CA client: %w", err)
+	}
+	resp, err := client.RenewWithToken(token)
+	if err != nil {
+		return fmt.Errorf("renew with token: %w", err)
+	}
+	if err := localserver.WriteCertPEM(certPath, resp); err != nil {
+		return fmt.Errorf("write renewed certificate: %w", err)
+	}
+	return nil
+}
+
+func renewalToken(stepCAURL, certPath, keyPath string) (string, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return "", err
+	}
+	if len(cert.Certificate) == 0 {
+		return "", fmt.Errorf("no certificates in %s", certPath)
+	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return "", err
+	}
+	if time.Now().After(leaf.NotAfter) {
+		return "", fmt.Errorf("certificate expired on %s; Step CA renewal requires an unexpired certificate", leaf.NotAfter.Format(time.RFC3339))
+	}
+
+	signer, ok := cert.PrivateKey.(crypto.Signer)
+	if !ok {
+		return "", fmt.Errorf("private key in %s does not implement crypto.Signer", keyPath)
+	}
+	alg, err := signingAlgorithm(signer.Public())
+	if err != nil {
+		return "", err
+	}
+
+	x5c := make([]string, 0, len(cert.Certificate))
+	for _, der := range cert.Certificate {
+		x5c = append(x5c, base64.StdEncoding.EncodeToString(der))
+	}
+
+	now := time.Now().UTC()
+	audience, err := renewAudience(stepCAURL)
+	if err != nil {
+		return "", err
+	}
+	claims := jose.Claims{
+		Audience:  []string{audience},
+		Subject:   leaf.Subject.CommonName,
+		Issuer:    "step-ca-client/1.0",
+		NotBefore: jose.NewNumericDate(now),
+		IssuedAt:  jose.NewNumericDate(now),
+		Expiry:    jose.NewNumericDate(now.Add(5 * time.Minute)),
+	}
+	opts := new(jose.SignerOptions).WithType("JWT").WithHeader("x5cInsecure", x5c)
+	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: alg, Key: signer}, opts)
+	if err != nil {
+		return "", err
+	}
+	return jose.Signed(sig).Claims(claims).CompactSerialize()
+}
+
+func renewAudience(stepCAURL string) (string, error) {
+	u, err := url.Parse(stepCAURL)
+	if err != nil {
+		return "", err
+	}
+	return u.ResolveReference(&url.URL{Path: "/1.0/renew"}).String(), nil
+}
+
+func signingAlgorithm(pub crypto.PublicKey) (jose.SignatureAlgorithm, error) {
+	switch key := pub.(type) {
+	case *ecdsa.PublicKey:
+		switch key.Curve.Params().BitSize {
+		case 256:
+			return jose.ES256, nil
+		case 384:
+			return jose.ES384, nil
+		case 521:
+			return jose.ES512, nil
+		default:
+			return "", fmt.Errorf("unsupported ECDSA curve size %d", key.Curve.Params().BitSize)
+		}
+	case *rsa.PublicKey:
+		return jose.RS256, nil
+	case ed25519.PublicKey:
+		return jose.EdDSA, nil
+	default:
+		return "", fmt.Errorf("unsupported private key public type %T", pub)
+	}
 }
 
 // loadLeafCert reads a PEM cert file and returns the first (leaf) certificate.

--- a/cmd/bridgectl/client_renew.go
+++ b/cmd/bridgectl/client_renew.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -122,7 +123,7 @@ func runClientRenew(stepCAURL, rootPath string, rootExplicit bool, certPath, key
 		return err
 	}
 	if mode == renewModeNativeInsecureTLS {
-		if err := renewClientCertNative(stepCAURL, certPath, keyPath, true); err != nil {
+		if err := renewClientCertNativeWithVerifiedFallback(stepCAURL, certPath, keyPath); err != nil {
 			return fmt.Errorf("native token renew: %w", err)
 		}
 		return printRenewedCert(certPath)
@@ -211,6 +212,17 @@ func renewRootArg(stepCAURL, rootPath string, rootExplicit bool) (string, renewM
 	return "", renewModeNativeInsecureTLS, nil
 }
 
+func renewClientCertNativeWithVerifiedFallback(stepCAURL, certPath, keyPath string) error {
+	err := renewClientCertNative(stepCAURL, certPath, keyPath, false)
+	if err == nil {
+		return nil
+	}
+	if !isTLSVerificationError(err) {
+		return err
+	}
+	return renewClientCertNative(stepCAURL, certPath, keyPath, true)
+}
+
 func renewClientCertNative(stepCAURL, certPath, keyPath string, insecureTLS bool) error {
 	token, err := renewalToken(stepCAURL, certPath, keyPath)
 	if err != nil {
@@ -235,6 +247,19 @@ func renewClientCertNative(stepCAURL, certPath, keyPath string, insecureTLS bool
 		return fmt.Errorf("write renewed certificate: %w", err)
 	}
 	return nil
+}
+
+func isTLSVerificationError(err error) bool {
+	var unknownAuthority x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthority) {
+		return true
+	}
+	var hostnameError x509.HostnameError
+	if errors.As(err, &hostnameError) {
+		return true
+	}
+	var invalidCert x509.CertificateInvalidError
+	return errors.As(err, &invalidCert)
 }
 
 func renewalToken(stepCAURL, certPath, keyPath string) (string, error) {
@@ -293,7 +318,7 @@ func renewAudience(stepCAURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return u.ResolveReference(&url.URL{Path: "/1.0/renew"}).String(), nil
+	return u.ResolveReference(&url.URL{Path: "/renew"}).String(), nil
 }
 
 func signingAlgorithm(pub crypto.PublicKey) (jose.SignatureAlgorithm, error) {

--- a/cmd/bridgectl/client_renew_test.go
+++ b/cmd/bridgectl/client_renew_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"net"
 	"net/http"
@@ -138,6 +139,27 @@ func TestRunClientRenewRejectsExpiredCertificateBeforeRenewal(t *testing.T) {
 	}
 	if _, err := os.Stat(rootPath); !os.IsNotExist(err) {
 		t.Fatalf("root cert should not be fetched for an expired certificate")
+	}
+}
+
+func TestRenewAudienceUsesRenewEndpoint(t *testing.T) {
+	got, err := renewAudience("https://step-ca.example.com:9443")
+	if err != nil {
+		t.Fatalf("renewAudience() error = %v", err)
+	}
+	want := "https://step-ca.example.com:9443/renew"
+	if got != want {
+		t.Fatalf("renewAudience() = %q, want %q", got, want)
+	}
+}
+
+func TestIsTLSVerificationError(t *testing.T) {
+	err := fmt.Errorf("renew with token: %w", x509.UnknownAuthorityError{})
+	if !isTLSVerificationError(err) {
+		t.Fatal("isTLSVerificationError() = false, want true")
+	}
+	if isTLSVerificationError(fmt.Errorf("renew with token: unauthorized")) {
+		t.Fatal("isTLSVerificationError() = true for non-TLS error, want false")
 	}
 }
 

--- a/cmd/bridgectl/client_renew_test.go
+++ b/cmd/bridgectl/client_renew_test.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	stepapi "github.com/smallstep/certificates/api"
+)
+
+func TestRunClientRenewUsesFetchedRootWhenItVerifiesEndpoint(t *testing.T) {
+	caPEM, caKey := selfSignedCA(t)
+
+	dir := t.TempDir()
+	certsDir := filepath.Join(dir, "certs")
+	if err := os.MkdirAll(certsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AI_AGENT_BRIDGE_STATE_DIR", dir)
+
+	rootPath := filepath.Join(certsDir, "step-ca-root.crt")
+	certPath, keyPath, renewedCert := writeRenewTestFiles(t, certsDir, time.Now().Add(time.Hour))
+	srv := tlsServerWithRoots(t, caPEM, caKey, caPEM, renewedCert)
+	argsPath := installFakeStep(t, renewedCert)
+
+	err := runClientRenew(srv.URL, rootPath, false, certPath, keyPath, 0)
+	if err != nil {
+		t.Fatalf("runClientRenew() error = %v", err)
+	}
+
+	args := readStepArgs(t, argsPath)
+	if !containsArgPair(args, "--root", rootPath) {
+		t.Fatalf("step args missing --root %s: %v", rootPath, args)
+	}
+	if !containsArg(args, "--mtls=false") {
+		t.Fatalf("step args missing --mtls=false: %v", args)
+	}
+}
+
+func TestRunClientRenewOmitsDefaultRootWhenEndpointUsesDifferentTLSRoot(t *testing.T) {
+	servingCA, servingKey := selfSignedCA(t)
+	stepCA, _ := selfSignedCA(t)
+
+	dir := t.TempDir()
+	certsDir := filepath.Join(dir, "certs")
+	if err := os.MkdirAll(certsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AI_AGENT_BRIDGE_STATE_DIR", dir)
+
+	rootPath := filepath.Join(certsDir, "step-ca-root.crt")
+	certPath, keyPath, renewedCert := writeRenewTestFiles(t, certsDir, time.Now().Add(time.Hour))
+	srv := tlsServerWithRoots(t, servingCA, servingKey, stepCA, renewedCert)
+	argsPath := installFakeStep(t, renewedCert)
+
+	err := runClientRenew(srv.URL, rootPath, false, certPath, keyPath, 0)
+	if err != nil {
+		t.Fatalf("runClientRenew() error = %v", err)
+	}
+
+	if _, err := os.Stat(argsPath); !os.IsNotExist(err) {
+		t.Fatalf("step CLI should not be called when default root cannot verify HTTPS endpoint")
+	}
+	renewed, err := loadLeafCert(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if time.Until(renewed.NotAfter) <= 0 {
+		t.Fatalf("cert was not renewed: expires %s", renewed.NotAfter.Format(time.RFC3339))
+	}
+}
+
+func TestRunClientRenewHonorsExplicitRoot(t *testing.T) {
+	servingCA, servingKey := selfSignedCA(t)
+	stepCA, _ := selfSignedCA(t)
+
+	dir := t.TempDir()
+	certsDir := filepath.Join(dir, "certs")
+	if err := os.MkdirAll(certsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AI_AGENT_BRIDGE_STATE_DIR", dir)
+
+	rootPath := writePEM(t, certsDir, "custom-root.crt", stepCA)
+	certPath, keyPath, renewedCert := writeRenewTestFiles(t, certsDir, time.Now().Add(time.Hour))
+	srv := tlsServerWithRoots(t, servingCA, servingKey, stepCA, renewedCert)
+	argsPath := installFakeStep(t, renewedCert)
+
+	err := runClientRenew(srv.URL, rootPath, true, certPath, keyPath, 0)
+	if err != nil {
+		t.Fatalf("runClientRenew() error = %v", err)
+	}
+
+	args := readStepArgs(t, argsPath)
+	if !containsArgPair(args, "--root", rootPath) {
+		t.Fatalf("step args missing explicit --root %s: %v", rootPath, args)
+	}
+}
+
+func TestRunClientRenewRejectsExpiredCertificateBeforeRenewal(t *testing.T) {
+	dir := t.TempDir()
+	certsDir := filepath.Join(dir, "certs")
+	if err := os.MkdirAll(certsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AI_AGENT_BRIDGE_STATE_DIR", dir)
+
+	rootPath := filepath.Join(certsDir, "step-ca-root.crt")
+	certPath, keyPath, renewedCert := writeRenewTestFiles(t, certsDir, time.Now().Add(-time.Hour))
+	argsPath := installFakeStep(t, renewedCert)
+
+	err := runClientRenew("https://step-ca.example.com", rootPath, false, certPath, keyPath, 0)
+	if err == nil {
+		t.Fatal("runClientRenew() error = nil, want expired certificate error")
+	}
+	if !strings.Contains(err.Error(), "certificate expired") {
+		t.Fatalf("runClientRenew() error = %v, want certificate expired", err)
+	}
+	if !strings.Contains(err.Error(), "bridgectl client init --step-ca-url https://step-ca.example.com --name client") {
+		t.Fatalf("runClientRenew() error = %v, want client init recovery command", err)
+	}
+	if _, err := os.Stat(argsPath); !os.IsNotExist(err) {
+		t.Fatalf("step CLI should not be called for an expired certificate")
+	}
+	if _, err := os.Stat(rootPath); !os.IsNotExist(err) {
+		t.Fatalf("root cert should not be fetched for an expired certificate")
+	}
+}
+
+func tlsServerWithRoots(t *testing.T, caPEM []byte, caKey *ecdsa.PrivateKey, rootsPEM []byte, renewedCertPath string) *httptest.Server {
+	t.Helper()
+
+	caCert, err := x509.ParseCertificate(mustDecode(t, caPEM))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srvTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(20),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	srvDER, err := x509.CreateCertificate(rand.Reader, srvTmpl, caCert, &srvKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/roots":
+			if err := json.NewEncoder(w).Encode(struct {
+				Crts []string `json:"crts"`
+			}{Crts: []string{string(rootsPEM)}}); err != nil {
+				t.Errorf("encode roots response: %v", err)
+			}
+		case "/renew":
+			if r.Header.Get("Authorization") == "" {
+				t.Errorf("renew request missing Authorization header")
+			}
+			renewed := parseCertFile(t, renewedCertPath)
+			w.WriteHeader(http.StatusCreated)
+			if err := json.NewEncoder(w).Encode(&stepapi.SignResponse{
+				ServerPEM: stepapi.NewCertificate(renewed),
+			}); err != nil {
+				t.Errorf("encode renew response: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{
+			{
+				Certificate: [][]byte{srvDER},
+				PrivateKey:  srvKey,
+			},
+		},
+	}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func writeRenewTestFiles(t *testing.T, certsDir string, existingNotAfter time.Time) (string, string, string) {
+	t.Helper()
+
+	certPath := filepath.Join(certsDir, "client.crt")
+	keyPath := filepath.Join(certsDir, "client.key")
+	renewedCert := filepath.Join(certsDir, "renewed.crt")
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(certPath, testLeafCertPEM(t, "client", existingNotAfter, key), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(renewedCert, testLeafCertPEM(t, "client", time.Now().Add(time.Hour), key), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	return certPath, keyPath, renewedCert
+}
+
+func testLeafCertPEM(t *testing.T, cn string, notAfter time.Time, key *ecdsa.PrivateKey) []byte {
+	t.Helper()
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-2 * time.Hour),
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func parseCertFile(t *testing.T, path string) *x509.Certificate {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		t.Fatalf("no PEM block in %s", path)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert
+}
+
+func installFakeStep(t *testing.T, renewedCert string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	stepPath := filepath.Join(dir, "step")
+	script := `#!/bin/sh
+last=
+prev=
+for arg in "$@"; do
+  printf '%s\n' "$arg" >> "$STEP_ARGS_FILE"
+  prev="$last"
+  last="$arg"
+done
+cp "$RENEWED_CERT" "$prev"
+`
+	if err := os.WriteFile(stepPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("STEP_ARGS_FILE", argsPath)
+	t.Setenv("RENEWED_CERT", renewedCert)
+	return argsPath
+}
+
+func readStepArgs(t *testing.T, argsPath string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.Fields(string(data))
+}
+
+func containsArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArgPair(args []string, key, value string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == key && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/bridgectl/client_test.go
+++ b/cmd/bridgectl/client_test.go
@@ -1,0 +1,50 @@
+package main
+
+import "testing"
+
+func TestDefaultServerNameFromTarget(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{
+			name:   "host port",
+			target: "d-5a0dd17c.tail6198c2.ts.net:9445",
+			want:   "d-5a0dd17c.tail6198c2.ts.net",
+		},
+		{
+			name:   "ipv4 host port",
+			target: "127.0.0.1:9445",
+			want:   "127.0.0.1",
+		},
+		{
+			name:   "ipv6 host port",
+			target: "[::1]:9445",
+			want:   "::1",
+		},
+		{
+			name:   "bare host",
+			target: "bridge.example.com",
+			want:   "bridge.example.com",
+		},
+		{
+			name:   "unix target",
+			target: "unix:///tmp/bridge.sock",
+			want:   "server",
+		},
+		{
+			name:   "ambiguous ipv6",
+			target: "::1",
+			want:   "server",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := defaultServerNameFromTarget(tt.target); got != tt.want {
+				t.Fatalf("defaultServerNameFromTarget(%q) = %q, want %q", tt.target, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/bridgectl/connect.go
+++ b/cmd/bridgectl/connect.go
@@ -45,7 +45,7 @@ func connectClient(stateDir string, timeout time.Duration) (*bridgeclient.Client
 //
 // Discovery rules:
 //   - CA bundle: step-ca-root.crt in certsDir
-//   - Client cert: the first non-CA *.crt in certsDir (override with --cert)
+//   - Client cert: <local-hostname>.crt or <short-hostname>.crt, then the first non-CA *.crt in certsDir (override with --cert)
 //   - JWT key: jwt-signing.key in certsDir, then stateDir (override with --jwt-key)
 //   - Issuer: CN extracted from the client cert
 func resolveRemoteCredentials(certOverride, keyOverride, jwtKeyOverride string) (*remoteCredentials, error) {
@@ -98,9 +98,30 @@ func resolveRemoteCredentials(certOverride, keyOverride, jwtKeyOverride string) 
 	return creds, nil
 }
 
-// discoverClientCert finds the first non-CA *.crt file in certsDir and
-// returns the cert path and its matching *.key path.
+// discoverClientCert prefers a certificate/key pair named after the local
+// hostname, then falls back to the first non-CA *.crt file in certsDir.
 func discoverClientCert(certsDir string) (cert, key string, err error) {
+	hostname, _ := os.Hostname()
+	return discoverClientCertForHostname(certsDir, hostname)
+}
+
+func discoverClientCertForHostname(certsDir, hostname string) (cert, key string, err error) {
+	for _, name := range hostnameCandidates(hostname) {
+		certPath := filepath.Join(certsDir, name+".crt")
+		keyPath := filepath.Join(certsDir, name+".key")
+		if _, statErr := os.Stat(certPath); statErr == nil {
+			if _, keyErr := os.Stat(keyPath); keyErr != nil {
+				return "", "", fmt.Errorf(
+					"client certificate %s was selected from local hostname %q, but matching key %s was not found\n\nSpecify the key with --key or re-issue the client certificate",
+					certPath, hostname, keyPath,
+				)
+			}
+			return certPath, keyPath, nil
+		} else if !os.IsNotExist(statErr) {
+			return "", "", fmt.Errorf("stat client certificate %s: %w", certPath, statErr)
+		}
+	}
+
 	entries, err := os.ReadDir(certsDir)
 	if err != nil {
 		return "", "", fmt.Errorf(
@@ -150,6 +171,18 @@ func discoverClientCert(certsDir string) (cert, key string, err error) {
 	}
 }
 
+func hostnameCandidates(hostname string) []string {
+	hostname = strings.TrimSpace(hostname)
+	if hostname == "" {
+		return nil
+	}
+	candidates := []string{hostname}
+	if short, _, ok := strings.Cut(hostname, "."); ok && short != "" && short != hostname {
+		candidates = append(candidates, short)
+	}
+	return candidates
+}
+
 // findJWTKey returns the path to jwt-signing.key, checking certsDir then
 // stateDir. Returns empty string if not found in either location.
 func findJWTKey(certsDir, stateDir string) string {
@@ -168,10 +201,14 @@ func findJWTKey(certsDir, stateDir string) string {
 //
 // hostname may include a port (e.g. "macbook.ts.net:9445"); if no port is
 // present, defaultRemotePort is used.
-func connectRemoteClient(hostname string, timeout time.Duration, certOverride, keyOverride, jwtKeyOverride string) (*bridgeclient.Client, error) {
+func connectRemoteClient(hostname string, timeout time.Duration, certOverride, keyOverride, jwtKeyOverride, serverNameOverride string) (*bridgeclient.Client, error) {
 	target := hostname
 	if !strings.Contains(hostname, ":") {
 		target = hostname + ":" + defaultRemotePort
+	}
+	serverName := serverNameOverride
+	if serverName == "" {
+		serverName = defaultServerNameFromTarget(target)
 	}
 
 	creds, err := resolveRemoteCredentials(certOverride, keyOverride, jwtKeyOverride)
@@ -189,7 +226,7 @@ func connectRemoteClient(hostname string, timeout time.Duration, certOverride, k
 			CABundlePath: creds.caBundle,
 			CertPath:     creds.cert,
 			KeyPath:      creds.key,
-			ServerName:   "server",
+			ServerName:   serverName,
 		}),
 		bridgeclient.WithJWT(bridgeclient.JWTConfig{
 			PrivateKeyPath: creds.jwtKey,
@@ -208,9 +245,9 @@ func connectRemoteClient(hostname string, timeout time.Duration, certOverride, k
 
 // connectClientForHost returns a client for a remote hostname (when non-empty)
 // or falls back to the local server.
-func connectClientForHost(remote string, timeout time.Duration, certOverride, keyOverride, jwtKeyOverride string) (*bridgeclient.Client, error) {
+func connectClientForHost(remote string, timeout time.Duration, certOverride, keyOverride, jwtKeyOverride, serverNameOverride string) (*bridgeclient.Client, error) {
 	if remote != "" {
-		return connectRemoteClient(remote, timeout, certOverride, keyOverride, jwtKeyOverride)
+		return connectRemoteClient(remote, timeout, certOverride, keyOverride, jwtKeyOverride, serverNameOverride)
 	}
 	return connectClient("", timeout)
 }

--- a/cmd/bridgectl/connect_test.go
+++ b/cmd/bridgectl/connect_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverClientCertForHostnamePrefersLocalHostname(t *testing.T) {
+	certsDir := t.TempDir()
+	touchFile(t, filepath.Join(certsDir, "other.crt"))
+	touchFile(t, filepath.Join(certsDir, "other.key"))
+	touchFile(t, filepath.Join(certsDir, "do-dev2.crt"))
+	touchFile(t, filepath.Join(certsDir, "do-dev2.key"))
+
+	cert, key, err := discoverClientCertForHostname(certsDir, "do-dev2")
+	if err != nil {
+		t.Fatalf("discoverClientCertForHostname() error = %v", err)
+	}
+
+	if cert != filepath.Join(certsDir, "do-dev2.crt") {
+		t.Fatalf("cert = %q, want hostname cert", cert)
+	}
+	if key != filepath.Join(certsDir, "do-dev2.key") {
+		t.Fatalf("key = %q, want hostname key", key)
+	}
+}
+
+func TestDiscoverClientCertForHostnameUsesShortHostname(t *testing.T) {
+	certsDir := t.TempDir()
+	touchFile(t, filepath.Join(certsDir, "do-dev2.crt"))
+	touchFile(t, filepath.Join(certsDir, "do-dev2.key"))
+
+	cert, key, err := discoverClientCertForHostname(certsDir, "do-dev2.example.com")
+	if err != nil {
+		t.Fatalf("discoverClientCertForHostname() error = %v", err)
+	}
+
+	if cert != filepath.Join(certsDir, "do-dev2.crt") {
+		t.Fatalf("cert = %q, want short hostname cert", cert)
+	}
+	if key != filepath.Join(certsDir, "do-dev2.key") {
+		t.Fatalf("key = %q, want short hostname key", key)
+	}
+}
+
+func TestDiscoverClientCertForHostnameMissingHostnameKey(t *testing.T) {
+	certsDir := t.TempDir()
+	touchFile(t, filepath.Join(certsDir, "do-dev2.crt"))
+	touchFile(t, filepath.Join(certsDir, "fallback.crt"))
+	touchFile(t, filepath.Join(certsDir, "fallback.key"))
+
+	_, _, err := discoverClientCertForHostname(certsDir, "do-dev2")
+	if err == nil {
+		t.Fatal("discoverClientCertForHostname() error = nil, want missing key error")
+	}
+	if !strings.Contains(err.Error(), "do-dev2.key") {
+		t.Fatalf("error = %v, want missing hostname key path", err)
+	}
+}
+
+func TestDiscoverClientCertForHostnameFallsBackToSingleCandidate(t *testing.T) {
+	certsDir := t.TempDir()
+	touchFile(t, filepath.Join(certsDir, "step-ca-root.crt"))
+	touchFile(t, filepath.Join(certsDir, "fallback.crt"))
+	touchFile(t, filepath.Join(certsDir, "fallback.key"))
+
+	cert, key, err := discoverClientCertForHostname(certsDir, "missing-host")
+	if err != nil {
+		t.Fatalf("discoverClientCertForHostname() error = %v", err)
+	}
+
+	if cert != filepath.Join(certsDir, "fallback.crt") {
+		t.Fatalf("cert = %q, want fallback cert", cert)
+	}
+	if key != filepath.Join(certsDir, "fallback.key") {
+		t.Fatalf("key = %q, want fallback key", key)
+	}
+}
+
+func touchFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/bridgectl/server.go
+++ b/cmd/bridgectl/server.go
@@ -212,10 +212,25 @@ func defaultServerConfigPath(stateDir string) string {
 
 func defaultServerConfigCandidates(stateDir string) []string {
 	candidates := []string{filepath.Join(stateDir, "bridge.yaml")}
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+		candidates = append(candidates, filepath.Join(xdgConfigHome, "bridgectl", "config.yaml"))
+	}
 	if configDir, err := os.UserConfigDir(); err == nil && configDir != "" {
-		candidates = append(candidates, filepath.Join(configDir, "bridgectl", "config.yaml"))
+		path := filepath.Join(configDir, "bridgectl", "config.yaml")
+		if !stringSliceContains(candidates, path) {
+			candidates = append(candidates, path)
+		}
 	}
 	return candidates
+}
+
+func stringSliceContains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func newServerStatusCmd() *cobra.Command {

--- a/cmd/bridgectl/server.go
+++ b/cmd/bridgectl/server.go
@@ -111,12 +111,9 @@ infrastructure (Google, GitHub, Okta, etc.) managed through Step CA.`,
 				return fmt.Errorf("server already running")
 			}
 
-			// Default config path to ~/.ai-agent-bridge/bridge.yaml when not set.
+			// Default config path to the first known per-user config when not set.
 			if configPath == "" {
-				defaultCfg := filepath.Join(localserver.StateDir(), "bridge.yaml")
-				if _, err := os.Stat(defaultCfg); err == nil {
-					configPath = defaultCfg
-				}
+				configPath = defaultServerConfigPath(localserver.StateDir())
 			}
 
 			// Build logger from --log-level and --log-format.
@@ -202,6 +199,23 @@ infrastructure (Google, GitHub, Okta, etc.) managed through Step CA.`,
 	cmd.Flags().DurationVar(&certRenewalCheckInterval, "cert-renewal-check-interval", 0, "how often to check certificate expiry (e.g. 10m, 1h); default 1 hour")
 
 	return cmd
+}
+
+func defaultServerConfigPath(stateDir string) string {
+	for _, path := range defaultServerConfigCandidates(stateDir) {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+func defaultServerConfigCandidates(stateDir string) []string {
+	candidates := []string{filepath.Join(stateDir, "bridge.yaml")}
+	if configDir, err := os.UserConfigDir(); err == nil && configDir != "" {
+		candidates = append(candidates, filepath.Join(configDir, "bridgectl", "config.yaml"))
+	}
+	return candidates
 }
 
 func newServerStatusCmd() *cobra.Command {

--- a/cmd/bridgectl/server_init_test.go
+++ b/cmd/bridgectl/server_init_test.go
@@ -138,3 +138,41 @@ func TestVerifyStepCARoot_missingFile(t *testing.T) {
 		t.Fatal("expected error for missing file")
 	}
 }
+
+func TestDefaultServerConfigPathUsesStateDirFirst(t *testing.T) {
+	stateDir := t.TempDir()
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	stateConfig := filepath.Join(stateDir, "bridge.yaml")
+	writeFile(t, stateConfig)
+	xdgConfig := filepath.Join(configHome, "bridgectl", "config.yaml")
+	writeFile(t, xdgConfig)
+
+	if got := defaultServerConfigPath(stateDir); got != stateConfig {
+		t.Fatalf("defaultServerConfigPath() = %q, want %q", got, stateConfig)
+	}
+}
+
+func TestDefaultServerConfigPathFallsBackToXDGConfig(t *testing.T) {
+	stateDir := t.TempDir()
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	xdgConfig := filepath.Join(configHome, "bridgectl", "config.yaml")
+	writeFile(t, xdgConfig)
+
+	if got := defaultServerConfigPath(stateDir); got != xdgConfig {
+		t.Fatalf("defaultServerConfigPath() = %q, want %q", got, xdgConfig)
+	}
+}
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -35,22 +35,23 @@ func newSessionCmd() *cobra.Command {
 	return cmd
 }
 
-// addRemoteFlags adds --remote, --cert, --key, and --jwt-key flags to cmd.
 // These are the standard flags for connecting to a remote bridge server.
-func addRemoteFlags(cmd *cobra.Command, remote, cert, key, jwtKey *string) {
+func addRemoteFlags(cmd *cobra.Command, remote, cert, key, jwtKey, serverName *string) {
 	cmd.Flags().StringVar(remote, "remote", "", "remote bridge server hostname (e.g. macbook.ts.net or macbook.ts.net:9445)")
 	cmd.Flags().StringVar(cert, "cert", "", "path to client certificate (auto-discovered from ~/.ai-agent-bridge/certs/ if omitted)")
 	cmd.Flags().StringVar(key, "key", "", "path to client private key (derived from --cert if omitted)")
 	cmd.Flags().StringVar(jwtKey, "jwt-key", "", "path to JWT signing key (auto-discovered from ~/.ai-agent-bridge/certs/ if omitted)")
+	cmd.Flags().StringVar(serverName, "server-name", "", "TLS server name to verify (defaults to host from --remote)")
 }
 
 func newSessionListCmd() *cobra.Command {
 	var (
-		project string
-		remote  string
-		cert    string
-		key     string
-		jwtKey  string
+		project    string
+		remote     string
+		cert       string
+		key        string
+		jwtKey     string
+		serverName string
 	)
 
 	cmd := &cobra.Command{
@@ -58,7 +59,7 @@ func newSessionListCmd() *cobra.Command {
 		Short:   "List active sessions",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := connectClientForHost(remote, 5*time.Second, cert, key, jwtKey)
+			client, err := connectClientForHost(remote, 5*time.Second, cert, key, jwtKey, serverName)
 			if err != nil {
 				if remote != "" {
 					return err
@@ -99,7 +100,7 @@ func newSessionListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&project, "project", "local", "project ID to filter")
-	addRemoteFlags(cmd, &remote, &cert, &key, &jwtKey)
+	addRemoteFlags(cmd, &remote, &cert, &key, &jwtKey, &serverName)
 	return cmd
 }
 
@@ -112,6 +113,7 @@ func newSessionAttachCmd() *cobra.Command {
 		cert        string
 		key         string
 		jwtKey      string
+		serverName  string
 	)
 
 	cmd := &cobra.Command{
@@ -121,29 +123,30 @@ func newSessionAttachCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			sessionID := args[0]
 			if release {
-				return releaseWriter(sessionID, remote, cert, key, jwtKey)
+				return releaseWriter(sessionID, remote, cert, key, jwtKey, serverName)
 			}
 			role := bridgev1.AttachRole_ATTACH_ROLE_WRITER
 			if observeOnly {
 				role = bridgev1.AttachRole_ATTACH_ROLE_OBSERVER
 			}
-			return attachSession(sessionID, role, takeOver, remote, cert, key, jwtKey)
+			return attachSession(sessionID, role, takeOver, remote, cert, key, jwtKey, serverName)
 		},
 	}
 
 	cmd.Flags().BoolVar(&observeOnly, "observe", false, "attach as read-only observer (no input)")
 	cmd.Flags().BoolVar(&takeOver, "take-over", false, "forcibly claim the writer slot from the current active writer")
 	cmd.Flags().BoolVar(&release, "release", false, "release the current active writer slot (affects whoever currently holds it)")
-	addRemoteFlags(cmd, &remote, &cert, &key, &jwtKey)
+	addRemoteFlags(cmd, &remote, &cert, &key, &jwtKey, &serverName)
 	return cmd
 }
 
 func newSessionWatchCmd() *cobra.Command {
 	var (
-		remote string
-		cert   string
-		key    string
-		jwtKey string
+		remote     string
+		cert       string
+		key        string
+		jwtKey     string
+		serverName string
 	)
 
 	cmd := &cobra.Command{
@@ -152,21 +155,22 @@ func newSessionWatchCmd() *cobra.Command {
 		Long:  "Attach to a running session as a read-only observer. Shorthand for 'session attach <session-id> --observe'.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return attachSession(args[0], bridgev1.AttachRole_ATTACH_ROLE_OBSERVER, false, remote, cert, key, jwtKey)
+			return attachSession(args[0], bridgev1.AttachRole_ATTACH_ROLE_OBSERVER, false, remote, cert, key, jwtKey, serverName)
 		},
 	}
 
-	addRemoteFlags(cmd, &remote, &cert, &key, &jwtKey)
+	addRemoteFlags(cmd, &remote, &cert, &key, &jwtKey, &serverName)
 	return cmd
 }
 
 func newSessionStopCmd() *cobra.Command {
 	var (
-		force  bool
-		remote string
-		cert   string
-		key    string
-		jwtKey string
+		force      bool
+		remote     string
+		cert       string
+		key        string
+		jwtKey     string
+		serverName string
 	)
 
 	cmd := &cobra.Command{
@@ -176,7 +180,7 @@ func newSessionStopCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			sessionID := args[0]
 
-			client, err := connectClientForHost(remote, 10*time.Second, cert, key, jwtKey)
+			client, err := connectClientForHost(remote, 10*time.Second, cert, key, jwtKey, serverName)
 			if err != nil {
 				return err
 			}
@@ -197,12 +201,12 @@ func newSessionStopCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "force kill (SIGKILL)")
-	addRemoteFlags(cmd, &remote, &cert, &key, &jwtKey)
+	addRemoteFlags(cmd, &remote, &cert, &key, &jwtKey, &serverName)
 	return cmd
 }
 
-func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, remote, cert, key, jwtKey string) error {
-	client, err := connectClientForHost(remote, 30*time.Minute, cert, key, jwtKey)
+func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, remote, cert, key, jwtKey, serverName string) error {
+	client, err := connectClientForHost(remote, 30*time.Minute, cert, key, jwtKey, serverName)
 	if err != nil {
 		return err
 	}
@@ -383,8 +387,8 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 // releaseWriter sends a ReleaseWriter RPC for sessionID targeting whoever
 // currently holds the active writer slot (not necessarily this client).
 // This is a fire-and-forget command: it doesn't attach a stream.
-func releaseWriter(sessionID, remote, cert, key, jwtKey string) error {
-	client, err := connectClientForHost(remote, 10*time.Second, cert, key, jwtKey)
+func releaseWriter(sessionID, remote, cert, key, jwtKey, serverName string) error {
+	client, err := connectClientForHost(remote, 10*time.Second, cert, key, jwtKey, serverName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- add remote TLS server-name handling across bridgectl session/client enrollment flows
- prefer hostname-matching remote client certs and support Step CA renewal when HTTPS serving trust differs from issuance trust
- auto-discover per-user bridgectl config from ~/.ai-agent-bridge/bridge.yaml or XDG config to avoid starting an unconfigured local daemon

## Tests
- go test ./...
- make build
- pre-commit hooks during commit
- pre-push go-test hook

## Config / operational impact
- bridgectl server start now also discovers $XDG_CONFIG_HOME/bridgectl/config.yaml when --config is omitted and ~/.ai-agent-bridge/bridge.yaml is absent
- remote session commands now accept --server-name for TLS verification overrides
- client renewal behavior changes for Step CA deployments with split HTTPS and issuance roots