### PR TITLE
Fix watcher cancellation on terminal resize

### DIFF
--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -302,6 +302,7 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 
 	isWriter := role == bridgev1.AttachRole_ATTACH_ROLE_WRITER || takeOver
 	var detached atomic.Bool
+	var sessionExit string
 
 	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
@@ -309,20 +310,15 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 	defer signal.Stop(sigCh)
 
 	go func() {
-		for sig := range sigCh {
-			if isSigwinch(sig) && isWriter {
-				c, r := currentTTYSize()
-				_, _ = client.ResizeSession(context.Background(), &bridgev1.ResizeSessionRequest{
-					SessionId: sessionID,
-					ClientId:  stream.ClientID(),
-					Cols:      c,
-					Rows:      r,
-				})
-				continue
-			}
-			cancel()
-			return
-		}
+		handleAttachSignals(ctx, sigCh, isWriter, func() {
+			c, r := currentTTYSize()
+			_, _ = client.ResizeSession(context.Background(), &bridgev1.ResizeSessionRequest{
+				SessionId: sessionID,
+				ClientId:  stream.ClientID(),
+				Cols:      c,
+				Rows:      r,
+			})
+		}, cancel)
 	}()
 
 	if isWriter {
@@ -386,6 +382,9 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 			return writeErr
 		case bridgev1.AttachEventType_ATTACH_EVENT_TYPE_ERROR:
 			return errors.New(ev.Error)
+		case bridgev1.AttachEventType_ATTACH_EVENT_TYPE_SESSION_EXIT:
+			sessionExit = sessionExitMessage(ev)
+			return errSessionExit
 		case bridgev1.AttachEventType_ATTACH_EVENT_TYPE_WRITER_CLAIMED:
 			_, writeErr := fmt.Fprintf(os.Stderr, "\r\n[ai-agent-bridge] writer claimed by %s\r\n", ev.WriterClientId)
 			return writeErr
@@ -401,6 +400,10 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 	if detached.Load() {
 		fmt.Fprintf(os.Stderr, "\r\nDetached from session %s\r\n", sessionID)
 		fmt.Fprintf(os.Stderr, "Reattach with: bridgectl session attach %s\r\n", sessionID)
+		return nil
+	}
+	if sessionExit != "" {
+		fmt.Fprintf(os.Stderr, "\r\n%s\r\n", sessionExit)
 		return nil
 	}
 	if err != nil {

--- a/cmd/bridgectl/session_events.go
+++ b/cmd/bridgectl/session_events.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	bridgev1 "github.com/markcallen/ai-agent-bridge/gen/bridge/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var errSessionExit = errors.New("session exit event received")
+
+type attachSignalHandling int
+
+const (
+	attachSignalCancel attachSignalHandling = iota
+	attachSignalIgnore
+	attachSignalResize
+)
+
+func attachSignalAction(sig os.Signal, isWriter bool) attachSignalHandling {
+	if !isSigwinch(sig) {
+		return attachSignalCancel
+	}
+	if isWriter {
+		return attachSignalResize
+	}
+	return attachSignalIgnore
+}
+
+func handleAttachSignals(ctx context.Context, sigCh <-chan os.Signal, isWriter bool, resize func(), cancel func()) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case sig := <-sigCh:
+			switch attachSignalAction(sig, isWriter) {
+			case attachSignalResize:
+				resize()
+			case attachSignalIgnore:
+				continue
+			case attachSignalCancel:
+				cancel()
+				return
+			}
+		}
+	}
+}
+
+func sessionExitMessage(ev *bridgev1.AttachSessionEvent) string {
+	if ev.GetExitRecorded() {
+		return fmt.Sprintf("Session exited with code %d.", ev.GetExitCode())
+	}
+	return "Session exited."
+}
+
+func isCanceledStreamError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return err != nil
+	}
+	st, ok := status.FromError(err)
+	return ok && st.Code() == codes.Canceled
+}

