### PR TITLE
Fix server SAN mismatch and format repo setup errors

### DIFF
--- a/cmd/bridgectl/run.go
+++ b/cmd/bridgectl/run.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -18,6 +19,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	bridgev1 "github.com/markcallen/ai-agent-bridge/gen/bridge/v1"
 	"github.com/markcallen/ai-agent-bridge/internal/localserver"
@@ -111,7 +114,7 @@ func runSession(dir, providerName, project string, timeout time.Duration) error 
 		InitialCols: cols,
 		InitialRows: rows,
 	}); err != nil {
-		return fmt.Errorf("start session: %w", err)
+		return formatStartSessionError(err)
 	}
 
 	// Put terminal in raw mode.
@@ -295,7 +298,7 @@ func runSessionNoTTY(dir, providerName, project string, timeout time.Duration) e
 		InitialCols: 80,
 		InitialRows: 24,
 	}); err != nil {
-		return fmt.Errorf("start session: %w", err)
+		return formatStartSessionError(err)
 	}
 
 	stream, err := client.AttachSession(ctx, &bridgev1.AttachSessionRequest{
@@ -362,6 +365,50 @@ func runSessionNoTTY(dir, providerName, project string, timeout time.Duration) e
 		return fmt.Errorf("session ended: %w", err)
 	}
 	return nil
+}
+
+// formatStartSessionError reformats gRPC errors from StartSession into
+// user-friendly multi-line output. Repo setup failures in particular get
+// structured with the exit code and indented script output.
+func formatStartSessionError(err error) error {
+	s, ok := status.FromError(err)
+	if !ok {
+		return fmt.Errorf("start session: %w", err)
+	}
+	if s.Code() != codes.FailedPrecondition {
+		return fmt.Errorf("start session: %s", s.Message())
+	}
+	msg := strings.TrimPrefix(s.Message(), "start session: ")
+	const marker = "repo setup failed: "
+	idx := strings.Index(msg, marker)
+	if idx < 0 {
+		return fmt.Errorf("start session: %s", msg)
+	}
+	detail := msg[idx+len(marker):]
+
+	var b strings.Builder
+	b.WriteString("repo setup failed\n\n")
+
+	switch {
+	case strings.HasPrefix(detail, "setup timed out"):
+		b.WriteString("  " + detail + "\n")
+	case strings.HasPrefix(detail, "command failed: "):
+		rest := detail[len("command failed: "):]
+		if outIdx := strings.Index(rest, "; output: "); outIdx >= 0 {
+			fmt.Fprintf(&b, "  %s\n\n", rest[:outIdx])
+			output := strings.TrimSpace(rest[outIdx+len("; output: "):])
+			b.WriteString("  Output:\n")
+			for _, line := range strings.Split(output, "\n") {
+				b.WriteString("    " + line + "\n")
+			}
+		} else {
+			b.WriteString("  " + rest + "\n")
+		}
+	default:
+		b.WriteString("  " + detail + "\n")
+	}
+
+	return errors.New(strings.TrimRight(b.String(), "\n"))
 }
 
 func currentTTYSize() (uint32, uint32) {

--- a/cmd/bridgectl/run_test.go
+++ b/cmd/bridgectl/run_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestFormatStartSessionError_SetupCommandFailed(t *testing.T) {
+	grpcErr := status.Errorf(codes.FailedPrecondition,
+		"start session: repo setup failed: command failed: exit status 254; output: line one\nline two\nline three")
+
+	got := formatStartSessionError(grpcErr)
+	msg := got.Error()
+
+	if !strings.HasPrefix(msg, "repo setup failed") {
+		t.Fatalf("expected prefix 'repo setup failed', got: %s", msg)
+	}
+	if !strings.Contains(msg, "exit status 254") {
+		t.Fatalf("expected exit status, got: %s", msg)
+	}
+	if !strings.Contains(msg, "    line one") {
+		t.Fatalf("expected indented output, got: %s", msg)
+	}
+	if strings.Contains(msg, "rpc error") {
+		t.Fatalf("should not contain gRPC framing, got: %s", msg)
+	}
+	if strings.Count(msg, "start session") > 0 {
+		t.Fatalf("should not contain 'start session', got: %s", msg)
+	}
+}
+
+func TestFormatStartSessionError_SetupTimeout(t *testing.T) {
+	grpcErr := status.Errorf(codes.FailedPrecondition,
+		"start session: repo setup failed: setup timed out after 2m0s")
+
+	got := formatStartSessionError(grpcErr)
+	msg := got.Error()
+
+	if !strings.Contains(msg, "setup timed out after 2m0s") {
+		t.Fatalf("expected timeout message, got: %s", msg)
+	}
+}
+
+func TestFormatStartSessionError_NonSetupError(t *testing.T) {
+	grpcErr := status.Errorf(codes.Unavailable, "provider unavailable")
+	got := formatStartSessionError(grpcErr)
+	msg := got.Error()
+
+	if !strings.Contains(msg, "start session") {
+		t.Fatalf("non-setup errors should keep 'start session' prefix, got: %s", msg)
+	}
+	if !strings.Contains(msg, "provider unavailable") {
+		t.Fatalf("should preserve original message, got: %s", msg)
+	}
+}
+
+func TestFormatStartSessionError_NonGRPC(t *testing.T) {
+	plainErr := errors.New("connection refused")
+	got := formatStartSessionError(plainErr)
+	msg := got.Error()
+
+	if !strings.HasPrefix(msg, "start session:") {
+		t.Fatalf("non-gRPC errors should keep prefix, got: %s", msg)
+	}
+}

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -146,7 +146,7 @@ func serverNameFromCert(certPath string) string {
 		return "server"
 	}
 	for _, name := range cert.DNSNames {
-		if strings.TrimSpace(name) != "" {
+		if strings.TrimSpace(name) != "" && !strings.HasPrefix(name, "*.") {
 			return name
 		}
 	}

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -636,6 +636,10 @@ func Start(cfg Config) (*Server, error) {
 				}
 				return nil, fmt.Errorf("ensure PKI: %w", pkiErr)
 			}
+			// Derive the TLS server name from the actual certificate SANs.
+			// Step CA renewal or ACME provisioners may drop bare-hostname
+			// SANs like "server", so we must use whatever the cert contains.
+			tlsServerName = serverNameFromCert(mat.ServerCertPath)
 		}
 		pkiMat = mat
 

