### PR TITLE
Add repo-local setup config

### DIFF
--- a/config/bridge-dev.yaml
+++ b/config/bridge-dev.yaml
@@ -16,6 +16,12 @@ auth:
 feature_flags:
   provider_fallbacks: true
 
+repo_setup:
+  enabled: true
+  config_path: ".ai-agent-bridge.yaml"
+  default_timeout: "2m"
+  max_timeout: "15m"
+
 sessions:
   max_per_project: 5
   max_global: 20

--- a/config/bridge-docker.yaml
+++ b/config/bridge-docker.yaml
@@ -16,6 +16,12 @@ auth:
 feature_flags:
   provider_fallbacks: true
 
+repo_setup:
+  enabled: true
+  config_path: ".ai-agent-bridge.yaml"
+  default_timeout: "2m"
+  max_timeout: "15m"
+
 sessions:
   max_per_project: 5
   max_global: 20

--- a/config/bridge.yaml
+++ b/config/bridge.yaml
@@ -16,6 +16,12 @@ auth:
 feature_flags:
   provider_fallbacks: true
 
+repo_setup:
+  enabled: true
+  config_path: ".ai-agent-bridge.yaml"
+  default_timeout: "2m"
+  max_timeout: "15m"
+
 sessions:
   max_per_project: 5
   max_global: 20

--- a/docs/service.md
+++ b/docs/service.md
@@ -145,6 +145,12 @@ rate_limits:
 feature_flags:
   provider_fallbacks: true
 
+repo_setup:
+  enabled: true
+  config_path: ".ai-agent-bridge.yaml"
+  default_timeout: "2m"
+  max_timeout: "15m"
+
 providers:
   claude:
     binary:          "node"
@@ -243,6 +249,56 @@ providers:
 In this example, `./node_modules/@openai/codex/bin/codex.js` resolves to
 `/opt/ai-agent-bridge/node_modules/@openai/codex/bin/codex.js` regardless of
 where the daemon process is launched from.
+
+#### `repo_setup`
+
+Controls repo-local shell setup before provider launch. These settings are optional; omitting the `repo_setup` block enables the feature with the defaults below. Repositories opt in by placing `.ai-agent-bridge.yaml` at the repo root. Repos without that file keep the existing provider launch behavior.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `true` | When false, repo-local setup files are ignored. |
+| `config_path` | `.ai-agent-bridge.yaml` | Relative path under `repo_path` for the repo-owned setup config. Absolute paths and `..` components are rejected. |
+| `default_timeout` | `2m` | Setup timeout when the repo file omits `timeout`. Expiry cancels setup and prevents provider launch. |
+| `max_timeout` | `15m` | Upper bound for repo-declared `timeout`. Values above this fail fast instead of being clamped. |
+
+Repo setup runs on the bridge host as the bridge user with `cwd` set to the requested `repo_path`. The bridge captures the final shell environment and uses it for provider health checks and the provider subprocess. Setup is serialized per canonical repo path, so two session starts for the same repo share one in-flight setup run instead of running setup concurrently.
+
+Root-level repo config example for a Next.js app using nvm and pnpm via corepack:
+
+```yaml
+# .ai-agent-bridge.yaml
+version: 1
+shell: bash
+timeout: 5m
+
+setup:
+  - source "${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+  - nvm use
+  - corepack enable
+  - corepack prepare pnpm@latest --activate
+  - export PATH="$PWD/node_modules/.bin:$PATH"
+
+env:
+  NEXT_TELEMETRY_DISABLED: "1"
+```
+
+Go repo example using a Makefile setup target:
+
+```yaml
+# .ai-agent-bridge.yaml
+version: 1
+shell: bash
+timeout: 5m
+
+setup:
+  - make setup
+  - export PATH="$PWD/bin:$PATH"
+
+env:
+  CGO_ENABLED: "1"
+```
+
+If setup exits non-zero, exceeds its effective timeout, or has an invalid config, `StartSession` fails with `FAILED_PRECONDITION` and the provider process is not started. Logs include setup start/success/failure metadata and configured redaction is applied to setup failure output before it is returned or logged.
 
 #### `providers`
 | Field | Description |

--- a/e2e/bridgectl/cli_test.go
+++ b/e2e/bridgectl/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -189,6 +190,81 @@ func TestEchoSessionLifecycle(t *testing.T) {
 		info.Status == bridgev1.SessionStatus_SESSION_STATUS_STOPPED ||
 			info.Status == bridgev1.SessionStatus_SESSION_STATUS_FAILED,
 		"session should be stopped or failed, got %v", info.Status)
