### PR TITLE
Fix local bridgectl discovery for explicit TLS

### DIFF
--- a/cmd/bridgectl/connect.go
+++ b/cmd/bridgectl/connect.go
@@ -267,7 +267,7 @@ func dialClient(target string, mode localserver.ServerMode, stateDir string, tim
 				CABundlePath: mat.CABundlePath,
 				CertPath:     mat.LocalClientCert,
 				KeyPath:      mat.LocalClientKey,
-				ServerName:   "server",
+				ServerName:   localserver.DiscoverServerName(stateDir),
 			}),
 			bridgeclient.WithJWT(bridgeclient.JWTConfig{
 				PrivateKeyPath: mat.JWTSigningKey,

--- a/cmd/bridgectl/server.go
+++ b/cmd/bridgectl/server.go
@@ -162,7 +162,7 @@ infrastructure (Google, GitHub, Okta, etc.) managed through Step CA.`,
 			}
 
 			mode := "local (unix socket, no auth)"
-			if listenAddr != "" {
+			if localserver.DiscoverMode(localserver.StateDir()) == localserver.ModeSecure {
 				mode = fmt.Sprintf("secure (mTLS+JWT on %s)", srv.Addr())
 			}
 			fmt.Fprintf(os.Stderr, "ai-agent-bridge server listening — %s (pid %d)\n", mode, os.Getpid())

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -62,6 +62,12 @@ func AddrPath() string {
 	return filepath.Join(StateDir(), "server.addr")
 }
 
+// ServerNamePath returns the path to the file recording the TLS name local
+// clients should use when probing or dialing a secure server.
+func ServerNamePath() string {
+	return filepath.Join(StateDir(), "server.name")
+}
+
 // Server wraps all the components needed for a local bridge server.
 type Server struct {
 	grpcServer *grpc.Server
@@ -113,6 +119,42 @@ func DiscoverMode(stateDir string) ServerMode {
 		return ModeSecure
 	}
 	return ModeLocal
+}
+
+// DiscoverServerName reads the TLS server name recorded by secure startup.
+// Older state directories do not have this file, so auto-PKI's historical
+// "server" name remains the fallback.
+func DiscoverServerName(stateDir string) string {
+	if stateDir == "" {
+		stateDir = StateDir()
+	}
+	data, err := os.ReadFile(filepath.Join(stateDir, "server.name"))
+	if err != nil {
+		return "server"
+	}
+	name := strings.TrimSpace(string(data))
+	if name == "" {
+		return "server"
+	}
+	return name
+}
+
+func serverNameFromCert(certPath string) string {
+	cert, err := pki.LoadCert(certPath)
+	if err != nil {
+		return "server"
+	}
+	for _, name := range cert.DNSNames {
+		if strings.TrimSpace(name) != "" {
+			return name
+		}
+	}
+	for _, ip := range cert.IPAddresses {
+		if ip != nil {
+			return ip.String()
+		}
+	}
+	return "server"
 }
 
 // Config controls local server behaviour.
@@ -481,6 +523,7 @@ func Start(cfg Config) (*Server, error) {
 	var stepCAConfig *StepCAConfig
 	var pkiMat *PKIMaterial
 	explicitCerts := false
+	tlsServerName := "server"
 
 	if cfg.ListenAddr != "" {
 		// Secure mode: TCP + mTLS + JWT.
@@ -508,11 +551,18 @@ func Start(cfg Config) (*Server, error) {
 				}
 				return nil, fmt.Errorf("CABundlePath requires TLSCertPath and TLSKeyPath to also be set")
 			}
-			mat = &PKIMaterial{
-				CABundlePath:   cfg.CABundlePath,
-				ServerCertPath: cfg.TLSCertPath,
-				ServerKeyPath:  cfg.TLSKeyPath,
+			var pkiErr error
+			mat, pkiErr = EnsureLocalManagementPKI(stateDir, cfg.CABundlePath, logger)
+			if pkiErr != nil {
+				sup.Close()
+				if store != nil {
+					_ = store.Close()
+				}
+				return nil, fmt.Errorf("ensure local management PKI: %w", pkiErr)
 			}
+			mat.ServerCertPath = cfg.TLSCertPath
+			mat.ServerKeyPath = cfg.TLSKeyPath
+			tlsServerName = serverNameFromCert(cfg.TLSCertPath)
 		} else {
 			// Auto-generate PKI material if not present, or delegate to Step CA.
 			serverSANs = BuildServerSANs(cfg.ListenAddr, cfg.ServerSANs)
@@ -603,6 +653,14 @@ func Start(cfg Config) (*Server, error) {
 		_ = ln.Close()
 		sup.Close()
 		return nil, fmt.Errorf("write mode file: %w", err)
+	}
+	if mode == ModeSecure {
+		nameFile := filepath.Join(stateDir, "server.name")
+		if err := os.WriteFile(nameFile, []byte(tlsServerName), 0o644); err != nil {
+			_ = ln.Close()
+			sup.Close()
+			return nil, fmt.Errorf("write server name file: %w", err)
+		}
 	}
 
 	logger.Info("server starting", "mode", mode, "addr", listenAddr, "pid", os.Getpid())
@@ -822,6 +880,7 @@ func (s *Server) Stop() {
 	_ = os.Remove(filepath.Join(s.stateDir, "server.pid"))
 	_ = os.Remove(filepath.Join(s.stateDir, "server.addr"))
 	_ = os.Remove(filepath.Join(s.stateDir, "server.mode"))
+	_ = os.Remove(filepath.Join(s.stateDir, "server.name"))
 	_ = os.Remove(filepath.Join(s.stateDir, "server.sock"))
 	_ = os.Remove(filepath.Join(s.stateDir, "server.lock"))
 }
@@ -1035,7 +1094,7 @@ func probeHealth(target string, mode ServerMode, stateDir string) bool {
 			CABundlePath: mat.CABundlePath,
 			CertPath:     mat.LocalClientCert,
 			KeyPath:      mat.LocalClientKey,
-			ServerName:   "server",
+			ServerName:   DiscoverServerName(stateDir),
 		})
 		if err != nil {
 			return false

--- a/internal/localserver/localserver_test.go
+++ b/internal/localserver/localserver_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/markcallen/ai-agent-bridge/internal/pki"
 	"github.com/markcallen/ai-agent-bridge/internal/redact"
 	"github.com/markcallen/ai-agent-bridge/internal/server"
 	"github.com/stretchr/testify/assert"
@@ -376,6 +377,49 @@ func TestIsServerRunningSecureMode(t *testing.T) {
 		t.Error("IsServerRunning returned false for a running secure server")
 	}
 
+	target, mode := DiscoverTarget(dir)
+	assert.NotEmpty(t, target)
+	assert.Equal(t, ModeSecure, mode)
+}
+
+func TestIsServerRunningSecureModeWithExplicitTLSCreatesLocalManagementPKI(t *testing.T) {
+	dir := t.TempDir()
+	tlsDir := filepath.Join(dir, "external-tls")
+	caCertPath, caKeyPath, err := pki.InitCA("external", tlsDir)
+	require.NoError(t, err)
+	caCert, caKey, err := pki.LoadCA(caCertPath, caKeyPath)
+	require.NoError(t, err)
+	serverCertPath, serverKeyPath, err := pki.IssueCert(caCert, caKey, pki.CertTypeServer, "bridge-host", []string{"bridge-host", "127.0.0.1"}, tlsDir, 0)
+	require.NoError(t, err)
+
+	srv, err := Start(Config{
+		StateDir:     dir,
+		ListenAddr:   "127.0.0.1:0",
+		CABundlePath: caCertPath,
+		TLSCertPath:  serverCertPath,
+		TLSKeyPath:   serverKeyPath,
+	})
+	if err != nil {
+		t.Skipf("secure mode start failed: %v", err)
+	}
+	t.Cleanup(func() { srv.Stop() })
+
+	mat := LoadPKIMaterial(dir)
+	for _, path := range []string{
+		mat.CABundlePath,
+		mat.LocalClientCert,
+		mat.LocalClientKey,
+		mat.JWTSigningKey,
+		mat.JWTSigningPub,
+	} {
+		_, err := os.Stat(path)
+		require.NoError(t, err, "file should exist: %s", path)
+	}
+
+	assert.Equal(t, "bridge-host", DiscoverServerName(dir))
+	if !IsServerRunning(dir) {
+		t.Fatal("IsServerRunning returned false for explicit-TLS secure server")
+	}
 	target, mode := DiscoverTarget(dir)
 	assert.NotEmpty(t, target)
 	assert.Equal(t, ModeSecure, mode)

--- a/internal/localserver/pki.go
+++ b/internal/localserver/pki.go
@@ -189,15 +189,36 @@ func EnsureLocalManagementPKI(stateDir, externalCABundle string, logger *slog.Lo
 		logger.Info("generated JWT signing keypair", "pub", pubPath)
 	}
 
-	if err := copyFile(externalCABundle, mat.CABundlePath); err != nil {
-		return nil, fmt.Errorf("copy external CA bundle: %w", err)
-	}
-	if err := pki.AppendBundle(mat.CABundlePath, mat.CACertPath); err != nil {
-		return nil, fmt.Errorf("append local management CA to bundle: %w", err)
+	if err := writeLocalManagementBundle(externalCABundle, mat.CABundlePath, mat.CACertPath); err != nil {
+		return nil, err
 	}
 	_ = writePKIMode(certsDir, pkiModeTLS)
 
 	return mat, nil
+}
+
+func writeLocalManagementBundle(externalCABundle, outPath, localCACertPath string) error {
+	bundle, err := os.ReadFile(externalCABundle)
+	if err != nil {
+		return fmt.Errorf("read external CA bundle: %w", err)
+	}
+	localCA, err := os.ReadFile(localCACertPath)
+	if err != nil {
+		return fmt.Errorf("read local management CA: %w", err)
+	}
+	if !strings.HasSuffix(string(bundle), "\n") {
+		bundle = append(bundle, '\n')
+	}
+	if !strings.Contains(string(bundle), strings.TrimSpace(string(localCA))) {
+		bundle = append(bundle, localCA...)
+		if !strings.HasSuffix(string(bundle), "\n") {
+			bundle = append(bundle, '\n')
+		}
+	}
+	if err := os.WriteFile(outPath, bundle, 0o644); err != nil {
+		return fmt.Errorf("write local management CA bundle: %w", err)
+	}
+	return nil
 }
 
 func filesExist(paths ...string) bool {

--- a/internal/localserver/pki.go
+++ b/internal/localserver/pki.go
@@ -20,6 +20,7 @@ var safeNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 const (
 	pkiModeAuto   = "auto"
 	pkiModeStepCA = "step-ca"
+	pkiModeTLS    = "tls"
 	pkiModeFile   = ".pki-mode"
 )
 
@@ -143,6 +144,72 @@ func EnsurePKI(stateDir string, serverSANs []string, logger *slog.Logger, stepCA
 		return ensurePKIStepCA(stateDir, serverSANs, logger, stepCA, mat, certsDir, certValidity)
 	}
 	return ensurePKIAutoGen(stateDir, serverSANs, logger, mat, certsDir, certValidity)
+}
+
+// EnsureLocalManagementPKI creates the local-only client credentials needed by
+// same-machine bridgectl commands when the server uses externally managed TLS
+// certificates. The returned CA bundle is a state-directory copy of the
+// external server CA bundle plus the generated local management CA.
+func EnsureLocalManagementPKI(stateDir, externalCABundle string, logger *slog.Logger) (*PKIMaterial, error) {
+	mat := LoadPKIMaterial(stateDir)
+	certsDir := CertsDir(stateDir)
+	if err := os.MkdirAll(certsDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create certs dir: %w", err)
+	}
+
+	if !filesExist(mat.CACertPath, mat.CAKeyPath, mat.LocalClientCert, mat.LocalClientKey) {
+		logger.Info("generating local management PKI material", "dir", certsDir)
+		localCACert, localCAKey, err := pki.InitCA("ai-agent-bridge-local", certsDir)
+		if err != nil {
+			return nil, fmt.Errorf("init local management CA: %w", err)
+		}
+		mat.CACertPath = localCACert
+		mat.CAKeyPath = localCAKey
+
+		localCA, localKey, err := pki.LoadCA(localCACert, localCAKey)
+		if err != nil {
+			return nil, fmt.Errorf("load local management CA: %w", err)
+		}
+		clientCert, clientKey, err := pki.IssueCert(localCA, localKey, pki.CertTypeClient, "local-client", nil, certsDir, 0)
+		if err != nil {
+			return nil, fmt.Errorf("issue local-client cert: %w", err)
+		}
+		mat.LocalClientCert = clientCert
+		mat.LocalClientKey = clientKey
+		logger.Info("generated local-client cert", "cert", clientCert)
+	}
+
+	if !filesExist(mat.JWTSigningKey, mat.JWTSigningPub) {
+		pubPath, privPath, err := pki.GenerateJWTKeypair(certsDir, "jwt-signing")
+		if err != nil {
+			return nil, fmt.Errorf("generate JWT keypair: %w", err)
+		}
+		mat.JWTSigningPub = pubPath
+		mat.JWTSigningKey = privPath
+		logger.Info("generated JWT signing keypair", "pub", pubPath)
+	}
+
+	if err := copyFile(externalCABundle, mat.CABundlePath); err != nil {
+		return nil, fmt.Errorf("copy external CA bundle: %w", err)
+	}
+	if err := pki.AppendBundle(mat.CABundlePath, mat.CACertPath); err != nil {
+		return nil, fmt.Errorf("append local management CA to bundle: %w", err)
+	}
+	_ = writePKIMode(certsDir, pkiModeTLS)
+
+	return mat, nil
+}
+
+func filesExist(paths ...string) bool {
+	for _, path := range paths {
+		if path == "" {
+			return false
+		}
+		if _, err := os.Stat(path); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 // ensurePKIAutoGen generates a self-signed CA and all derived material.

--- a/internal/localserver/pki_test.go
+++ b/internal/localserver/pki_test.go
@@ -135,6 +135,40 @@ func TestEnsurePKI_Idempotent(t *testing.T) {
 	assert.Equal(t, ca1, ca2, "CA cert should not be regenerated on second call")
 }
 
+func TestEnsureLocalManagementPKIHandlesStateDirCABundle(t *testing.T) {
+	stateDir := t.TempDir()
+	certsDir := CertsDir(stateDir)
+	require.NoError(t, os.MkdirAll(certsDir, 0o700))
+
+	externalDir := filepath.Join(stateDir, "external")
+	externalCAPath, _, err := pki.InitCA("external", externalDir)
+	require.NoError(t, err)
+	externalCA, err := os.ReadFile(externalCAPath)
+	require.NoError(t, err)
+
+	bundlePath := filepath.Join(certsDir, "ca-bundle.crt")
+	require.NoError(t, os.WriteFile(bundlePath, externalCA, 0o644))
+
+	mat, err := EnsureLocalManagementPKI(stateDir, bundlePath, testLogger())
+	require.NoError(t, err)
+	require.Equal(t, bundlePath, mat.CABundlePath)
+
+	firstBundle, err := os.ReadFile(bundlePath)
+	require.NoError(t, err)
+	require.Contains(t, string(firstBundle), strings.TrimSpace(string(externalCA)))
+	localCA, err := os.ReadFile(mat.CACertPath)
+	require.NoError(t, err)
+	localCAPEM := strings.TrimSpace(string(localCA))
+	require.Equal(t, 1, strings.Count(string(firstBundle), localCAPEM))
+
+	_, err = EnsureLocalManagementPKI(stateDir, bundlePath, testLogger())
+	require.NoError(t, err)
+	secondBundle, err := os.ReadFile(bundlePath)
+	require.NoError(t, err)
+	require.Contains(t, string(secondBundle), strings.TrimSpace(string(externalCA)))
+	require.Equal(t, 1, strings.Count(string(secondBundle), localCAPEM))
+}
+
 func TestIssueClientCert(t *testing.T) {
 	stateDir := t.TempDir()
 	logger := testLogger()


### PR DESCRIPTION
## Summary
- generate local management client credentials when secure server startup uses externally managed TLS certs
- record and reuse the actual TLS server name for same-machine secure discovery and local client dialing
- fix the server startup banner when secure mode comes from config rather than the CLI flag

## Test Evidence
- go test ./...
- deployed rebuilt bridgectl to d-6da8e54b and restarted the user server
- verified bridgectl server status reports secure mode with claude/codex/echo available
- verified bridgectl run /workspace/penduin/ reaches Claude's workspace trust prompt instead of timing out