--- a/internal/localserver/localserver_test.go
+++ b/internal/localserver/localserver_test.go
@@ -531,6 +531,46 @@ func TestDiscoverTargetSecureModeServerNameFromCert(t *testing.T) {
 	assert.Equal(t, ModeSecure, mode)
 }
 
+// TestServerNameFromCertSkipsWildcard verifies that serverNameFromCert skips
+// wildcard DNS SANs and returns the first concrete DNS name.
+func TestServerNameFromCertSkipsWildcard(t *testing.T) {
+	dir := t.TempDir()
+	caCertPath, caKeyPath, err := pki.InitCA("test-ca", dir)
+	require.NoError(t, err)
+	caCert, caKey, err := pki.LoadCA(caCertPath, caKeyPath)
+	require.NoError(t, err)
+
+	certPath, _, err := pki.IssueCert(
+		caCert, caKey, pki.CertTypeServer, "wildcard-test",
+		[]string{"*.example.com", "concrete.example.com", "127.0.0.1"}, dir, 0,
+	)
+	require.NoError(t, err)
+
+	name := serverNameFromCert(certPath)
+	assert.Equal(t, "concrete.example.com", name,
+		"should skip wildcard SAN and return the first concrete DNS name")
+}
+
+// TestServerNameFromCertWildcardOnlyFallsBackToIP verifies that when all DNS
+// SANs are wildcards, serverNameFromCert falls back to the first IP SAN.
+func TestServerNameFromCertWildcardOnlyFallsBackToIP(t *testing.T) {
+	dir := t.TempDir()
+	caCertPath, caKeyPath, err := pki.InitCA("test-ca", dir)
+	require.NoError(t, err)
+	caCert, caKey, err := pki.LoadCA(caCertPath, caKeyPath)
+	require.NoError(t, err)
+
+	certPath, _, err := pki.IssueCert(
+		caCert, caKey, pki.CertTypeServer, "wildcard-only",
+		[]string{"*.example.com", "10.0.0.1"}, dir, 0,
+	)
+	require.NoError(t, err)
+
+	name := serverNameFromCert(certPath)
+	assert.Equal(t, "10.0.0.1", name,
+		"should fall back to IP SAN when all DNS SANs are wildcards")
+}
+
 // TestRedactingHandlerRedactsMessage verifies that the redactingHandler wraps
 // the underlying handler and redacts sensitive values from log messages and
 // string attributes without altering non-string attributes.

