### PR TITLE
Improve remote auth hint

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -141,7 +141,7 @@ Remote operator CLI acceptance criteria:
 - Remote credential discovery prefers the current host's client certificate before falling back to other client certificates in the cert directory.
 - `bridgectl server start` auto-loads the first available per-user config from `~/.ai-agent-bridge/bridge.yaml` or `$XDG_CONFIG_HOME/bridgectl/config.yaml` when `--config` is omitted, so local and remote operator commands target the same configured daemon.
 - Same-machine `bridgectl` commands discover an already-running secure TCP server from local state without requiring remote host, certificate, key, or JWT flags; wildcard bind addresses are recorded as loopback dial targets for local clients.
-- Remote session commands surface an actionable retry hint when JWT authentication fails and a `jwt-signing.key` in the current directory may be the intended credential.
+- `bridgectl session list --remote` surfaces an actionable retry hint when JWT authentication fails and a `jwt-signing.key` in the current directory may be the intended credential.
 - `bridgectl client renew` handles Step CA deployments where the HTTPS serving certificate chain differs from the Step CA root used for bridge certificate issuance, while rejecting expired client certificates before attempting renewal.
 
 **Session persistence**: with `--db-path`, the server writes session metadata and PTY output chunks to a BoltDB file. On restart, `LoadHistory()` rehydrates sessions so SDK clients can reconnect and replay events they missed.

--- a/PRD.md
+++ b/PRD.md
@@ -141,6 +141,7 @@ Remote operator CLI acceptance criteria:
 - Remote credential discovery prefers the current host's client certificate before falling back to other client certificates in the cert directory.
 - `bridgectl server start` auto-loads the first available per-user config from `~/.ai-agent-bridge/bridge.yaml` or `$XDG_CONFIG_HOME/bridgectl/config.yaml` when `--config` is omitted, so local and remote operator commands target the same configured daemon.
 - Same-machine `bridgectl` commands discover an already-running secure TCP server from local state without requiring remote host, certificate, key, or JWT flags; wildcard bind addresses are recorded as loopback dial targets for local clients.
+- Remote session commands surface an actionable retry hint when JWT authentication fails and a `jwt-signing.key` in the current directory may be the intended credential.
 - `bridgectl client renew` handles Step CA deployments where the HTTPS serving certificate chain differs from the Step CA root used for bridge certificate issuance, while rejecting expired client certificates before attempting renewal.
 
 **Session persistence**: with `--db-path`, the server writes session metadata and PTY output chunks to a BoltDB file. On restart, `LoadHistory()` rehydrates sessions so SDK clients can reconnect and replay events they missed.

--- a/cmd/bridgectl/connect_test.go
+++ b/cmd/bridgectl/connect_test.go
@@ -91,6 +91,9 @@ func TestRemoteAuthHintSuggestsLocalJWTKey(t *testing.T) {
 	if !strings.Contains(hint, "bridgectl session list --remote example.ts.net --jwt-key") {
 		t.Fatalf("hint = %q, want retry command", hint)
 	}
+	if !strings.Contains(hint, "Remote commands use JWT keys from ~/.ai-agent-bridge/certs/ or ~/.ai-agent-bridge unless --jwt-key is set") {
+		t.Fatalf("hint = %q, want credential discovery explanation", hint)
+	}
 	if !strings.Contains(hint, filepath.Join(dir, "jwt-signing.key")) {
 		t.Fatalf("hint = %q, want absolute local key path", hint)
 	}

--- a/cmd/bridgectl/connect_test.go
+++ b/cmd/bridgectl/connect_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/markcallen/ai-agent-bridge/pkg/bridgeclient"
 )
 
 func TestDiscoverClientCertForHostnamePrefersLocalHostname(t *testing.T) {
@@ -76,6 +79,58 @@ func TestDiscoverClientCertForHostnameFallsBackToSingleCandidate(t *testing.T) {
 	}
 	if key != filepath.Join(certsDir, "fallback.key") {
 		t.Fatalf("key = %q, want fallback key", key)
+	}
+}
+
+func TestRemoteAuthHintSuggestsLocalJWTKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	touchFile(t, filepath.Join(dir, "jwt-signing.key"))
+
+	hint := remoteAuthHint(bridgeclient.ErrUnauthorized, "example.ts.net", "")
+	if !strings.Contains(hint, "bridgectl session list --remote example.ts.net --jwt-key") {
+		t.Fatalf("hint = %q, want retry command", hint)
+	}
+	if !strings.Contains(hint, filepath.Join(dir, "jwt-signing.key")) {
+		t.Fatalf("hint = %q, want absolute local key path", hint)
+	}
+}
+
+func TestRemoteAuthHintSkippedWhenNotApplicable(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	touchFile(t, filepath.Join(dir, "jwt-signing.key"))
+
+	tests := []struct {
+		name   string
+		err    error
+		remote string
+		jwtKey string
+	}{
+		{
+			name:   "local command",
+			err:    bridgeclient.ErrUnauthorized,
+			remote: "",
+		},
+		{
+			name:   "explicit jwt key",
+			err:    bridgeclient.ErrUnauthorized,
+			remote: "example.ts.net",
+			jwtKey: "/tmp/jwt-signing.key",
+		},
+		{
+			name:   "different error",
+			err:    errors.New("connection refused"),
+			remote: "example.ts.net",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if hint := remoteAuthHint(tt.err, tt.remote, tt.jwtKey); hint != "" {
+				t.Fatalf("remoteAuthHint() = %q, want empty", hint)
+			}
+		})
 	}
 }
 

