### PR TITLE
Renew explicit TLS certs via Step CA

### DIFF
--- a/cmd/bridgectl/server.go
+++ b/cmd/bridgectl/server.go
@@ -499,11 +499,18 @@ immediate renewal (e.g. when the cert has already expired).`,
 				}
 			}
 			var certValidity time.Duration
+			mat := localserver.LoadPKIMaterial(stateDir)
 			if configPath != "" {
 				fileCfg, err := config.Load(configPath)
 				if err != nil {
 					logger.Warn("could not load config file", "path", configPath, "error", err)
 				} else {
+					if fileCfg.TLS.Cert != "" {
+						mat.ServerCertPath = fileCfg.TLS.Cert
+					}
+					if fileCfg.TLS.Key != "" {
+						mat.ServerKeyPath = fileCfg.TLS.Key
+					}
 					if len(serverSANs) == 0 && len(fileCfg.Server.SANs) > 0 {
 						serverSANs = fileCfg.Server.SANs
 					}
@@ -534,7 +541,6 @@ immediate renewal (e.g. when the cert has already expired).`,
 			}
 
 			// Show current cert status.
-			mat := localserver.LoadPKIMaterial(stateDir)
 			_, notAfter, err := localserver.ServerCertExpiry(mat.ServerCertPath)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: could not read current cert: %v\n", err)