--- a/internal/localserver/localserver_test.go
+++ b/internal/localserver/localserver_test.go
@@ -469,6 +469,68 @@ func TestDiscoverTargetSecureModeWithWildcardListen(t *testing.T) {
 	assert.Equal(t, ModeSecure, mode)
 }
 
+// TestDiscoverTargetSecureModeServerNameFromCert verifies that when a server
+// cert lacks the default "server" SAN (as happens with Step CA renewal or ACME
+// provisioners), DiscoverTarget still finds the running server because
+// server.name is derived from the actual certificate SANs, not hardcoded.
+func TestDiscoverTargetSecureModeServerNameFromCert(t *testing.T) {
+	dir := t.TempDir()
+	certsDir := CertsDir(dir)
+	require.NoError(t, os.MkdirAll(certsDir, 0o700))
+
+	// Create a CA and issue a server cert with only "custom.example.com" — no "server" SAN.
+	// This simulates what happens after Step CA mTLS renewal drops bare-hostname SANs.
+	caCertPath, caKeyPath, err := pki.InitCA("test-ca", certsDir)
+	require.NoError(t, err)
+	caCert, caKey, err := pki.LoadCA(caCertPath, caKeyPath)
+	require.NoError(t, err)
+
+	// CN is "server" so the file is named server.crt (matching LoadPKIMaterial),
+	// but the SANs only contain "custom.example.com" — no "server" DNS SAN.
+	_, _, err = pki.IssueCert(
+		caCert, caKey, pki.CertTypeServer, "server",
+		[]string{"custom.example.com", "127.0.0.1"}, certsDir, 0,
+	)
+	require.NoError(t, err)
+
+	// Issue a local-client cert (used by probeHealth for mTLS).
+	_, _, err = pki.IssueCert(caCert, caKey, pki.CertTypeClient, "local-client", nil, certsDir, 0)
+	require.NoError(t, err)
+
+	// Create JWT keypair.
+	_, _, err = pki.GenerateJWTKeypair(certsDir, "jwt-signing")
+	require.NoError(t, err)
+
+	// Write a ca-bundle.crt that includes the CA cert (same as both server and client CA here).
+	caData, err := os.ReadFile(caCertPath)
+	require.NoError(t, err)
+	bundlePath := filepath.Join(certsDir, "ca-bundle.crt")
+	require.NoError(t, os.WriteFile(bundlePath, caData, 0o644))
+
+	// Mark PKI mode as auto so EnsurePKI returns early (certs already exist).
+	require.NoError(t, writePKIMode(certsDir, pkiModeAuto))
+
+	// Start the server. The auto-PKI path should derive tlsServerName from the cert.
+	srv, err := Start(Config{
+		StateDir:   dir,
+		ListenAddr: "127.0.0.1:0",
+	})
+	if err != nil {
+		t.Fatalf("secure mode start failed: %v", err)
+	}
+	t.Cleanup(func() { srv.Stop() })
+
+	// server.name must reflect the actual cert SAN, not the default "server".
+	actualName := DiscoverServerName(dir)
+	assert.Equal(t, "custom.example.com", actualName,
+		"server.name should be derived from the cert SAN, not the default 'server'")
+
+	// DiscoverTarget must find the running server despite the non-default SAN.
+	target, mode := DiscoverTarget(dir)
+	assert.NotEmpty(t, target, "DiscoverTarget should find the running secure server")
+	assert.Equal(t, ModeSecure, mode)
+}
+
 // TestRedactingHandlerRedactsMessage verifies that the redactingHandler wraps
 // the underlying handler and redacts sensitive values from log messages and
 // string attributes without altering non-string attributes.


### PR DESCRIPTION
## Summary

- **Fix server.name mismatch when Step CA renewal drops server SAN**: The auto-PKI/Step CA code path never derived `tlsServerName` from the actual certificate — it stayed hardcoded as `"server"`. When Step CA mTLS renewal re-issued a cert without the bare `"server"` SAN, `probeHealth` failed TLS verification. Now derives `tlsServerName` from the cert's actual SANs after `EnsurePKI`.
- **Format repo setup errors for readability in bridgectl run**: Strip gRPC framing noise and duplicated prefixes from `StartSession` errors, and present setup failures with indented, multi-line output so users can quickly identify the failing command and its output.

## Test plan

- [x] New test for SAN derivation in `localserver_test.go`
- [x] New test for error formatting in `run_test.go`
- [ ] Existing CI checks pass (go-lint, go-test, smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)