--- a/cmd/bridgectl/session_events_test.go
+++ b/cmd/bridgectl/session_events_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	bridgev1 "github.com/markcallen/ai-agent-bridge/gen/bridge/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestSessionExitMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		ev   *bridgev1.AttachSessionEvent
+		want string
+	}{
+		{
+			name: "exit recorded",
+			ev: &bridgev1.AttachSessionEvent{
+				ExitRecorded: true,
+				ExitCode:     7,
+			},
+			want: "Session exited with code 7.",
+		},
+		{
+			name: "exit not recorded",
+			ev:   &bridgev1.AttachSessionEvent{},
+			want: "Session exited.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sessionExitMessage(tt.ev); got != tt.want {
+				t.Fatalf("sessionExitMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsCanceledStreamError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "context canceled",
+			err:  context.Canceled,
+			want: true,
+		},
+		{
+			name: "wrapped context canceled",
+			err:  errors.Join(errors.New("stream failed"), context.Canceled),
+			want: true,
+		},
+		{
+			name: "grpc canceled",
+			err:  status.Error(codes.Canceled, "context canceled"),
+			want: true,
+		},
+		{
+			name: "grpc unavailable",
+			err:  status.Error(codes.Unavailable, "transport closed"),
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCanceledStreamError(tt.err); got != tt.want {
+				t.Fatalf("isCanceledStreamError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/bridgectl/session_signal_unix_test.go
+++ b/cmd/bridgectl/session_signal_unix_test.go
@@ -1,0 +1,140 @@
+//go:build !windows
+
+package main
+
+import (
+	"context"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestAttachSignalAction(t *testing.T) {
+	tests := []struct {
+		name     string
+		sig      os.Signal
+		isWriter bool
+		want     attachSignalHandling
+	}{
+		{
+			name:     "observer ignores resize",
+			sig:      syscall.SIGWINCH,
+			isWriter: false,
+			want:     attachSignalIgnore,
+		},
+		{
+			name:     "writer resizes",
+			sig:      syscall.SIGWINCH,
+			isWriter: true,
+			want:     attachSignalResize,
+		},
+		{
+			name:     "interrupt cancels observer",
+			sig:      os.Interrupt,
+			isWriter: false,
+			want:     attachSignalCancel,
+		},
+		{
+			name:     "interrupt cancels writer",
+			sig:      os.Interrupt,
+			isWriter: true,
+			want:     attachSignalCancel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := attachSignalAction(tt.sig, tt.isWriter); got != tt.want {
+				t.Fatalf("attachSignalAction(%v, %v) = %v, want %v", tt.sig, tt.isWriter, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleAttachSignalsObserverIgnoresResize(t *testing.T) {
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+
+	sigCh := make(chan os.Signal, 2)
+	done := make(chan struct{})
+	var resizeCalls atomic.Int32
+	var cancelCalls atomic.Int32
+
+	go func() {
+		defer close(done)
+		handleAttachSignals(ctx, sigCh, false, func() {
+			resizeCalls.Add(1)
+		}, func() {
+			cancelCalls.Add(1)
+		})
+	}()
+
+	sigCh <- syscall.SIGWINCH
+	select {
+	case <-done:
+		t.Fatal("observer resize signal ended handler")
+	case <-time.After(25 * time.Millisecond):
+	}
+	if got := resizeCalls.Load(); got != 0 {
+		t.Fatalf("resizeCalls = %d, want 0", got)
+	}
+	if got := cancelCalls.Load(); got != 0 {
+		t.Fatalf("cancelCalls = %d, want 0", got)
+	}
+
+	sigCh <- os.Interrupt
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("interrupt did not end handler")
+	}
+	if got := cancelCalls.Load(); got != 1 {
+		t.Fatalf("cancelCalls = %d, want 1", got)
+	}
+}
+
+func TestHandleAttachSignalsWriterResizes(t *testing.T) {
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+
+	sigCh := make(chan os.Signal, 2)
+	done := make(chan struct{})
+	var resizeCalls atomic.Int32
+	var cancelCalls atomic.Int32
+
+	go func() {
+		defer close(done)
+		handleAttachSignals(ctx, sigCh, true, func() {
+			resizeCalls.Add(1)
+		}, func() {
+			cancelCalls.Add(1)
+		})
+	}()
+
+	sigCh <- syscall.SIGWINCH
+	eventually(t, func() bool { return resizeCalls.Load() == 1 })
+	if got := cancelCalls.Load(); got != 0 {
+		t.Fatalf("cancelCalls = %d, want 0", got)
+	}
+
+	stop()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("context cancellation did not end handler")
+	}
+}
+
+func eventually(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition was not met before deadline")
+}


### PR DESCRIPTION
## Summary
- keep read-only session watchers attached when the terminal emits SIGWINCH
- move attach signal handling into a ctx-aware helper so the signal goroutine exits when attach ends
- add focused regression coverage for observer resize handling, writer resize handling, interrupt cancellation, and ctx cancellation shutdown

## Test evidence
- go test ./cmd/bridgectl
- go test ./...
- make test

## Operational impact
- client-side bridgectl watch/attach behavior only; no server protocol or config changes