### PR TITLE
Fix secure local server discovery

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -140,6 +140,7 @@ Remote operator CLI acceptance criteria:
 - `bridgectl session` remote subcommands allow operators to override the TLS server name when a bridge server certificate is issued for a DNS name that differs from the dial address.
 - Remote credential discovery prefers the current host's client certificate before falling back to other client certificates in the cert directory.
 - `bridgectl server start` auto-loads the first available per-user config from `~/.ai-agent-bridge/bridge.yaml` or `$XDG_CONFIG_HOME/bridgectl/config.yaml` when `--config` is omitted, so local and remote operator commands target the same configured daemon.
+- Same-machine `bridgectl` commands discover an already-running secure TCP server from local state without requiring remote host, certificate, key, or JWT flags; wildcard bind addresses are recorded as loopback dial targets for local clients.
 - `bridgectl client renew` handles Step CA deployments where the HTTPS serving certificate chain differs from the Step CA root used for bridge certificate issuance, while rejecting expired client certificates before attempting renewal.
 
 **Session persistence**: with `--db-path`, the server writes session metadata and PTY output chunks to a BoltDB file. On restart, `LoadHistory()` rehydrates sessions so SDK clients can reconnect and replay events they missed.

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -572,7 +572,7 @@ func Start(cfg Config) (*Server, error) {
 			sup.Close()
 			return nil, fmt.Errorf("listen tcp %s: %w", cfg.ListenAddr, err)
 		}
-		listenAddr = ln.Addr().String()
+		listenAddr = localDialAddr(ln.Addr().String())
 	} else {
 		ln, listenAddr, err = listen(stateDir)
 		if err != nil {
@@ -748,6 +748,21 @@ func BuildServerSANs(listenAddr string, extra []string) []string {
 		add(s)
 	}
 	return sans
+}
+
+func localDialAddr(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	switch host {
+	case "0.0.0.0", "":
+		return net.JoinHostPort("127.0.0.1", port)
+	case "::", "[::]":
+		return net.JoinHostPort("::1", port)
+	default:
+		return addr
+	}
 }
 
 // Addr returns the listener address (unix socket path or TCP address).

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -758,7 +758,7 @@ func localDialAddr(addr string) string {
 	switch host {
 	case "0.0.0.0", "":
 		return net.JoinHostPort("127.0.0.1", port)
-	case "::", "[::]":
+	case "::":
 		return net.JoinHostPort("::1", port)
 	default:
 		return addr

--- a/internal/localserver/localserver_test.go
+++ b/internal/localserver/localserver_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -249,6 +250,41 @@ func TestServerTarget(t *testing.T) {
 	assert.NotEmpty(t, srv.Target())
 }
 
+func TestLocalDialAddrNormalizesWildcard(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{
+			name: "ipv4 wildcard",
+			addr: "0.0.0.0:9445",
+			want: "127.0.0.1:9445",
+		},
+		{
+			name: "ipv6 wildcard",
+			addr: "[::]:9445",
+			want: "[::1]:9445",
+		},
+		{
+			name: "concrete address",
+			addr: "10.0.0.1:9445",
+			want: "10.0.0.1:9445",
+		},
+		{
+			name: "unix target",
+			addr: "unix:///tmp/server.sock",
+			want: "unix:///tmp/server.sock",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, localDialAddr(tt.addr))
+		})
+	}
+}
+
 // TestIsServerRunningAndDiscoverTarget verifies that IsServerRunning and
 // DiscoverTarget correctly report a live server.
 func TestIsServerRunningAndDiscoverTarget(t *testing.T) {
@@ -338,6 +374,34 @@ func TestIsServerRunningSecureMode(t *testing.T) {
 
 	if !IsServerRunning(dir) {
 		t.Error("IsServerRunning returned false for a running secure server")
+	}
+
+	target, mode := DiscoverTarget(dir)
+	assert.NotEmpty(t, target)
+	assert.Equal(t, ModeSecure, mode)
+}
+
+func TestDiscoverTargetSecureModeWithWildcardListen(t *testing.T) {
+	dir := t.TempDir()
+	srv, err := Start(Config{
+		StateDir:   dir,
+		ListenAddr: "0.0.0.0:0",
+	})
+	if err != nil {
+		t.Skipf("secure mode start failed: %v", err)
+	}
+	t.Cleanup(func() { srv.Stop() })
+
+	addrData, err := os.ReadFile(filepath.Join(dir, "server.addr"))
+	require.NoError(t, err)
+	host, _, err := net.SplitHostPort(string(bytes.TrimSpace(addrData)))
+	require.NoError(t, err)
+	ip := net.ParseIP(host)
+	require.NotNil(t, ip)
+	assert.True(t, ip.IsLoopback(), "server.addr host %q should be loopback", host)
+
+	if !IsServerRunning(dir) {
+		t.Error("IsServerRunning returned false for a secure wildcard listener")
 	}
 
 	target, mode := DiscoverTarget(dir)


### PR DESCRIPTION
## Summary
- document that same-machine bridgectl commands must discover secure TCP servers without remote credential flags
- write loopback dial targets to server.addr when secure mode binds wildcard addresses
- add regression coverage for wildcard normalization and secure discovery

## Test Evidence
- go test ./...
- pre-commit: gofmt, goimports, golangci-lint
- pre-push: go-test

## Config / Operational Impact
- Secure servers bound to 0.0.0.0 or [::] now record a local loopback target for same-machine discovery.
- Secure servers bound to a specific IP continue recording that specific IP.