### PR TITLE
Add graceful session shutdown

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -146,6 +146,11 @@ Remote operator CLI acceptance criteria:
 
 **Session persistence**: with `--db-path`, the server writes session metadata and PTY output chunks to a BoltDB file. On restart, `LoadHistory()` rehydrates sessions so SDK clients can reconnect and replay events they missed.
 
+Session shutdown acceptance criteria:
+- When the user-session server receives process termination from its service manager, it stops accepting new work, gracefully terminates active provider sessions, and persists each session's terminal state before closing the session store.
+- Graceful server shutdown sends each active provider session its normal termination signal and waits up to the configured provider grace period inside a bounded server shutdown deadline before using forced termination as a fallback.
+- Sessions stopped during graceful server shutdown must reload after restart as terminal session history, not as daemon-orphaned failures, so clients can reconnect and replay persisted output/state.
+
 #### Human Interjection
 
 Human operators can observe and interact with any running session without stopping it. The session model distinguishes two roles:

--- a/internal/bridge/errors.go
+++ b/internal/bridge/errors.go
@@ -13,6 +13,7 @@ var (
 	ErrClientMismatch             = errors.New("client does not own attached session")
 	ErrProviderUnavailable        = errors.New("provider unavailable")
 	ErrRepoSetupFailed            = errors.New("repo setup failed")
+	ErrSupervisorShuttingDown     = errors.New("supervisor shutting down")
 	ErrSessionLimitReached        = errors.New("session limit reached")
 	ErrInputTooLarge              = errors.New("input too large")
 	// ErrWriterConflict is returned by ClaimWriter when another client already

--- a/internal/bridge/supervisor.go
+++ b/internal/bridge/supervisor.go
@@ -84,9 +84,10 @@ type Supervisor struct {
 	idleTimeout     time.Duration
 	cleanupInterval time.Duration
 
-	mu       sync.RWMutex
-	sessions map[string]*managedSession
-	done     chan struct{}
+	mu        sync.RWMutex
+	sessions  map[string]*managedSession
+	done      chan struct{}
+	closeOnce sync.Once
 
 	store     SessionStore
 	repoSetup RepoSetupRunner
@@ -568,12 +569,17 @@ func (s *Supervisor) readLoop(ms *managedSession) {
 			if errors.Is(err, io.EOF) {
 				slog.Info("session PTY closed", "session_id", ms.info.SessionID, "provider", ms.info.Provider)
 			} else {
-				slog.Warn("session PTY read error", "session_id", ms.info.SessionID, "provider", ms.info.Provider, "error", err)
 				ms.mu.Lock()
-				if ms.info.Error == "" && !ms.info.ExitRecorded {
+				stopping := ms.info.State == SessionStateStopping
+				if ms.info.Error == "" && !ms.info.ExitRecorded && !stopping {
 					ms.info.Error = err.Error()
 				}
 				ms.mu.Unlock()
+				if stopping {
+					slog.Debug("session PTY closed during stop", "session_id", ms.info.SessionID, "provider", ms.info.Provider, "error", err)
+					return
+				}
+				slog.Warn("session PTY read error", "session_id", ms.info.SessionID, "provider", ms.info.Provider, "error", err)
 				// Force-terminate the process so any pending WriteInput calls see
 				// SessionNotFound rather than writing to a dead PTY file descriptor.
 				sessionID := ms.info.SessionID
@@ -755,11 +761,12 @@ func (s *Supervisor) waitLoop(ms *managedSession) {
 	}
 
 	ms.mu.Lock()
+	stopping := ms.info.State == SessionStateStopping
 	ms.info.StoppedAt = nowUTC()
 	ms.info.ExitRecorded = true
 	ms.info.ExitCode = exitCode
 	ms.info.ProcessID = 0
-	if err != nil && !ms.forceStop {
+	if err != nil && !ms.forceStop && !stopping {
 		ms.info.State = SessionStateFailed
 		if ms.info.Error == "" {
 			ms.info.Error = err.Error()
@@ -1132,8 +1139,69 @@ func (s *Supervisor) List(projectID string) []SessionInfo {
 	return out
 }
 
+// Shutdown gracefully stops all active sessions and waits until they reach a
+// terminal state. If ctx expires, any remaining sessions are force-stopped and
+// ctx.Err() is returned.
+func (s *Supervisor) Shutdown(ctx context.Context) error {
+	s.closeOnce.Do(func() {
+		close(s.done)
+	})
+
+	s.mu.RLock()
+	ids := make([]string, 0, len(s.sessions))
+	for id := range s.sessions {
+		ids = append(ids, id)
+	}
+	s.mu.RUnlock()
+
+	for _, id := range ids {
+		if err := s.Stop(id, false); err != nil && !errors.Is(err, ErrSessionNotFound) {
+			slog.Warn("graceful session stop failed", "session_id", id, "error", err)
+		}
+	}
+
+	if err := s.waitForSessions(ctx, ids); err != nil {
+		for _, id := range ids {
+			_ = s.Stop(id, true)
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *Supervisor) waitForSessions(ctx context.Context, ids []string) error {
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		allStopped := true
+		for _, id := range ids {
+			info, err := s.Get(id)
+			if errors.Is(err, ErrSessionNotFound) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if info.State != SessionStateStopped && info.State != SessionStateFailed {
+				allStopped = false
+				break
+			}
+		}
+		if allStopped {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
 func (s *Supervisor) Close() {
-	close(s.done)
+	s.closeOnce.Do(func() {
+		close(s.done)
+	})
 	s.mu.RLock()
 	ids := make([]string, 0, len(s.sessions))
 	for id := range s.sessions {

--- a/internal/bridge/supervisor.go
+++ b/internal/bridge/supervisor.go
@@ -84,10 +84,11 @@ type Supervisor struct {
 	idleTimeout     time.Duration
 	cleanupInterval time.Duration
 
-	mu        sync.RWMutex
-	sessions  map[string]*managedSession
-	done      chan struct{}
-	closeOnce sync.Once
+	mu           sync.RWMutex
+	sessions     map[string]*managedSession
+	done         chan struct{}
+	closeOnce    sync.Once
+	shuttingDown bool
 
 	store     SessionStore
 	repoSetup RepoSetupRunner
@@ -399,6 +400,10 @@ func (s *Supervisor) Start(ctx context.Context, cfg SessionConfig) (*SessionInfo
 	}
 
 	s.mu.Lock()
+	if s.shuttingDown {
+		s.mu.Unlock()
+		return nil, ErrSupervisorShuttingDown
+	}
 	if _, exists := s.sessions[cfg.SessionID]; exists {
 		s.mu.Unlock()
 		return nil, fmt.Errorf("%w: %q", ErrSessionAlreadyExists, cfg.SessionID)
@@ -513,6 +518,14 @@ func (s *Supervisor) Start(ctx context.Context, cfg SessionConfig) (*SessionInfo
 		ms.stdin = stdinPipe
 		ms.info.ProcessID = cmd.Process.Pid
 		s.mu.Lock()
+		if s.shuttingDown {
+			s.mu.Unlock()
+			cancel()
+			_ = stdinPipe.Close()
+			_ = stdoutPipe.Close()
+			_ = cmd.Wait()
+			return nil, ErrSupervisorShuttingDown
+		}
 		if _, exists := s.sessions[cfg.SessionID]; exists {
 			s.mu.Unlock()
 			cancel()
@@ -535,6 +548,13 @@ func (s *Supervisor) Start(ctx context.Context, cfg SessionConfig) (*SessionInfo
 		ms.ptmx = ptmx
 		ms.info.ProcessID = cmd.Process.Pid
 		s.mu.Lock()
+		if s.shuttingDown {
+			s.mu.Unlock()
+			cancel()
+			_ = ptmx.Close()
+			_ = cmd.Wait()
+			return nil, ErrSupervisorShuttingDown
+		}
 		if _, exists := s.sessions[cfg.SessionID]; exists {
 			s.mu.Unlock()
 			cancel()
@@ -1147,47 +1167,54 @@ func (s *Supervisor) Shutdown(ctx context.Context) error {
 		close(s.done)
 	})
 
-	s.mu.RLock()
-	ids := make([]string, 0, len(s.sessions))
-	for id := range s.sessions {
-		ids = append(ids, id)
-	}
-	s.mu.RUnlock()
+	s.mu.Lock()
+	s.shuttingDown = true
+	s.mu.Unlock()
 
-	for _, id := range ids {
-		if err := s.Stop(id, false); err != nil && !errors.Is(err, ErrSessionNotFound) {
-			slog.Warn("graceful session stop failed", "session_id", id, "error", err)
-		}
-	}
-
-	if err := s.waitForSessions(ctx, ids); err != nil {
-		for _, id := range ids {
-			_ = s.Stop(id, true)
-		}
+	s.stopSessions(s.nonTerminalSessionIDs(), false)
+	if err := s.waitForAllSessions(ctx); err != nil {
+		s.stopSessions(s.nonTerminalSessionIDs(), true)
+		s.waitBestEffort(2 * time.Second)
 		return err
 	}
 	return nil
 }
 
-func (s *Supervisor) waitForSessions(ctx context.Context, ids []string) error {
+func (s *Supervisor) nonTerminalSessionIDs() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ids := make([]string, 0, len(s.sessions))
+	for id, ms := range s.sessions {
+		info := ms.snapshotInfo()
+		if info.State == SessionStateStopped || info.State == SessionStateFailed {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func (s *Supervisor) stopSessions(ids []string, force bool) {
+	for _, id := range ids {
+		if err := s.Stop(id, force); err != nil && !errors.Is(err, ErrSessionNotFound) {
+			slog.Warn("session stop failed", "session_id", id, "force", force, "error", err)
+		}
+	}
+}
+
+func (s *Supervisor) waitBestEffort(timeout time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := s.waitForAllSessions(ctx); err != nil {
+		slog.Warn("timed out waiting for forced sessions to persist terminal state", "error", err)
+	}
+}
+
+func (s *Supervisor) waitForAllSessions(ctx context.Context) error {
 	ticker := time.NewTicker(25 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		allStopped := true
-		for _, id := range ids {
-			info, err := s.Get(id)
-			if errors.Is(err, ErrSessionNotFound) {
-				continue
-			}
-			if err != nil {
-				return err
-			}
-			if info.State != SessionStateStopped && info.State != SessionStateFailed {
-				allStopped = false
-				break
-			}
-		}
-		if allStopped {
+		if len(s.nonTerminalSessionIDs()) == 0 {
 			return nil
 		}
 		select {
@@ -1202,6 +1229,10 @@ func (s *Supervisor) Close() {
 	s.closeOnce.Do(func() {
 		close(s.done)
 	})
+	s.mu.Lock()
+	s.shuttingDown = true
+	s.mu.Unlock()
+
 	s.mu.RLock()
 	ids := make([]string, 0, len(s.sessions))
 	for id := range s.sessions {

--- a/internal/bridge/supervisor_test.go
+++ b/internal/bridge/supervisor_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"os/exec"
+	"os/signal"
 	"regexp"
 	"strings"
 	"syscall"
@@ -32,6 +34,30 @@ func (p *testProvider) BuildCommand(ctx context.Context, cfg SessionConfig) (*ex
 	cmd := exec.CommandContext(ctx, "/bin/cat")
 	cmd.Dir = cfg.RepoPath
 	return cmd, nil
+}
+
+type termTrapProvider struct {
+	testProvider
+}
+
+func (p *termTrapProvider) StopGrace() time.Duration { return 500 * time.Millisecond }
+
+func (p *termTrapProvider) BuildCommand(ctx context.Context, cfg SessionConfig) (*exec.Cmd, error) {
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestGracefulShutdownHelperProcess")
+	cmd.Dir = cfg.RepoPath
+	cmd.Env = append(os.Environ(), "BRIDGE_GRACEFUL_HELPER=1")
+	return cmd, nil
+}
+
+func TestGracefulShutdownHelperProcess(t *testing.T) {
+	if os.Getenv("BRIDGE_GRACEFUL_HELPER") != "1" {
+		return
+	}
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM)
+	<-sigCh
+	_, _ = os.Stdout.WriteString("BRIDGE_TERM_OK\n")
+	os.Exit(0)
 }
 
 type setupRunnerFunc func(context.Context, string, []string) ([]string, error)
@@ -357,6 +383,63 @@ func TestSupervisorPersistenceAndHistory(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("persist-1 not found in List after restart")
+	}
+}
+
+func TestSupervisorShutdownGracefullyStopsAndPersistsRunningSession(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(&termTrapProvider{testProvider: testProvider{id: "term-trap"}}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	dbPath := t.TempDir() + "/sessions.db"
+	store, err := NewBoltSessionStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewBoltSessionStore: %v", err)
+	}
+
+	sup := NewSupervisor(registry, DefaultPolicy(), 1024, time.Minute, WithStore(store))
+	if _, err := sup.Start(context.Background(), SessionConfig{
+		ProjectID: "proj-shutdown",
+		SessionID: "shutdown-1",
+		RepoPath:  t.TempDir(),
+		Options:   map[string]string{"provider": "term-trap"},
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := sup.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("store.Close: %v", err)
+	}
+
+	store2, err := NewBoltSessionStore(dbPath)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer func() { _ = store2.Close() }()
+	sup2 := NewSupervisor(registry, DefaultPolicy(), 1024, time.Minute, WithStore(store2))
+	defer sup2.Close()
+	if err := sup2.LoadHistory(); err != nil {
+		t.Fatalf("LoadHistory: %v", err)
+	}
+
+	info, err := sup2.Get("shutdown-1")
+	if err != nil {
+		t.Fatalf("Get after shutdown: %v", err)
+	}
+	if info.State != SessionStateStopped {
+		t.Fatalf("State=%v want Stopped", info.State)
+	}
+	if !info.ExitRecorded {
+		t.Fatal("ExitRecorded=false want true")
+	}
+	if strings.Contains(info.Error, "orphaned by daemon restart") {
+		t.Fatalf("Error=%q should not mark graceful shutdown as orphaned", info.Error)
 	}
 }
 

--- a/internal/bridge/supervisor_test.go
+++ b/internal/bridge/supervisor_test.go
@@ -49,15 +49,33 @@ func (p *termTrapProvider) BuildCommand(ctx context.Context, cfg SessionConfig) 
 	return cmd, nil
 }
 
+type ignoreTermProvider struct {
+	testProvider
+}
+
+func (p *ignoreTermProvider) StopGrace() time.Duration { return 5 * time.Second }
+
+func (p *ignoreTermProvider) BuildCommand(ctx context.Context, cfg SessionConfig) (*exec.Cmd, error) {
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestGracefulShutdownHelperProcess")
+	cmd.Dir = cfg.RepoPath
+	cmd.Env = append(os.Environ(), "BRIDGE_IGNORE_TERM_HELPER=1")
+	return cmd, nil
+}
+
 func TestGracefulShutdownHelperProcess(t *testing.T) {
-	if os.Getenv("BRIDGE_GRACEFUL_HELPER") != "1" {
+	switch {
+	case os.Getenv("BRIDGE_GRACEFUL_HELPER") == "1":
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGTERM)
+		<-sigCh
+		_, _ = os.Stdout.WriteString("BRIDGE_TERM_OK\n")
+		os.Exit(0)
+	case os.Getenv("BRIDGE_IGNORE_TERM_HELPER") == "1":
+		signal.Ignore(syscall.SIGTERM)
+		select {}
+	default:
 		return
 	}
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM)
-	<-sigCh
-	_, _ = os.Stdout.WriteString("BRIDGE_TERM_OK\n")
-	os.Exit(0)
 }
 
 type setupRunnerFunc func(context.Context, string, []string) ([]string, error)
@@ -440,6 +458,87 @@ func TestSupervisorShutdownGracefullyStopsAndPersistsRunningSession(t *testing.T
 	}
 	if strings.Contains(info.Error, "orphaned by daemon restart") {
 		t.Fatalf("Error=%q should not mark graceful shutdown as orphaned", info.Error)
+	}
+}
+
+func TestSupervisorShutdownRejectsNewSessions(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(&testProvider{id: "fake"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	sup := NewSupervisor(registry, DefaultPolicy(), 1024, time.Minute)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := sup.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	_, err := sup.Start(context.Background(), SessionConfig{
+		ProjectID: "proj-shutdown",
+		SessionID: "shutdown-reject",
+		RepoPath:  t.TempDir(),
+		Options:   map[string]string{"provider": "fake"},
+	})
+	if !errors.Is(err, ErrSupervisorShuttingDown) {
+		t.Fatalf("Start after shutdown error=%v want %v", err, ErrSupervisorShuttingDown)
+	}
+}
+
+func TestSupervisorShutdownForceStopWaitsForTerminalPersistence(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(&ignoreTermProvider{testProvider: testProvider{id: "ignore-term"}}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	dbPath := t.TempDir() + "/sessions.db"
+	store, err := NewBoltSessionStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewBoltSessionStore: %v", err)
+	}
+
+	sup := NewSupervisor(registry, DefaultPolicy(), 1024, time.Minute, WithStore(store))
+	if _, err := sup.Start(context.Background(), SessionConfig{
+		ProjectID: "proj-shutdown",
+		SessionID: "shutdown-force-1",
+		RepoPath:  t.TempDir(),
+		Options:   map[string]string{"provider": "ignore-term"},
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if err := sup.Shutdown(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Shutdown error=%v want %v", err, context.DeadlineExceeded)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("store.Close: %v", err)
+	}
+
+	store2, err := NewBoltSessionStore(dbPath)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer func() { _ = store2.Close() }()
+	sup2 := NewSupervisor(registry, DefaultPolicy(), 1024, time.Minute, WithStore(store2))
+	defer sup2.Close()
+	if err := sup2.LoadHistory(); err != nil {
+		t.Fatalf("LoadHistory: %v", err)
+	}
+
+	info, err := sup2.Get("shutdown-force-1")
+	if err != nil {
+		t.Fatalf("Get after shutdown: %v", err)
+	}
+	if info.State != SessionStateStopped {
+		t.Fatalf("State=%v want Stopped", info.State)
+	}
+	if !info.ExitRecorded {
+		t.Fatal("ExitRecorded=false want true")
+	}
+	if strings.Contains(info.Error, "orphaned by daemon restart") {
+		t.Fatalf("Error=%q should not mark forced shutdown as orphaned", info.Error)
 	}
 }
 

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -98,6 +98,8 @@ const (
 	ModeLocal ServerMode = "local"
 	// ModeSecure uses TCP + mTLS + JWT for remote access.
 	ModeSecure ServerMode = "secure"
+
+	gracefulServerShutdownTimeout = 30 * time.Second
 )
 
 // ModePath returns the path to the server mode file.
@@ -932,18 +934,24 @@ func (s *Server) Stop() {
 		s.renewCancel()
 	}
 
-	// Bounded graceful shutdown: try graceful first, then force-stop after
-	// 5 seconds. GracefulStop can block indefinitely if long-lived streams
-	// (e.g. AttachSession) are active.
+	// Stop accepting new RPCs, then gracefully drain provider sessions so
+	// long-lived AttachSession streams can finish before the gRPC server exits.
 	done := make(chan struct{})
 	go func() {
 		s.grpcServer.GracefulStop()
 		close(done)
 	}()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), gracefulServerShutdownTimeout)
+	if err := s.supervisor.Shutdown(shutdownCtx); err != nil {
+		s.logger.Warn("graceful session shutdown timed out, forced remaining sessions", "error", err)
+	}
+	cancel()
+
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		s.logger.Warn("graceful shutdown timed out, forcing stop")
+		s.logger.Warn("grpc graceful shutdown timed out, forcing stop")
 		s.grpcServer.Stop()
 	}
 

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -99,7 +99,7 @@ const (
 	// ModeSecure uses TCP + mTLS + JWT for remote access.
 	ModeSecure ServerMode = "secure"
 
-	gracefulServerShutdownTimeout = 30 * time.Second
+	sessionDrainShutdownTimeout = 30 * time.Second
 )
 
 // ModePath returns the path to the server mode file.
@@ -942,7 +942,7 @@ func (s *Server) Stop() {
 		close(done)
 	}()
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), gracefulServerShutdownTimeout)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), sessionDrainShutdownTimeout)
 	if err := s.supervisor.Shutdown(shutdownCtx); err != nil {
 		s.logger.Warn("graceful session shutdown timed out, forced remaining sessions", "error", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -417,7 +417,7 @@ func mapBridgeError(err error, op string) error {
 		return status.Errorf(codes.ResourceExhausted, "%s: %v", op, err)
 	case errors.Is(err, bridge.ErrClientNotAttached), errors.Is(err, bridge.ErrClientMismatch):
 		return status.Errorf(codes.PermissionDenied, "%s: %v", op, err)
-	case errors.Is(err, bridge.ErrProviderUnavailable), errors.Is(err, bridge.ErrSessionRecoveryUnavailable):
+	case errors.Is(err, bridge.ErrProviderUnavailable), errors.Is(err, bridge.ErrSessionRecoveryUnavailable), errors.Is(err, bridge.ErrSupervisorShuttingDown):
 		return status.Errorf(codes.Unavailable, "%s: %v", op, err)
 	case errors.Is(err, bridge.ErrRepoSetupFailed):
 		return status.Errorf(codes.FailedPrecondition, "%s: %v", op, err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -233,6 +233,7 @@ func TestMapBridgeErrorAndState(t *testing.T) {
 		{err: bridge.ErrClientMismatch, code: codes.PermissionDenied},
 		{err: bridge.ErrProviderUnavailable, code: codes.Unavailable},
 		{err: bridge.ErrSessionRecoveryUnavailable, code: codes.Unavailable},
+		{err: bridge.ErrSupervisorShuttingDown, code: codes.Unavailable},
 		{err: bridge.ErrRepoSetupFailed, code: codes.FailedPrecondition},
 		{err: bridge.ErrSessionLimitReached, code: codes.ResourceExhausted},
 		{err: errors.New("boom"), code: codes.Internal},


### PR DESCRIPTION
## Summary
- add PRD acceptance criteria for graceful service-manager shutdown
- add supervisor-level bounded graceful shutdown for active sessions
- wire local server stop through session draining before closing the store
- treat intentional SIGTERM/session stopping as a stopped terminal state instead of an orphaned failure

## Test evidence
- go test ./internal/bridge -run TestSupervisorShutdownGracefullyStopsAndPersistsRunningSession -count=1
- go test ./internal/bridge -count=1
- go test ./internal/localserver -count=1
- make test
- pre-commit/pre-push hooks: gofmt, goimports, golangci-lint, go-test

## Config / operational impact
- user-service restarts now allow up to 30s for bridge provider sessions to shut down gracefully before force-stop fallback
- persisted sessions stopped during graceful server shutdown reload as terminal history rather than daemon-orphaned failures