--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -17,6 +18,7 @@ import (
 	"golang.org/x/term"
 
 	bridgev1 "github.com/markcallen/ai-agent-bridge/gen/bridge/v1"
+	"github.com/markcallen/ai-agent-bridge/pkg/bridgeclient"
 )
 
 func newSessionCmd() *cobra.Command {
@@ -77,6 +79,9 @@ func newSessionListCmd() *cobra.Command {
 				ProjectId: project,
 			})
 			if err != nil {
+				if hint := remoteAuthHint(err, remote, jwtKey); hint != "" {
+					return fmt.Errorf("list sessions: %w\n\n%s", err, hint)
+				}
 				return fmt.Errorf("list sessions: %w", err)
 			}
 
@@ -102,6 +107,26 @@ func newSessionListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&project, "project", "local", "project ID to filter")
 	addRemoteFlags(cmd, &remote, &cert, &key, &jwtKey, &serverName)
 	return cmd
+}
+
+func remoteAuthHint(err error, remote, jwtKey string) string {
+	if remote == "" || jwtKey != "" || !errors.Is(err, bridgeclient.ErrUnauthorized) {
+		return ""
+	}
+
+	localJWTKey, statErr := filepath.Abs("jwt-signing.key")
+	if statErr != nil {
+		localJWTKey = "jwt-signing.key"
+	}
+	if _, statErr := os.Stat(localJWTKey); statErr != nil {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"Found a JWT signing key in the current directory. Remote commands auto-discover JWT keys from ~/.ai-agent-bridge/certs/ before the current directory, so this command may be using an older key. Retry with:\n  bridgectl session list --remote %s --jwt-key %s",
+		remote,
+		localJWTKey,
+	)
 }
 
 func newSessionAttachCmd() *cobra.Command {

--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -123,7 +123,7 @@ func remoteAuthHint(err error, remote, jwtKey string) string {
 	}
 
 	return fmt.Sprintf(
-		"Found a JWT signing key in the current directory. Remote commands auto-discover JWT keys from ~/.ai-agent-bridge/certs/ before the current directory, so this command may be using an older key. Retry with:\n  bridgectl session list --remote %s --jwt-key %s",
+		"Found a JWT signing key in the current directory. Remote commands use JWT keys from ~/.ai-agent-bridge/certs/ or ~/.ai-agent-bridge unless --jwt-key is set. If this local key is intended, retry with:\n  bridgectl session list --remote %s --jwt-key %s",
 		remote,
 		localJWTKey,
 	)


### PR DESCRIPTION
## Summary
- add an actionable hint when remote session listing fails with JWT authorization and a local jwt-signing.key is present
- document the remote operator CLI expectation in PRD.md
- add tests for the hint and skip cases

## Test Evidence
- go test ./...
- pre-commit: gofmt, goimports, golangci-lint
- pre-push: go-test

## Config / Operational Impact
- No config changes.
- Remote session list errors may include an additional retry suggestion when a current-directory jwt-signing.key exists.