@@ -558,7 +564,7 @@ immediate renewal (e.g. when the cert has already expired).`,
 				}
 			}
 
-			if err := localserver.RenewServerCert(stateDir, serverSANs, logger, stepCA, certValidity); err != nil {
+			if err := localserver.RenewServerCertMaterial(mat, serverSANs, logger, stepCA, certValidity); err != nil {
 				return fmt.Errorf("renew cert: %w", err)
 			}
 

--- a/cmd/bridgectl/server.go
+++ b/cmd/bridgectl/server.go
@@ -505,10 +505,11 @@ immediate renewal (e.g. when the cert has already expired).`,
 				if err != nil {
 					logger.Warn("could not load config file", "path", configPath, "error", err)
 				} else {
+					if (fileCfg.TLS.Cert == "") != (fileCfg.TLS.Key == "") {
+						return fmt.Errorf("config %q must set both tls.cert and tls.key or neither", configPath)
+					}
 					if fileCfg.TLS.Cert != "" {
 						mat.ServerCertPath = fileCfg.TLS.Cert
-					}
-					if fileCfg.TLS.Key != "" {
 						mat.ServerKeyPath = fileCfg.TLS.Key
 					}
 					if len(serverSANs) == 0 && len(fileCfg.Server.SANs) > 0 {

--- a/cmd/bridgectl/server_init_test.go
+++ b/cmd/bridgectl/server_init_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -164,6 +165,32 @@ func TestDefaultServerConfigPathFallsBackToXDGConfig(t *testing.T) {
 
 	if got := defaultServerConfigPath(stateDir); got != xdgConfig {
 		t.Fatalf("defaultServerConfigPath() = %q, want %q", got, xdgConfig)
+	}
+}
+
+func TestServerRenewCertRejectsPartialExplicitTLSConfig(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AI_AGENT_BRIDGE_STATE_DIR", stateDir)
+
+	configPath := filepath.Join(t.TempDir(), "bridge.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+tls:
+  cert: /tmp/server.crt
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newServerRenewCertCmd()
+	cmd.SetArgs([]string{"--config", configPath})
+	cmd.SetOut(nil)
+	cmd.SetErr(nil)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want partial TLS config error")
+	}
+	if !strings.Contains(err.Error(), "must set both tls.cert and tls.key or neither") {
+		t.Fatalf("Execute() error = %v", err)
 	}
 }
 

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -587,6 +587,7 @@ func Start(cfg Config) (*Server, error) {
 	var stepCAConfig *StepCAConfig
 	var pkiMat *PKIMaterial
 	explicitCerts := false
+	renewExplicitCerts := false
 	tlsServerName := "server"
 
 	if cfg.ListenAddr != "" {
@@ -604,6 +605,17 @@ func Start(cfg Config) (*Server, error) {
 		mode = ModeSecure
 
 		var mat *PKIMaterial
+
+		serverSANs = BuildServerSANs(cfg.ListenAddr, cfg.ServerSANs)
+		if cfg.StepCAURL != "" {
+			stepCAConfig = &StepCAConfig{
+				URL:                     cfg.StepCAURL,
+				RootPath:                cfg.StepCARootPath,
+				OIDCProviderURL:         cfg.StepCAOIDCProvider,
+				Provisioner:             cfg.StepCAProvisioner,
+				ProvisionerPasswordFile: cfg.StepCAProvisionerPasswordFile,
+			}
+		}
 
 		if cfg.CABundlePath != "" {
 			// Use pre-issued certificates from Config (e.g. provided via config file).
@@ -626,19 +638,19 @@ func Start(cfg Config) (*Server, error) {
 			}
 			mat.ServerCertPath = cfg.TLSCertPath
 			mat.ServerKeyPath = cfg.TLSKeyPath
+			if stepCAConfig != nil {
+				renewExplicitCerts = true
+			}
+			if err := ensureExplicitServerCertFresh(mat, serverSANs, logger, stepCAConfig); err != nil {
+				sup.Close()
+				if store != nil {
+					_ = store.Close()
+				}
+				return nil, err
+			}
 			tlsServerName = serverNameFromCert(cfg.TLSCertPath)
 		} else {
 			// Auto-generate PKI material if not present, or delegate to Step CA.
-			serverSANs = BuildServerSANs(cfg.ListenAddr, cfg.ServerSANs)
-			if cfg.StepCAURL != "" {
-				stepCAConfig = &StepCAConfig{
-					URL:                     cfg.StepCAURL,
-					RootPath:                cfg.StepCARootPath,
-					OIDCProviderURL:         cfg.StepCAOIDCProvider,
-					Provisioner:             cfg.StepCAProvisioner,
-					ProvisionerPasswordFile: cfg.StepCAProvisionerPasswordFile,
-				}
-			}
 			var pkiErr error
 			mat, pkiErr = EnsurePKI(stateDir, serverSANs, logger, stepCAConfig, cfg.CertValidity)
 			if pkiErr != nil {
@@ -743,11 +755,10 @@ func Start(cfg Config) (*Server, error) {
 		stateDir:   stateDir,
 	}
 
-	// Start background certificate renewal for auto-PKI and Step CA modes.
-	// Explicit certs are managed externally; the CertReloader in the TLS
-	// config still picks up changes on disk, but we don't run the renewal
-	// loop ourselves.
-	if mode == ModeSecure && !explicitCerts {
+	// Start background certificate renewal for managed PKI. Explicit certs are
+	// normally externally managed, but when Step CA settings are also present
+	// we can safely renew the configured cert/key paths in-place.
+	if mode == ModeSecure && (!explicitCerts || renewExplicitCerts) {
 		s.serverSANs = serverSANs
 		s.stepCA = stepCAConfig
 		s.pkiMat = pkiMat
@@ -951,6 +962,70 @@ func (s *Server) Stop() {
 	_ = os.Remove(filepath.Join(s.stateDir, "server.name"))
 	_ = os.Remove(filepath.Join(s.stateDir, "server.sock"))
 	_ = os.Remove(filepath.Join(s.stateDir, "server.lock"))
+}
+
+func ensureExplicitServerCertFresh(mat *PKIMaterial, serverSANs []string, logger *slog.Logger, stepCA *StepCAConfig) error {
+	notBefore, notAfter, err := ServerCertExpiry(mat.ServerCertPath)
+	if err != nil {
+		if stepCA == nil || stepCA.URL == "" {
+			return fmt.Errorf("read explicit TLS certificate %q: %w", mat.ServerCertPath, err)
+		}
+		logger.Warn("explicit TLS certificate unreadable, requesting replacement from Step CA",
+			"cert", mat.ServerCertPath,
+			"error", err,
+		)
+		if err := RenewServerCertMaterial(mat, serverSANs, logger, stepCA, 0); err != nil {
+			return fmt.Errorf("renew explicit TLS certificate %q: %w", mat.ServerCertPath, err)
+		}
+		return nil
+	}
+
+	lifetime := notAfter.Sub(notBefore)
+	remaining := time.Until(notAfter)
+	renewThreshold := lifetime / 3
+
+	if remaining > renewThreshold {
+		return nil
+	}
+
+	if stepCA == nil || stepCA.URL == "" {
+		if remaining <= 0 {
+			return fmt.Errorf("explicit TLS certificate %q expired at %s; configure step_ca.url and step_ca.provisioner_password_file or replace the certificate",
+				mat.ServerCertPath,
+				notAfter.Format(time.RFC3339),
+			)
+		}
+		logger.Warn("explicit TLS certificate is approaching expiry but no Step CA renewal config is available",
+			"cert", mat.ServerCertPath,
+			"expires", notAfter.Format(time.RFC3339),
+			"remaining", remaining.Round(time.Second),
+		)
+		return nil
+	}
+
+	if remaining <= 0 {
+		logger.Warn("explicit TLS certificate has expired, renewing before startup",
+			"cert", mat.ServerCertPath,
+			"expired", notAfter.Format(time.RFC3339),
+		)
+		if err := RenewServerCertMaterial(mat, serverSANs, logger, stepCA, 0); err != nil {
+			return fmt.Errorf("renew expired explicit TLS certificate %q: %w", mat.ServerCertPath, err)
+		}
+		return nil
+	}
+
+	logger.Info("explicit TLS certificate approaching expiry, renewing before startup",
+		"cert", mat.ServerCertPath,
+		"expires", notAfter.Format(time.RFC3339),
+		"remaining", remaining.Round(time.Second),
+	)
+	if err := RenewServerCertMaterial(mat, serverSANs, logger, stepCA, 0); err != nil {
+		logger.Warn("explicit TLS certificate renewal failed; continuing with current valid certificate",
+			"cert", mat.ServerCertPath,
+			"error", err,
+		)
+	}
+	return nil
 }
 
 // defaultCertRenewalCheckInterval is how often the renewal loop checks cert expiry.

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -1088,7 +1088,7 @@ func (s *Server) checkAndRenew() {
 		)
 	}
 
-	if err := RenewServerCert(s.stateDir, s.serverSANs, s.logger, s.stepCA, s.certValidity); err != nil {
+	if err := RenewServerCertMaterial(s.pkiMat, s.serverSANs, s.logger, s.stepCA, s.certValidity); err != nil {
 		s.logger.Error("cert renewal: failed to renew server certificate", "error", err)
 		return
 	}

--- a/internal/localserver/localserver_test.go
+++ b/internal/localserver/localserver_test.go
@@ -441,6 +441,83 @@ func TestIsServerRunningSecureModeWithExplicitTLSCreatesLocalManagementPKI(t *te
 	assert.Equal(t, ModeSecure, mode)
 }
 
+func TestStartExplicitTLSWithStepCARenewsExpiredCert(t *testing.T) {
+	dir := t.TempDir()
+	tlsDir := filepath.Join(dir, "external-tls")
+	caCertPath, caKeyPath, err := pki.InitCA("external", tlsDir)
+	require.NoError(t, err)
+	caCert, caKey, err := pki.LoadCA(caCertPath, caKeyPath)
+	require.NoError(t, err)
+	serverCertPath, serverKeyPath, err := pki.IssueCert(caCert, caKey, pki.CertTypeServer, "bridge-host", []string{"bridge-host", "127.0.0.1"}, tlsDir, time.Nanosecond)
+	require.NoError(t, err)
+	time.Sleep(10 * time.Millisecond)
+
+	oldMTLS := renewCertMTLSFn
+	renewCertMTLSFn = func(_ *StepCAConfig, _, _ string, _ *slog.Logger) error {
+		return assert.AnError
+	}
+	t.Cleanup(func() { renewCertMTLSFn = oldMTLS })
+
+	jwkCalled := false
+	oldJWK := requestCertJWKFn
+	requestCertJWKFn = func(_ *StepCAConfig, sans []string, certPath, keyPath string, _ *slog.Logger) error {
+		jwkCalled = true
+		issuedCertPath, issuedKeyPath, err := pki.IssueCert(caCert, caKey, pki.CertTypeServer, "replacement", sans, t.TempDir(), 0)
+		require.NoError(t, err)
+		certData, err := os.ReadFile(issuedCertPath)
+		require.NoError(t, err)
+		keyData, err := os.ReadFile(issuedKeyPath)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(certPath, certData, 0o644))
+		require.NoError(t, os.WriteFile(keyPath, keyData, 0o600))
+		return nil
+	}
+	t.Cleanup(func() { requestCertJWKFn = oldJWK })
+
+	srv, err := Start(Config{
+		StateDir:                      dir,
+		ListenAddr:                    "127.0.0.1:0",
+		CABundlePath:                  caCertPath,
+		TLSCertPath:                   serverCertPath,
+		TLSKeyPath:                    serverKeyPath,
+		StepCAURL:                     "https://ca.example.internal",
+		StepCARootPath:                caCertPath,
+		StepCAProvisioner:             "admin",
+		StepCAProvisionerPasswordFile: filepath.Join(dir, "step-password"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { srv.Stop() })
+
+	assert.True(t, jwkCalled, "expired explicit cert should be reissued through Step CA fallback")
+	_, notAfter, err := ServerCertExpiry(serverCertPath)
+	require.NoError(t, err)
+	assert.True(t, time.Until(notAfter) > 24*time.Hour, "server should be using a fresh replacement cert")
+	assert.True(t, IsServerRunning(dir), "renewed explicit-TLS server should pass local health checks")
+}
+
+func TestStartExplicitTLSExpiredWithoutStepCAFails(t *testing.T) {
+	dir := t.TempDir()
+	tlsDir := filepath.Join(dir, "external-tls")
+	caCertPath, caKeyPath, err := pki.InitCA("external", tlsDir)
+	require.NoError(t, err)
+	caCert, caKey, err := pki.LoadCA(caCertPath, caKeyPath)
+	require.NoError(t, err)
+	serverCertPath, serverKeyPath, err := pki.IssueCert(caCert, caKey, pki.CertTypeServer, "bridge-host", []string{"bridge-host", "127.0.0.1"}, tlsDir, time.Nanosecond)
+	require.NoError(t, err)
+	time.Sleep(10 * time.Millisecond)
+
+	_, err = Start(Config{
+		StateDir:     dir,
+		ListenAddr:   "127.0.0.1:0",
+		CABundlePath: caCertPath,
+		TLSCertPath:  serverCertPath,
+		TLSKeyPath:   serverKeyPath,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "explicit TLS certificate")
+	assert.Contains(t, err.Error(), "expired")
+}
+
 func TestDiscoverTargetSecureModeWithWildcardListen(t *testing.T) {
 	dir := t.TempDir()
 	srv, err := Start(Config{

--- a/internal/localserver/localserver_test.go
+++ b/internal/localserver/localserver_test.go
@@ -518,6 +518,45 @@ func TestStartExplicitTLSExpiredWithoutStepCAFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "expired")
 }
 
+func TestCheckAndRenewUsesConfiguredPKIMaterial(t *testing.T) {
+	dir := t.TempDir()
+	tlsDir := filepath.Join(dir, "external-tls")
+	caCertPath, caKeyPath, err := pki.InitCA("external", tlsDir)
+	require.NoError(t, err)
+	caCert, caKey, err := pki.LoadCA(caCertPath, caKeyPath)
+	require.NoError(t, err)
+	serverCertPath, serverKeyPath, err := pki.IssueCert(caCert, caKey, pki.CertTypeServer, "bridge-host", []string{"bridge-host"}, tlsDir, time.Nanosecond)
+	require.NoError(t, err)
+	time.Sleep(10 * time.Millisecond)
+
+	oldMTLS := renewCertMTLSFn
+	renewCertMTLSFn = func(_ *StepCAConfig, certPath, keyPath string, _ *slog.Logger) error {
+		require.Equal(t, serverCertPath, certPath)
+		require.Equal(t, serverKeyPath, keyPath)
+		require.NoError(t, os.WriteFile(certPath, []byte("EXPLICIT-CERT-RENEWED"), 0o644))
+		return nil
+	}
+	t.Cleanup(func() { renewCertMTLSFn = oldMTLS })
+
+	srv := &Server{
+		logger:     testLogger(),
+		stateDir:   dir,
+		pkiMat:     &PKIMaterial{ServerCertPath: serverCertPath, ServerKeyPath: serverKeyPath},
+		serverSANs: []string{"bridge-host"},
+		stepCA:     &StepCAConfig{URL: "https://ca.example.internal"},
+	}
+
+	srv.checkAndRenew()
+
+	data, err := os.ReadFile(serverCertPath)
+	require.NoError(t, err)
+	assert.Equal(t, "EXPLICIT-CERT-RENEWED", string(data))
+
+	stateMat := LoadPKIMaterial(dir)
+	assert.NoFileExists(t, stateMat.ServerCertPath)
+	assert.NoFileExists(t, stateMat.ServerKeyPath)
+}
+
 func TestDiscoverTargetSecureModeWithWildcardListen(t *testing.T) {
 	dir := t.TempDir()
 	srv, err := Start(Config{

--- a/internal/localserver/pki.go
+++ b/internal/localserver/pki.go
@@ -456,6 +456,9 @@ func renewServerCertStepCA(mat *PKIMaterial, serverSANs []string, logger *slog.L
 				return fmt.Errorf("renew server cert (ACME fallback after mTLS failure): %w", err)
 			}
 		default:
+			if stepCA.ProvisionerPasswordFile == "" {
+				return fmt.Errorf("renew server cert (JWK fallback after mTLS failure): step_ca.provisioner_password_file is required for non-interactive renewal")
+			}
 			if err := requestCertJWKFn(stepCA, serverSANs, mat.ServerCertPath, mat.ServerKeyPath, logger); err != nil {
 				return fmt.Errorf("renew server cert (JWK fallback after mTLS failure): %w", err)
 			}

--- a/internal/localserver/pki.go
+++ b/internal/localserver/pki.go
@@ -411,7 +411,13 @@ func acmeSANs(serverSANs []string) []string {
 // CertReloader picks it up on the next TLS handshake without a server restart.
 func RenewServerCert(stateDir string, serverSANs []string, logger *slog.Logger, stepCA *StepCAConfig, certValidity time.Duration) error {
 	mat := LoadPKIMaterial(stateDir)
+	return RenewServerCertMaterial(mat, serverSANs, logger, stepCA, certValidity)
+}
 
+// RenewServerCertMaterial re-issues the certificate described by mat in-place.
+// It is used both for state-dir managed certificates and for explicit TLS
+// certificate paths loaded from config.
+func RenewServerCertMaterial(mat *PKIMaterial, serverSANs []string, logger *slog.Logger, stepCA *StepCAConfig, certValidity time.Duration) error {
 	if stepCA != nil && stepCA.URL != "" {
 		return renewServerCertStepCA(mat, serverSANs, logger, stepCA)
 	}

--- a/internal/localserver/pki_test.go
+++ b/internal/localserver/pki_test.go
@@ -584,8 +584,9 @@ func TestRenewServerCertStepCA_MTLSError_FallsBackToJWK(t *testing.T) {
 		ServerKeyPath:  serverKey,
 	}
 	stepCfg := &StepCAConfig{
-		URL:      "https://ca.example.com",
-		RootPath: rootPath,
+		URL:                     "https://ca.example.com",
+		RootPath:                rootPath,
+		ProvisionerPasswordFile: filepath.Join(t.TempDir(), "password"),
 	}
 
 	err := renewServerCertStepCA(mat, []string{"server"}, testLogger(), stepCfg)
@@ -595,6 +596,46 @@ func TestRenewServerCertStepCA_MTLSError_FallsBackToJWK(t *testing.T) {
 	data, err := os.ReadFile(serverCert)
 	require.NoError(t, err)
 	assert.Equal(t, "JWK-RENEWED-CERT", string(data))
+}
+
+func TestRenewServerCertStepCA_MTLSErrorWithoutPasswordFileFailsFast(t *testing.T) {
+	stateDir := t.TempDir()
+	certsDir := filepath.Join(stateDir, "certs")
+	require.NoError(t, os.MkdirAll(certsDir, 0o700))
+
+	rootPath := filepath.Join(t.TempDir(), "root.crt")
+	require.NoError(t, os.WriteFile(rootPath, []byte("FAKE-ROOT"), 0o644))
+
+	serverCert := filepath.Join(certsDir, "server.crt")
+	serverKey := filepath.Join(certsDir, "server.key")
+	require.NoError(t, os.WriteFile(serverCert, []byte("OLD-CERT"), 0o644))
+	require.NoError(t, os.WriteFile(serverKey, []byte("OLD-KEY"), 0o600))
+
+	oldMTLS := renewCertMTLSFn
+	renewCertMTLSFn = func(_ *StepCAConfig, _, _ string, _ *slog.Logger) error {
+		return fmt.Errorf("certificate expired")
+	}
+	t.Cleanup(func() { renewCertMTLSFn = oldMTLS })
+
+	oldJWK := requestCertJWKFn
+	requestCertJWKFn = func(_ *StepCAConfig, _ []string, _, _ string, _ *slog.Logger) error {
+		t.Fatal("requestCertJWKFn should not be called without a password file")
+		return nil
+	}
+	t.Cleanup(func() { requestCertJWKFn = oldJWK })
+
+	mat := &PKIMaterial{
+		ServerCertPath: serverCert,
+		ServerKeyPath:  serverKey,
+	}
+	stepCfg := &StepCAConfig{
+		URL:      "https://ca.example.com",
+		RootPath: rootPath,
+	}
+
+	err := renewServerCertStepCA(mat, []string{"server"}, testLogger(), stepCfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provisioner_password_file")
 }
 
 // TestRenewServerCertStepCA_MTLSError_FallsBackToACME verifies that when mTLS
@@ -683,8 +724,9 @@ func TestRenewServerCertStepCA_MTLSAndFallbackBothFail(t *testing.T) {
 		ServerKeyPath:  serverKey,
 	}
 	stepCfg := &StepCAConfig{
-		URL:      "https://ca.example.com",
-		RootPath: rootPath,
+		URL:                     "https://ca.example.com",
+		RootPath:                rootPath,
+		ProvisionerPasswordFile: filepath.Join(t.TempDir(), "password"),
 	}
 
 	err := renewServerCertStepCA(mat, []string{"server"}, testLogger(), stepCfg)


### PR DESCRIPTION
## Summary
- renew configured explicit TLS cert/key paths via Step CA when they are expired or approaching expiry
- fail fast on expired explicit TLS certs when no Step CA renewal config is available
- make `bridgectl server renew-cert --config` target configured `tls.cert` and `tls.key` paths

## Tests
- `go test ./internal/localserver`
- `go test ./cmd/bridgectl`
- `go test ./...`
- `make test`

## Operational impact
Hosts using explicit TLS cert paths can add `step_ca.provisioner_password_file` and allow `server start` / renewal to refresh those configured files instead of starting with an unusable expired cert.