+}
+
+func TestRepoSetupConfigEnvironmentPropagation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	stateDir := testStateDir(t)
+	repoDir := t.TempDir()
+	binDir := t.TempDir()
+	providerScript := filepath.Join(binDir, "print-setup-env.sh")
+	require.NoError(t, os.WriteFile(providerScript, []byte(`#!/bin/sh
+printf 'SETUP_VALUE=%s\n' "$BRIDGE_E2E_SETUP_VALUE"
+sleep 5
+`), 0o755))
+	configPath := filepath.Join(t.TempDir(), "bridge.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+providers:
+  setupenv:
+    binary: `+strconv.Quote(providerScript)+`
+    startup_probe: output
+    startup_timeout: 5s
+    required_env: ["BRIDGE_E2E_SETUP_VALUE"]
+repo_setup:
+  default_timeout: 5s
+  max_timeout: 30s
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".ai-agent-bridge.yaml"), []byte(`
+version: 1
+shell: bash
+setup:
+  - export BRIDGE_E2E_SETUP_VALUE=from-repo-setup
+`), 0o644))
+
+	srv, err := localserver.Start(localserver.Config{
+		StateDir:   stateDir,
+		ConfigPath: configPath,
+	})
+	require.NoError(t, err)
+	defer srv.Stop()
+
+	client, err := bridgeclient.New(bridgeclient.WithTarget(srv.Target()))
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+	client.SetProject("test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	sessionID := uuid.NewString()
+	_, err = client.StartSession(ctx, &bridgev1.StartSessionRequest{
+		ProjectId:   "test",
+		SessionId:   sessionID,
+		RepoPath:    repoDir,
+		Provider:    "setupenv",
+		InitialCols: 80,
+		InitialRows: 24,
+	})
+	require.NoError(t, err)
+
+	_, attached, getEvents, stopRecv := attachAndCollectEvents(t, ctx, client, sessionID, uuid.NewString(), bridgev1.AttachRole_ATTACH_ROLE_WRITER)
+	defer stopRecv()
+	waitForAttach(t, attached)
+
+	require.Eventually(t, func() bool {
+		for _, ev := range getEvents() {
+			if ev.Type == bridgev1.AttachEventType_ATTACH_EVENT_TYPE_OUTPUT && strings.Contains(string(ev.Payload), "SETUP_VALUE=from-repo-setup") {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 100*time.Millisecond)
+
+	_, err = client.StopSession(ctx, &bridgev1.StopSessionRequest{SessionId: sessionID, Force: true})
+	require.NoError(t, err)
 }
 
 // TestAutoServerDiscovery tests that a second client discovers the first server.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/bbolt v1.4.3
+	go.step.sm/crypto v0.77.1
+	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.43.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.2
@@ -105,13 +107,11 @@ require (
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
-	go.step.sm/crypto v0.77.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect

--- a/internal/bridge/errors.go
+++ b/internal/bridge/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrClientNotAttached          = errors.New("client is not attached")
 	ErrClientMismatch             = errors.New("client does not own attached session")
 	ErrProviderUnavailable        = errors.New("provider unavailable")
+	ErrRepoSetupFailed            = errors.New("repo setup failed")
 	ErrSessionLimitReached        = errors.New("session limit reached")
 	ErrInputTooLarge              = errors.New("input too large")
 	// ErrWriterConflict is returned by ClaimWriter when another client already

--- a/internal/bridge/provider.go
+++ b/internal/bridge/provider.go
@@ -20,12 +20,25 @@ type Provider interface {
 	Version(ctx context.Context) (string, error)
 }
 
+// EnvHealthProvider is implemented by providers that can evaluate runtime
+// availability against a prepared session environment.
+type EnvHealthProvider interface {
+	HealthWithEnv(ctx context.Context, env []string) error
+}
+
+// RepoSetupRunner prepares a repository-specific environment before provider
+// selection and launch.
+type RepoSetupRunner interface {
+	Prepare(ctx context.Context, repoPath string, baseEnv []string) ([]string, error)
+}
+
 // SessionConfig holds configuration for starting a new provider session.
 type SessionConfig struct {
 	ProjectID string
 	SessionID string
 	RepoPath  string
 	Options   map[string]string
+	Env       []string
 	// Fallbacks is an ordered list of provider IDs to try if the primary
 	// provider (Options["provider"]) is unavailable. At most 2 entries are
 	// meaningful; extras are silently ignored.

--- a/internal/bridge/supervisor.go
+++ b/internal/bridge/supervisor.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -69,6 +70,12 @@ func WithStore(store SessionStore) SupervisorOption {
 	}
 }
 
+func WithRepoSetupRunner(runner RepoSetupRunner) SupervisorOption {
+	return func(s *Supervisor) {
+		s.repoSetup = runner
+	}
+}
+
 // Supervisor manages the lifecycle of PTY-backed provider sessions.
 type Supervisor struct {
 	registry        *Registry
@@ -81,9 +88,10 @@ type Supervisor struct {
 	sessions map[string]*managedSession
 	done     chan struct{}
 
-	store   SessionStore
-	histMu  sync.RWMutex
-	history map[string]SessionInfo
+	store     SessionStore
+	repoSetup RepoSetupRunner
+	histMu    sync.RWMutex
+	history   map[string]SessionInfo
 }
 
 type managedSession struct {
@@ -340,7 +348,7 @@ func (s *Supervisor) cleanupLoop() {
 // resolveProvider tries the primary provider ID, then each fallback in order,
 // returning the first one that is registered and passes its Health check. If
 // no candidate succeeds, the last error is returned.
-func (s *Supervisor) resolveProvider(ctx context.Context, primary string, fallbacks []string) (Provider, error) {
+func (s *Supervisor) resolveProvider(ctx context.Context, primary string, fallbacks []string, env []string) (Provider, error) {
 	candidates := make([]string, 0, 1+len(fallbacks))
 	candidates = append(candidates, primary)
 	candidates = append(candidates, fallbacks...)
@@ -351,9 +359,15 @@ func (s *Supervisor) resolveProvider(ctx context.Context, primary string, fallba
 			lastErr = err
 			continue
 		}
-		if err := p.Health(ctx); err != nil {
-			lastErr = fmt.Errorf("%w: %v", ErrProviderUnavailable, err)
-			slog.Warn("provider unavailable, trying fallback", "provider", id, "error", err)
+		var healthErr error
+		if hp, ok := p.(EnvHealthProvider); ok && env != nil {
+			healthErr = hp.HealthWithEnv(ctx, env)
+		} else {
+			healthErr = p.Health(ctx)
+		}
+		if healthErr != nil {
+			lastErr = fmt.Errorf("%w: %v", ErrProviderUnavailable, healthErr)
+			slog.Warn("provider unavailable, trying fallback", "provider", id, "error", healthErr)
 			continue
 		}
 		if id != primary {
@@ -362,6 +376,11 @@ func (s *Supervisor) resolveProvider(ctx context.Context, primary string, fallba
 		return p, nil
 	}
 	return nil, lastErr
+}
+
+func trimSetupError(err error) string {
+	msg := err.Error()
+	return strings.TrimPrefix(msg, ErrRepoSetupFailed.Error()+": ")
 }
 
 func (s *Supervisor) Start(ctx context.Context, cfg SessionConfig) (*SessionInfo, error) {
@@ -399,7 +418,15 @@ func (s *Supervisor) Start(ctx context.Context, cfg SessionConfig) (*SessionInfo
 	}
 	s.mu.Unlock()
 
-	provider, err := s.resolveProvider(ctx, cfg.Options["provider"], cfg.Fallbacks)
+	if s.repoSetup != nil {
+		env, err := s.repoSetup.Prepare(ctx, cfg.RepoPath, cfg.Env)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrRepoSetupFailed, trimSetupError(err))
+		}
+		cfg.Env = env
+	}
+
+	provider, err := s.resolveProvider(ctx, cfg.Options["provider"], cfg.Fallbacks, cfg.Env)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/bridge/supervisor_test.go
+++ b/internal/bridge/supervisor_test.go
@@ -34,6 +34,42 @@ func (p *testProvider) BuildCommand(ctx context.Context, cfg SessionConfig) (*ex
 	return cmd, nil
 }
 
+type setupRunnerFunc func(context.Context, string, []string) ([]string, error)
+
+func (f setupRunnerFunc) Prepare(ctx context.Context, repoPath string, baseEnv []string) ([]string, error) {
+	return f(ctx, repoPath, baseEnv)
+}
+
+type envHealthProvider struct {
+	testProvider
+	requiredKey string
+}
+
+func (p *envHealthProvider) Health(context.Context) error {
+	return errors.New("HealthWithEnv was not used")
+}
+
+func (p *envHealthProvider) HealthWithEnv(_ context.Context, env []string) error {
+	for _, item := range env {
+		if strings.HasPrefix(item, p.requiredKey+"=") {
+			return nil
+		}
+	}
+	return errors.New("missing " + p.requiredKey)
+}
+
+type nilEnvProvider struct {
+	testProvider
+}
+
+func (p *nilEnvProvider) Health(context.Context) error {
+	return nil
+}
+
+func (p *nilEnvProvider) HealthWithEnv(context.Context, []string) error {
+	return errors.New("HealthWithEnv should not be used without prepared env")
+}
+
 func TestSupervisorSessionLifecycle(t *testing.T) {
 	registry := NewRegistry()
 	if err := registry.Register(&testProvider{id: "fake"}); err != nil {
@@ -115,6 +151,90 @@ func TestSupervisorSessionLifecycle(t *testing.T) {
 		t.Fatalf("Stop: %v", err)
 	}
 	waitForStopped(t, supervisor, "session-a")
+}
+
+func TestSupervisorNilEnvUsesProviderHealth(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(&nilEnvProvider{testProvider: testProvider{id: "nil-env"}}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	supervisor := NewSupervisor(registry, DefaultPolicy(), 1024, time.Minute)
+	defer supervisor.Close()
+
+	info, err := supervisor.Start(context.Background(), SessionConfig{
+		ProjectID: "project-a",
+		SessionID: "nil-env",
+		RepoPath:  t.TempDir(),
+		Options:   map[string]string{"provider": "nil-env"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if info.Provider != "nil-env" {
+		t.Fatalf("Provider=%q want nil-env", info.Provider)
+	}
+	_ = supervisor.Stop("nil-env", true)
+}
+
+func TestSupervisorRepoSetupRunnerProvidesProviderHealthEnv(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(&envHealthProvider{
+		testProvider: testProvider{id: "env-provider"},
+		requiredKey:  "FROM_SETUP",
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	supervisor := NewSupervisor(
+		registry,
+		DefaultPolicy(),
+		1024,
+		time.Minute,
+		WithRepoSetupRunner(setupRunnerFunc(func(_ context.Context, _ string, _ []string) ([]string, error) {
+			return []string{"FROM_SETUP=1"}, nil
+		})),
+	)
+	defer supervisor.Close()
+
+	info, err := supervisor.Start(context.Background(), SessionConfig{
+		ProjectID: "project-a",
+		SessionID: "setup-env",
+		RepoPath:  t.TempDir(),
+		Options:   map[string]string{"provider": "env-provider"},
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if info.Provider != "env-provider" {
+		t.Fatalf("Provider=%q want env-provider", info.Provider)
+	}
+	_ = supervisor.Stop("setup-env", true)
+}
+
+func TestSupervisorRepoSetupRunnerFailure(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(&testProvider{id: "fake"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	supervisor := NewSupervisor(
+		registry,
+		DefaultPolicy(),
+		1024,
+		time.Minute,
+		WithRepoSetupRunner(setupRunnerFunc(func(context.Context, string, []string) ([]string, error) {
+			return nil, errors.New("repo setup failed: boom")
+		})),
+	)
+	defer supervisor.Close()
+
+	_, err := supervisor.Start(context.Background(), SessionConfig{
+		ProjectID: "project-a",
+		SessionID: "setup-fail",
+		RepoPath:  t.TempDir(),
+		Options:   map[string]string{"provider": "fake"},
+	})
+	if !errors.Is(err, ErrRepoSetupFailed) || strings.Contains(err.Error(), "repo setup failed: repo setup failed") {
+		t.Fatalf("Start error=%v want trimmed repo setup failure", err)
+	}
 }
 
 func TestSupervisorStartValidationAndLimits(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	RateLimits   RateLimitsConfig          `yaml:"rate_limits"`
 	Persistence  PersistenceConfig         `yaml:"persistence"`
 	Runtime      RuntimeConfig             `yaml:"runtime"`
+	RepoSetup    RepoSetupConfig           `yaml:"repo_setup"`
 	Providers    map[string]ProviderConfig `yaml:"providers"`
 	AllowedPaths []string                  `yaml:"allowed_paths"`
 	Logging      LoggingConfig             `yaml:"logging"`
@@ -34,6 +35,18 @@ type Config struct {
 // empty, existing CWD-relative behaviour is preserved.
 type RuntimeConfig struct {
 	ProviderRoot string `yaml:"provider_root"`
+}
+
+// RepoSetupConfig controls repo-local pre-agent setup execution.
+type RepoSetupConfig struct {
+	Enabled        *bool  `yaml:"enabled"`
+	ConfigPath     string `yaml:"config_path"`
+	DefaultTimeout string `yaml:"default_timeout"`
+	MaxTimeout     string `yaml:"max_timeout"`
+}
+
+func (r RepoSetupConfig) IsEnabled() bool {
+	return r.Enabled == nil || *r.Enabled
 }
 
 type ServerConfig struct {
@@ -165,6 +178,24 @@ func Load(path string) (*Config, error) {
 	return cfg, nil
 }
 
+// HasExplicitServerListen reports whether a YAML config file explicitly sets
+// server.listen, before defaults are applied by Load.
+func HasExplicitServerListen(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("read config: %w", err)
+	}
+	var raw struct {
+		Server struct {
+			Listen *string `yaml:"listen"`
+		} `yaml:"server"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return false, fmt.Errorf("parse config: %w", err)
+	}
+	return raw.Server.Listen != nil && strings.TrimSpace(*raw.Server.Listen) != "", nil
+}
+
 // ParseDuration is a helper that parses a duration string with a fallback.
 func ParseDuration(s string, fallback time.Duration) time.Duration {
 	if s == "" {
@@ -235,6 +266,15 @@ func applyDefaults(cfg *Config) {
 	if cfg.Logging.Format == "" {
 		cfg.Logging.Format = "json"
 	}
+	if cfg.RepoSetup.ConfigPath == "" {
+		cfg.RepoSetup.ConfigPath = ".ai-agent-bridge.yaml"
+	}
+	if cfg.RepoSetup.DefaultTimeout == "" {
+		cfg.RepoSetup.DefaultTimeout = "2m"
+	}
+	if cfg.RepoSetup.MaxTimeout == "" {
+		cfg.RepoSetup.MaxTimeout = "15m"
+	}
 }
 
 func validate(cfg *Config) error {
@@ -264,6 +304,32 @@ func validate(cfg *Config) error {
 	}
 	if cfg.Runtime.ProviderRoot != "" && !filepath.IsAbs(cfg.Runtime.ProviderRoot) {
 		return fmt.Errorf("config: runtime.provider_root must be an absolute path, got %q", cfg.Runtime.ProviderRoot)
+	}
+	if cfg.RepoSetup.ConfigPath == "" {
+		return fmt.Errorf("config: repo_setup.config_path is required")
+	}
+	if filepath.IsAbs(cfg.RepoSetup.ConfigPath) {
+		return fmt.Errorf("config: repo_setup.config_path must be relative, got %q", cfg.RepoSetup.ConfigPath)
+	}
+	if hasParentPathComponent(cfg.RepoSetup.ConfigPath) {
+		return fmt.Errorf("config: repo_setup.config_path must not contain '..', got %q", cfg.RepoSetup.ConfigPath)
+	}
+	defaultSetupTimeout, err := time.ParseDuration(cfg.RepoSetup.DefaultTimeout)
+	if err != nil {
+		return fmt.Errorf("config: repo_setup.default_timeout: %w", err)
+	}
+	if defaultSetupTimeout <= 0 {
+		return fmt.Errorf("config: repo_setup.default_timeout must be > 0")
+	}
+	maxSetupTimeout, err := time.ParseDuration(cfg.RepoSetup.MaxTimeout)
+	if err != nil {
+		return fmt.Errorf("config: repo_setup.max_timeout: %w", err)
+	}
+	if maxSetupTimeout <= 0 {
+		return fmt.Errorf("config: repo_setup.max_timeout must be > 0")
+	}
+	if defaultSetupTimeout > maxSetupTimeout {
+		return fmt.Errorf("config: repo_setup.default_timeout must not exceed repo_setup.max_timeout")
 	}
 	if _, err := time.ParseDuration(cfg.Auth.JWTMaxTTL); err != nil {
 		return fmt.Errorf("config: auth.jwt_max_ttl: %w", err)
@@ -340,6 +406,15 @@ func validate(cfg *Config) error {
 		}
 	}
 	return nil
+}
+
+func hasParentPathComponent(path string) bool {
+	for _, part := range strings.Split(filepath.Clean(path), string(os.PathSeparator)) {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func safeIssuerName(issuer string) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -250,6 +250,143 @@ sessions:
 	}
 }
 
+func TestLoadRepoSetupDefaultsAndValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name: "defaults",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+providers:
+  echo:
+    binary: "cat"
+`,
+		},
+		{
+			name: "explicit valid config",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+repo_setup:
+  enabled: false
+  config_path: ".ai-agent-bridge.yaml"
+  default_timeout: "1m"
+  max_timeout: "10m"
+providers:
+  echo:
+    binary: "cat"
+`,
+		},
+		{
+			name: "absolute path rejected",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+repo_setup:
+  config_path: "/tmp/setup.yaml"
+providers:
+  echo:
+    binary: "cat"
+`,
+			wantErr: "config_path must be relative",
+		},
+		{
+			name: "parent component rejected",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+repo_setup:
+  config_path: "../setup.yaml"
+providers:
+  echo:
+    binary: "cat"
+`,
+			wantErr: "must not contain '..'",
+		},
+		{
+			name: "default exceeds max",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+repo_setup:
+  default_timeout: "20m"
+  max_timeout: "10m"
+providers:
+  echo:
+    binary: "cat"
+`,
+			wantErr: "default_timeout must not exceed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "bridge.yaml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			cfg, err := Load(path)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("Load error=%v want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.RepoSetup.ConfigPath != ".ai-agent-bridge.yaml" {
+				t.Fatalf("ConfigPath=%q want .ai-agent-bridge.yaml", cfg.RepoSetup.ConfigPath)
+			}
+			if cfg.RepoSetup.DefaultTimeout == "" || cfg.RepoSetup.MaxTimeout == "" {
+				t.Fatalf("repo setup timeouts not defaulted: %+v", cfg.RepoSetup)
+			}
+		})
+	}
+}
+
+func TestRepoSetupIsEnabled(t *testing.T) {
+	if !(RepoSetupConfig{}).IsEnabled() {
+		t.Fatal("nil enabled should default true")
+	}
+	disabled := false
+	if (RepoSetupConfig{Enabled: &disabled}).IsEnabled() {
+		t.Fatal("explicit false should disable repo setup")
+	}
+}
+
+func TestHasExplicitServerListen(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "missing", body: "providers: {}\n", want: false},
+		{name: "empty", body: "server:\n  listen: \"\"\n", want: false},
+		{name: "set", body: "server:\n  listen: \"127.0.0.1:9445\"\n", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "bridge.yaml")
+			if err := os.WriteFile(path, []byte(tc.body), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			got, err := HasExplicitServerListen(path)
+			if err != nil {
+				t.Fatalf("HasExplicitServerListen: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("HasExplicitServerListen=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLoadStepCAClients(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bridge.yaml")

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/markcallen/ai-agent-bridge/internal/pki"
 	"github.com/markcallen/ai-agent-bridge/internal/provider"
 	"github.com/markcallen/ai-agent-bridge/internal/redact"
+	"github.com/markcallen/ai-agent-bridge/internal/reposetup"
 	"github.com/markcallen/ai-agent-bridge/internal/server"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -197,6 +198,13 @@ type Config struct {
 	// values from log output.
 	RedactPatterns []string
 
+	// RepoSetup controls repo-local pre-agent setup files. Nil means enabled
+	// with built-in defaults.
+	RepoSetupEnabled        *bool
+	RepoSetupConfigPath     string
+	RepoSetupDefaultTimeout time.Duration
+	RepoSetupMaxTimeout     time.Duration
+
 	// RateLimits overrides the default rate-limit config. Zero values keep
 	// the built-in defaults.
 	RateLimits server.RateLimitConfig
@@ -262,7 +270,17 @@ func Start(cfg Config) (*Server, error) {
 	// its zero value.
 	var configProviderDefs map[string]config.ProviderConfig
 	var providerRoot string
+	repoSetupEnabled := true
+	repoSetupConfigPath := ".ai-agent-bridge.yaml"
+	repoSetupDefaultTimeout := 2 * time.Minute
+	repoSetupMaxTimeout := 15 * time.Minute
+	configHasServerListen := false
 	if cfg.ConfigPath != "" {
+		var err error
+		configHasServerListen, err = config.HasExplicitServerListen(cfg.ConfigPath)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("inspect config %q: %w", cfg.ConfigPath, err)
+		}
 		fileCfg, err := config.Load(cfg.ConfigPath)
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("load config %q: %w", cfg.ConfigPath, err)
@@ -272,6 +290,10 @@ func Start(cfg Config) (*Server, error) {
 				configProviderDefs = fileCfg.Providers
 			}
 			providerRoot = fileCfg.Runtime.ProviderRoot
+			repoSetupEnabled = fileCfg.RepoSetup.IsEnabled()
+			repoSetupConfigPath = fileCfg.RepoSetup.ConfigPath
+			repoSetupDefaultTimeout = config.ParseDuration(fileCfg.RepoSetup.DefaultTimeout, repoSetupDefaultTimeout)
+			repoSetupMaxTimeout = config.ParseDuration(fileCfg.RepoSetup.MaxTimeout, repoSetupMaxTimeout)
 			if cfg.DBPath == "" && fileCfg.Persistence.DBPath != "" {
 				cfg.DBPath = fileCfg.Persistence.DBPath
 			}
@@ -305,7 +327,7 @@ func Start(cfg Config) (*Server, error) {
 			if cfg.AllowedPaths == nil && len(fileCfg.AllowedPaths) > 0 {
 				cfg.AllowedPaths = fileCfg.AllowedPaths
 			}
-			if cfg.ListenAddr == "" && fileCfg.Server.Listen != "" {
+			if cfg.ListenAddr == "" && configHasServerListen && fileCfg.Server.Listen != "" {
 				cfg.ListenAddr = fileCfg.Server.Listen
 			}
 			if cfg.CABundlePath == "" && fileCfg.TLS.CABundle != "" {
@@ -378,6 +400,18 @@ func Start(cfg Config) (*Server, error) {
 	if cfg.IdleTimeout <= 0 {
 		cfg.IdleTimeout = 30 * time.Minute
 	}
+	if cfg.RepoSetupEnabled != nil {
+		repoSetupEnabled = *cfg.RepoSetupEnabled
+	}
+	if cfg.RepoSetupConfigPath != "" {
+		repoSetupConfigPath = cfg.RepoSetupConfigPath
+	}
+	if cfg.RepoSetupDefaultTimeout > 0 {
+		repoSetupDefaultTimeout = cfg.RepoSetupDefaultTimeout
+	}
+	if cfg.RepoSetupMaxTimeout > 0 {
+		repoSetupMaxTimeout = cfg.RepoSetupMaxTimeout
+	}
 
 	stateDir := cfg.StateDir
 	if stateDir == "" {
@@ -396,12 +430,14 @@ func Start(cfg Config) (*Server, error) {
 		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
 	}
 
+	var logRedactor *redact.Redactor
 	// Apply log redaction when patterns are configured.
 	if len(cfg.RedactPatterns) > 0 {
 		redactor, err := redact.New(cfg.RedactPatterns)
 		if err != nil {
 			return nil, fmt.Errorf("compile redact patterns: %w", err)
 		}
+		logRedactor = redactor
 		logger = slog.New(&redactingHandler{inner: logger.Handler(), redactor: redactor})
 	}
 
@@ -412,6 +448,21 @@ func Start(cfg Config) (*Server, error) {
 	// Build provider registry. Config-file providers take precedence; the
 	// auto-detect path fills in any providers not explicitly configured.
 	registry := bridge.NewRegistry()
+	var redactFunc func(string) string
+	if logRedactor != nil {
+		redactFunc = logRedactor.Redact
+	}
+	repoSetupRunner := reposetup.NewCoordinator(reposetup.Options{
+		Enabled:        repoSetupEnabled,
+		ConfigPath:     repoSetupConfigPath,
+		DefaultTimeout: repoSetupDefaultTimeout,
+		MaxTimeout:     repoSetupMaxTimeout,
+		Logger:         logger,
+		Redact:         redactFunc,
+		BaseEnv: func() []string {
+			return provider.FilterEnv(os.Environ())
+		},
+	})
 
 	// Register providers explicitly declared in the config file.
 	for id, pc := range configProviderDefs {
@@ -493,6 +544,7 @@ func Start(cfg Config) (*Server, error) {
 
 	// Supervisor options: persistence store when DBPath is set.
 	var supOpts []bridge.SupervisorOption
+	supOpts = append(supOpts, bridge.WithRepoSetupRunner(repoSetupRunner))
 	var store bridge.SessionStore
 	if cfg.DBPath != "" {
 		var err error

--- a/internal/localserver/localserver_test.go
+++ b/internal/localserver/localserver_test.go
@@ -114,6 +114,22 @@ sessions:
 	assert.NotNil(t, srv)
 }
 
+func TestStartWithConfigFileWithoutListenStaysLocal(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "bridge.yaml")
+	require.NoError(t, os.WriteFile(cfgFile, []byte(`
+providers:
+  echo:
+    binary: "cat"
+`), 0o644))
+
+	srv := startLocalServer(t, Config{
+		StateDir:   dir,
+		ConfigPath: cfgFile,
+	})
+	assert.Equal(t, "unix", srv.listener.Addr().Network())
+}
+
 // TestStartConfigFileExplicitOverride verifies that an explicit flag value
 // takes precedence over the same value in the config file.
 func TestStartConfigFileExplicitOverride(t *testing.T) {

--- a/internal/provider/stdio.go
+++ b/internal/provider/stdio.go
@@ -102,7 +102,11 @@ func (p *StdioProvider) BuildCommand(ctx context.Context, cfg bridge.SessionConf
 	}
 	cmd := exec.CommandContext(ctx, binPath, args...)
 	cmd.Dir = cfg.RepoPath
-	cmd.Env = filterEnv(os.Environ())
+	if cfg.Env != nil {
+		cmd.Env = append([]string(nil), cfg.Env...)
+	} else {
+		cmd.Env = FilterEnv(os.Environ())
+	}
 	return cmd, nil
 }
 
@@ -253,6 +257,10 @@ func (p *StdioProvider) Version(ctx context.Context) (string, error) {
 }
 
 func (p *StdioProvider) Health(ctx context.Context) error {
+	return p.HealthWithEnv(ctx, FilterEnv(os.Environ()))
+}
+
+func (p *StdioProvider) HealthWithEnv(ctx context.Context, env []string) error {
 	p.mu.RLock()
 	unavailErr := p.unavailableErr
 	p.mu.RUnlock()
@@ -271,7 +279,7 @@ func (p *StdioProvider) Health(ctx context.Context) error {
 		return fmt.Errorf("binary %q is not executable", path)
 	}
 	for _, envName := range p.cfg.RequiredEnv {
-		if strings.TrimSpace(os.Getenv(envName)) == "" {
+		if strings.TrimSpace(envValue(env, envName)) == "" {
 			return fmt.Errorf("required env var %s not set", envName)
 		}
 	}
@@ -384,9 +392,9 @@ func versionProbeEnv() []string {
 	return env
 }
 
-// filterEnv returns a filtered environment excluding sensitive variables and
+// FilterEnv returns a filtered environment excluding sensitive variables and
 // variables that interfere with subprocess behaviour.
-func filterEnv(env []string) []string {
+func FilterEnv(env []string) []string {
 	blocked := map[string]bool{
 		"AWS_SECRET_ACCESS_KEY": true,
 		"AWS_SESSION_TOKEN":     true,
@@ -410,6 +418,20 @@ func filterEnv(env []string) []string {
 		filtered = append(filtered, "COLORTERM=truecolor")
 	}
 	return filtered
+}
+
+func filterEnv(env []string) []string {
+	return FilterEnv(env)
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			return strings.TrimPrefix(item, prefix)
+		}
+	}
+	return ""
 }
 
 func hasEnvKey(env []string, key string) bool {

--- a/internal/provider/stdio_additional_test.go
+++ b/internal/provider/stdio_additional_test.go
@@ -52,6 +52,11 @@ func TestHealthRequiredEnv(t *testing.T) {
 	if err := p.Health(context.Background()); err != nil {
 		t.Fatalf("Health with env set: %v", err)
 	}
+
+	_ = os.Unsetenv(key)
+	if err := p.HealthWithEnv(context.Background(), []string{"PATH=" + os.Getenv("PATH"), key + "=from-setup"}); err != nil {
+		t.Fatalf("HealthWithEnv with setup env: %v", err)
+	}
 }
 
 func TestValidateStartupRequiredEnv(t *testing.T) {

--- a/internal/provider/stdio_test.go
+++ b/internal/provider/stdio_test.go
@@ -39,6 +39,26 @@ func TestBuildCommandIncludesProviderArgs(t *testing.T) {
 	}
 }
 
+func TestBuildCommandUsesPreparedEnvironment(t *testing.T) {
+	p := NewStdioProvider(StdioConfig{
+		ProviderID: "fake",
+		Binary:     "/bin/echo",
+	})
+
+	cmd, err := p.BuildCommand(context.Background(), bridge.SessionConfig{
+		ProjectID: "test",
+		SessionID: "session",
+		RepoPath:  ".",
+		Env:       []string{"FROM_SETUP=1"},
+	})
+	if err != nil {
+		t.Fatalf("BuildCommand: %v", err)
+	}
+	if len(cmd.Env) != 1 || cmd.Env[0] != "FROM_SETUP=1" {
+		t.Fatalf("Env=%v want prepared environment", cmd.Env)
+	}
+}
+
 func TestBuildCommandAbsolutizesRelativeScriptArgForNode(t *testing.T) {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/internal/reposetup/process_unix.go
+++ b/internal/reposetup/process_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package reposetup
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}

--- a/internal/reposetup/process_windows.go
+++ b/internal/reposetup/process_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package reposetup
+
+import "os/exec"
+
+func setProcessGroup(*exec.Cmd) {}
+
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+}

--- a/internal/reposetup/setup.go
+++ b/internal/reposetup/setup.go
@@ -1,0 +1,315 @@
+package reposetup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+	"gopkg.in/yaml.v3"
+)
+
+const envMarker = "__AI_AGENT_BRIDGE_ENV__"
+
+var ErrSetupFailed = errors.New("repo setup failed")
+
+type Options struct {
+	Enabled        bool
+	ConfigPath     string
+	DefaultTimeout time.Duration
+	MaxTimeout     time.Duration
+	Logger         *slog.Logger
+	Redact         func(string) string
+	BaseEnv        func() []string
+}
+
+type Coordinator struct {
+	opts  Options
+	group singleflight.Group
+}
+
+type fileConfig struct {
+	Version int               `yaml:"version"`
+	Shell   string            `yaml:"shell"`
+	Setup   []string          `yaml:"setup"`
+	Env     map[string]string `yaml:"env"`
+	Timeout string            `yaml:"timeout"`
+}
+
+func NewCoordinator(opts Options) *Coordinator {
+	if opts.ConfigPath == "" {
+		opts.ConfigPath = ".ai-agent-bridge.yaml"
+	}
+	if opts.DefaultTimeout <= 0 {
+		opts.DefaultTimeout = 2 * time.Minute
+	}
+	if opts.MaxTimeout <= 0 {
+		opts.MaxTimeout = 15 * time.Minute
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+	if opts.Redact == nil {
+		opts.Redact = defaultRedact
+	}
+	if opts.BaseEnv == nil {
+		opts.BaseEnv = os.Environ
+	}
+	return &Coordinator{opts: opts}
+}
+
+func (c *Coordinator) Prepare(ctx context.Context, repoPath string, baseEnv []string) ([]string, error) {
+	if c == nil {
+		if baseEnv == nil {
+			baseEnv = os.Environ()
+		}
+		return append([]string(nil), baseEnv...), nil
+	}
+	if baseEnv == nil {
+		if c.opts.BaseEnv != nil {
+			baseEnv = c.opts.BaseEnv()
+		} else {
+			baseEnv = os.Environ()
+		}
+	}
+	if !c.opts.Enabled {
+		return append([]string(nil), baseEnv...), nil
+	}
+	cleanRepo, configPath, err := resolveConfigPath(repoPath, c.opts.ConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(configPath); err != nil {
+		if os.IsNotExist(err) {
+			return append([]string(nil), baseEnv...), nil
+		}
+		return nil, fmt.Errorf("%w: stat %s: %v", ErrSetupFailed, configPath, err)
+	}
+
+	key := cleanRepo
+	env, err, _ := c.group.Do(key, func() (any, error) {
+		return c.prepareOnce(ctx, cleanRepo, configPath, baseEnv)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return append([]string(nil), env.([]string)...), nil
+}
+
+func (c *Coordinator) prepareOnce(ctx context.Context, repoPath, configPath string, baseEnv []string) ([]string, error) {
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrSetupFailed, err)
+	}
+	timeout, err := effectiveTimeout(cfg.Timeout, c.opts.DefaultTimeout, c.opts.MaxTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrSetupFailed, err)
+	}
+	env := mergeEnv(baseEnv, cfg.Env)
+
+	c.opts.Logger.Info("repo setup starting", "repo_path", repoPath, "config_path", configPath, "timeout", timeout.String(), "shell", cfg.Shell)
+	setupCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(setupCtx, cfg.Shell, "-lc", setupScript(cfg.Setup))
+	cmd.Dir = repoPath
+	cmd.Env = env
+	setProcessGroup(cmd)
+
+	out, runErr := cmd.CombinedOutput()
+	if setupCtx.Err() == context.DeadlineExceeded {
+		killProcessGroup(cmd)
+		msg := fmt.Sprintf("setup timed out after %s", timeout)
+		c.opts.Logger.Warn("repo setup failed", "repo_path", repoPath, "error", msg)
+		return nil, fmt.Errorf("%w: %s", ErrSetupFailed, msg)
+	}
+	if runErr != nil {
+		killProcessGroup(cmd)
+		msg := strings.TrimSpace(c.opts.Redact(string(out)))
+		if msg == "" {
+			msg = runErr.Error()
+		}
+		c.opts.Logger.Warn("repo setup failed", "repo_path", repoPath, "error", runErr, "output", msg)
+		return nil, fmt.Errorf("%w: command failed: %v; output: %s", ErrSetupFailed, runErr, msg)
+	}
+
+	captured, err := parseCapturedEnv(out)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrSetupFailed, err)
+	}
+	c.opts.Logger.Info("repo setup succeeded", "repo_path", repoPath)
+	return captured, nil
+}
+
+func loadConfig(path string) (*fileConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	cfg := &fileConfig{}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if cfg.Version != 1 {
+		return nil, fmt.Errorf("version must be 1")
+	}
+	if cfg.Shell == "" {
+		cfg.Shell = "bash"
+	}
+	switch cfg.Shell {
+	case "bash", "sh":
+	default:
+		return nil, fmt.Errorf("unsupported shell %q", cfg.Shell)
+	}
+	for i, line := range cfg.Setup {
+		if strings.TrimSpace(line) == "" {
+			return nil, fmt.Errorf("setup[%d] must not be empty", i)
+		}
+	}
+	for key := range cfg.Env {
+		if !validEnvKey(key) {
+			return nil, fmt.Errorf("env key %q is invalid", key)
+		}
+	}
+	return cfg, nil
+}
+
+func resolveConfigPath(repoPath, configPath string) (string, string, error) {
+	if filepath.IsAbs(configPath) {
+		return "", "", fmt.Errorf("%w: config_path must be relative", ErrSetupFailed)
+	}
+	repoAbs, err := filepath.Abs(repoPath)
+	if err != nil {
+		return "", "", fmt.Errorf("%w: resolve repo path: %v", ErrSetupFailed, err)
+	}
+	repoReal, err := filepath.EvalSymlinks(repoAbs)
+	if err != nil {
+		repoReal = filepath.Clean(repoAbs)
+	}
+	candidate := filepath.Join(repoReal, configPath)
+	cleanCandidate := filepath.Clean(candidate)
+	rel, err := filepath.Rel(repoReal, cleanCandidate)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", "", fmt.Errorf("%w: config path escapes repo root", ErrSetupFailed)
+	}
+	return repoReal, cleanCandidate, nil
+}
+
+func effectiveTimeout(raw string, def, max time.Duration) (time.Duration, error) {
+	if raw == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("timeout: %w", err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("timeout must be > 0")
+	}
+	if d > max {
+		return 0, fmt.Errorf("timeout %s exceeds max_timeout %s", d, max)
+	}
+	return d, nil
+}
+
+func setupScript(lines []string) string {
+	var b strings.Builder
+	b.WriteString("set -e\n")
+	for _, line := range lines {
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	b.WriteString("printf '\\n")
+	b.WriteString(envMarker)
+	b.WriteString("\\n'\n")
+	b.WriteString("env -0\n")
+	return b.String()
+}
+
+func parseCapturedEnv(out []byte) ([]string, error) {
+	marker := []byte("\n" + envMarker + "\n")
+	idx := bytes.LastIndex(out, marker)
+	if idx < 0 {
+		return nil, fmt.Errorf("environment marker missing from setup output")
+	}
+	raw := out[idx+len(marker):]
+	parts := bytes.Split(raw, []byte{0})
+	env := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		if !bytes.Contains(part, []byte("=")) {
+			continue
+		}
+		env = append(env, string(part))
+	}
+	return env, nil
+}
+
+func mergeEnv(base []string, extra map[string]string) []string {
+	out := append([]string(nil), base...)
+	for key, value := range extra {
+		out = setEnv(out, key, value)
+	}
+	return out
+}
+
+func setEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	item := prefix + value
+	for i, existing := range env {
+		if strings.HasPrefix(existing, prefix) {
+			env[i] = item
+			return env
+		}
+	}
+	return append(env, item)
+}
+
+func validEnvKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for i, r := range key {
+		if i == 0 {
+			if r != '_' && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') {
+				return false
+			}
+			continue
+		}
+		if r != '_' && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func defaultRedact(s string) string {
+	for _, key := range []string{"TOKEN", "SECRET", "PASSWORD", "API_KEY"} {
+		s = redactAssignments(s, key)
+	}
+	return s
+}
+
+func redactAssignments(s, contains string) string {
+	fields := strings.Fields(s)
+	for i, field := range fields {
+		key, _, ok := strings.Cut(field, "=")
+		if ok && strings.Contains(strings.ToUpper(key), contains) {
+			fields[i] = key + "=" + strconv.Quote("[REDACTED]")
+		}
+	}
+	if len(fields) == 0 {
+		return s
+	}
+	return strings.Join(fields, " ")
+}

--- a/internal/reposetup/setup_test.go
+++ b/internal/reposetup/setup_test.go
@@ -1,0 +1,278 @@
+package reposetup
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPrepareNoConfigReturnsBaseEnv(t *testing.T) {
+	c := NewCoordinator(Options{Enabled: true})
+	env, err := c.Prepare(context.Background(), t.TempDir(), []string{"PATH=/bin", "KEEP=1"})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if got := strings.Join(env, "\n"); !strings.Contains(got, "KEEP=1") {
+		t.Fatalf("env=%v want KEEP=1", env)
+	}
+}
+
+func TestPrepareDisabledReturnsProvidedEnv(t *testing.T) {
+	c := NewCoordinator(Options{
+		Enabled: false,
+		BaseEnv: func() []string {
+			return []string{"KEEP=default-base"}
+		},
+	})
+	env, err := c.Prepare(context.Background(), t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if got := envValue(env, "KEEP"); got != "default-base" {
+		t.Fatalf("KEEP=%q want default-base", got)
+	}
+}
+
+func TestPrepareDisabledZeroValueCoordinatorUsesProcessEnv(t *testing.T) {
+	t.Setenv("BRIDGE_REPOSETUP_BASE_ENV_TEST", "present")
+	c := &Coordinator{}
+	env, err := c.Prepare(context.Background(), t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if got := envValue(env, "BRIDGE_REPOSETUP_BASE_ENV_TEST"); got != "present" {
+		t.Fatalf("BRIDGE_REPOSETUP_BASE_ENV_TEST=%q want present", got)
+	}
+}
+
+func TestPrepareNilCoordinatorUsesProcessEnv(t *testing.T) {
+	t.Setenv("BRIDGE_REPOSETUP_NIL_BASE_ENV_TEST", "present")
+	var c *Coordinator
+	env, err := c.Prepare(context.Background(), t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if got := envValue(env, "BRIDGE_REPOSETUP_NIL_BASE_ENV_TEST"); got != "present" {
+		t.Fatalf("BRIDGE_REPOSETUP_NIL_BASE_ENV_TEST=%q want present", got)
+	}
+}
+
+func TestPrepareRunsSetupAndCapturesEnvironment(t *testing.T) {
+	repo := t.TempDir()
+	writeSetup(t, repo, `
+version: 1
+shell: bash
+timeout: 5s
+env:
+  FROM_ENV: configured
+setup:
+  - export FROM_SETUP="$FROM_ENV-done"
+`)
+
+	c := NewCoordinator(Options{
+		Enabled:        true,
+		DefaultTimeout: time.Second,
+		MaxTimeout:     10 * time.Second,
+		BaseEnv: func() []string {
+			return []string{"PATH=" + os.Getenv("PATH")}
+		},
+	})
+	env, err := c.Prepare(context.Background(), repo, nil)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if got := envValue(env, "FROM_ENV"); got != "configured" {
+		t.Fatalf("FROM_ENV=%q want configured", got)
+	}
+	if got := envValue(env, "FROM_SETUP"); got != "configured-done" {
+		t.Fatalf("FROM_SETUP=%q want configured-done", got)
+	}
+}
+
+func TestPrepareTimesOut(t *testing.T) {
+	repo := t.TempDir()
+	writeSetup(t, repo, `
+version: 1
+setup:
+  - sleep 5
+`)
+
+	c := NewCoordinator(Options{Enabled: true, DefaultTimeout: 50 * time.Millisecond, MaxTimeout: time.Second})
+	_, err := c.Prepare(context.Background(), repo, []string{"PATH=" + os.Getenv("PATH")})
+	if !errors.Is(err, ErrSetupFailed) || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("Prepare error=%v want timeout setup failure", err)
+	}
+}
+
+func TestPrepareFailsWhenTimeoutExceedsMax(t *testing.T) {
+	repo := t.TempDir()
+	writeSetup(t, repo, `
+version: 1
+timeout: 20s
+setup:
+  - true
+`)
+
+	c := NewCoordinator(Options{Enabled: true, DefaultTimeout: time.Second, MaxTimeout: 2 * time.Second})
+	_, err := c.Prepare(context.Background(), repo, []string{"PATH=" + os.Getenv("PATH")})
+	if !errors.Is(err, ErrSetupFailed) || !strings.Contains(err.Error(), "exceeds max_timeout") {
+		t.Fatalf("Prepare error=%v want max timeout setup failure", err)
+	}
+}
+
+func TestLoadConfigValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "bad version", content: `version: 2`, want: "version must be 1"},
+		{name: "bad shell", content: "version: 1\nshell: fish\n", want: "unsupported shell"},
+		{name: "empty setup", content: "version: 1\nsetup: [\"\"]\n", want: "setup[0]"},
+		{name: "bad env key", content: "version: 1\nenv:\n  1BAD: value\n", want: "env key"},
+		{name: "bad yaml", content: "version: [", want: "parse"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeSetup(t, repo, tc.content)
+			c := NewCoordinator(Options{Enabled: true})
+			_, err := c.Prepare(context.Background(), repo, []string{"PATH=" + os.Getenv("PATH")})
+			if !errors.Is(err, ErrSetupFailed) || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Prepare error=%v want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveConfigPathRejectsEscapes(t *testing.T) {
+	repo := t.TempDir()
+	for _, configPath := range []string{"/tmp/setup.yaml", "../setup.yaml"} {
+		_, _, err := resolveConfigPath(repo, configPath)
+		if !errors.Is(err, ErrSetupFailed) {
+			t.Fatalf("resolveConfigPath(%q) error=%v want setup failure", configPath, err)
+		}
+	}
+}
+
+func TestParseCapturedEnvRequiresMarker(t *testing.T) {
+	_, err := parseCapturedEnv([]byte("NO_MARKER=1\x00"))
+	if err == nil || !strings.Contains(err.Error(), "marker missing") {
+		t.Fatalf("parseCapturedEnv error=%v want marker missing", err)
+	}
+}
+
+func TestDefaultRedact(t *testing.T) {
+	got := defaultRedact("OPENAI_API_KEY=secret OTHER=value TOKEN=tok")
+	if strings.Contains(got, "secret") || strings.Contains(got, "tok") {
+		t.Fatalf("defaultRedact leaked secret: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("defaultRedact=%q want redaction marker", got)
+	}
+}
+
+func TestPrepareFailsOnCommandErrorWithRedactedOutput(t *testing.T) {
+	repo := t.TempDir()
+	writeSetup(t, repo, `
+version: 1
+setup:
+  - echo "API_KEY=secret-value"
+  - exit 7
+`)
+
+	c := NewCoordinator(Options{
+		Enabled:        true,
+		DefaultTimeout: time.Second,
+		MaxTimeout:     2 * time.Second,
+		Redact: func(s string) string {
+			return strings.ReplaceAll(s, "secret-value", "[REDACTED]")
+		},
+	})
+	_, err := c.Prepare(context.Background(), repo, []string{"PATH=" + os.Getenv("PATH")})
+	if !errors.Is(err, ErrSetupFailed) {
+		t.Fatalf("Prepare error=%v want setup failure", err)
+	}
+	if strings.Contains(err.Error(), "secret-value") || !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("error was not redacted: %v", err)
+	}
+}
+
+func TestPrepareSerializesConcurrentSameRepoSetup(t *testing.T) {
+	repo := t.TempDir()
+	countFile := filepath.Join(repo, "count")
+	writeSetup(t, repo, `
+version: 1
+setup:
+  - current="$(cat count 2>/dev/null || true)"
+  - if [ -z "$current" ]; then current=0; fi
+  - echo "$((current + 1))" > count
+  - sleep 0.2
+  - export SETUP_COUNT="$(cat count)"
+`)
+
+	var baseCalls atomic.Int32
+	c := NewCoordinator(Options{
+		Enabled:        true,
+		DefaultTimeout: 2 * time.Second,
+		MaxTimeout:     5 * time.Second,
+		BaseEnv: func() []string {
+			baseCalls.Add(1)
+			return []string{"PATH=" + os.Getenv("PATH")}
+		},
+	})
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			env, err := c.Prepare(context.Background(), repo, nil)
+			if err == nil && envValue(env, "SETUP_COUNT") != "1" {
+				err = errors.New("unexpected setup count " + envValue(env, "SETUP_COUNT"))
+			}
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	data, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "1" {
+		t.Fatalf("setup count=%q want 1", got)
+	}
+	if got := baseCalls.Load(); got != 2 {
+		t.Fatalf("base env calls=%d want 2", got)
+	}
+}
+
+func writeSetup(t *testing.T, repo, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, ".ai-agent-bridge.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			return strings.TrimPrefix(item, prefix)
+		}
+	}
+	return ""
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -419,6 +419,8 @@ func mapBridgeError(err error, op string) error {
 		return status.Errorf(codes.PermissionDenied, "%s: %v", op, err)
 	case errors.Is(err, bridge.ErrProviderUnavailable), errors.Is(err, bridge.ErrSessionRecoveryUnavailable):
 		return status.Errorf(codes.Unavailable, "%s: %v", op, err)
+	case errors.Is(err, bridge.ErrRepoSetupFailed):
+		return status.Errorf(codes.FailedPrecondition, "%s: %v", op, err)
 	case errors.Is(err, bridge.ErrSessionLimitReached):
 		return status.Errorf(codes.ResourceExhausted, "%s: %v", op, err)
 	default:

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -233,6 +233,7 @@ func TestMapBridgeErrorAndState(t *testing.T) {
 		{err: bridge.ErrClientMismatch, code: codes.PermissionDenied},
 		{err: bridge.ErrProviderUnavailable, code: codes.Unavailable},
 		{err: bridge.ErrSessionRecoveryUnavailable, code: codes.Unavailable},
+		{err: bridge.ErrRepoSetupFailed, code: codes.FailedPrecondition},
 		{err: bridge.ErrSessionLimitReached, code: codes.ResourceExhausted},
 		{err: errors.New("boom"), code: codes.Internal},
 	}

--- a/packaging/bridge.yaml
+++ b/packaging/bridge.yaml
@@ -37,6 +37,12 @@ rate_limits:
 persistence:
   # db_path: "~/.ai-agent-bridge/sessions.db"
 
+repo_setup:
+  enabled: true
+  config_path: ".ai-agent-bridge.yaml"
+  default_timeout: "2m"
+  max_timeout: "15m"
+
 providers: {}
 
 allowed_paths:

--- a/packaging/examples/bridge-example.yaml
+++ b/packaging/examples/bridge-example.yaml
@@ -65,6 +65,12 @@ persistence:
 runtime:
   provider_root: "/opt/ai-agent-bridge"
 
+repo_setup:
+  enabled: true
+  config_path: ".ai-agent-bridge.yaml"
+  default_timeout: "2m"
+  max_timeout: "15m"
+
 # Enable one or more providers below. Credentials are read from the environment
 # (injected via /etc/ai-agent-bridge/agents.env at service startup).
 #


### PR DESCRIPTION
## Summary
- add repo-local .ai-agent-bridge.yaml setup execution before provider selection and launch
- serialize in-flight setup per canonical repo path and propagate captured env into provider health checks/subprocesses
- document repo_setup defaults and examples for Next.js+nvm/corepack/pnpm and Go Makefile setup

## Tests
- make test
- make lint
- go test -v -count=1 -race -timeout 120s ./e2e/bridgectl/

Closes #164