### PR TITLE
Batch WriteInput RPCs to prevent rate limiting when typing

### DIFF
--- a/cmd/bridgectl/inputwriter.go
+++ b/cmd/bridgectl/inputwriter.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	bridgev1 "github.com/markcallen/ai-agent-bridge/gen/bridge/v1"
+)
+
+// inputWriterClient is the subset of the gRPC client needed by inputWriter.
+type inputWriterClient interface {
+	WriteInput(ctx context.Context, req *bridgev1.WriteInputRequest) (*bridgev1.WriteInputResponse, error)
+}
+
+// inputWriterConfig configures an inputWriter.
+type inputWriterConfig struct {
+	// Reader is the source of raw input (typically os.Stdin).
+	Reader io.Reader
+	// Client sends coalesced data to the bridge.
+	Client inputWriterClient
+	// SessionID and ClientID for the WriteInput RPC.
+	SessionID string
+	ClientID  string
+	// DetachKey, if non-zero, causes the writer to stop when this byte is read.
+	// OnDetach is called before returning when the detach key is encountered.
+	DetachKey byte
+	OnDetach  func()
+	// OnReadError is called when the reader returns an error (other than the
+	// detach-key path). The writer goroutine exits after calling it.
+	OnReadError func(err error)
+
+	// FlushInterval controls how long the writer waits after the last byte
+	// before flushing. Defaults to 20ms.
+	FlushInterval time.Duration
+}
+
+// inputWriter coalesces individual keystrokes into batched WriteInput RPCs.
+// Instead of sending one RPC per os.Stdin.Read (often a single byte in raw
+// terminal mode), it buffers input and flushes either when no new data arrives
+// for FlushInterval or when the buffer reaches 4 KiB.
+type inputWriter struct {
+	cfg inputWriterConfig
+
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+const (
+	defaultFlushInterval = 20 * time.Millisecond
+	maxBatchSize         = 4096
+)
+
+// Run starts reading from cfg.Reader and coalescing writes. It blocks until
+// the reader returns an error or the detach key is encountered. It is intended
+// to be called in a goroutine.
+func (w *inputWriter) Run() {
+	flushInterval := w.cfg.FlushInterval
+	if flushInterval == 0 {
+		flushInterval = defaultFlushInterval
+	}
+
+	readCh := make(chan []byte, 32)
+	errCh := make(chan error, 1)
+
+	// Reader goroutine: reads raw bytes and sends them to readCh.
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, readErr := w.cfg.Reader.Read(buf)
+			if n > 0 {
+				data := make([]byte, n)
+				copy(data, buf[:n])
+				readCh <- data
+			}
+			if readErr != nil {
+				errCh <- readErr
+				return
+			}
+		}
+	}()
+
+	timer := time.NewTimer(flushInterval)
+	timer.Stop()
+
+	for {
+		select {
+		case data := <-readCh:
+			// Check for detach key before buffering.
+			if w.cfg.DetachKey != 0 {
+				if idx := bytes.IndexByte(data, w.cfg.DetachKey); idx >= 0 {
+					// Buffer everything before the detach key, flush, then detach.
+					if idx > 0 {
+						w.mu.Lock()
+						w.buf.Write(data[:idx])
+						w.mu.Unlock()
+					}
+					w.flush()
+					if w.cfg.OnDetach != nil {
+						w.cfg.OnDetach()
+					}
+					return
+				}
+			}
+
+			w.mu.Lock()
+			w.buf.Write(data)
+			size := w.buf.Len()
+			w.mu.Unlock()
+
+			if size >= maxBatchSize {
+				timer.Stop()
+				w.flush()
+			} else {
+				// Reset timer to coalesce more bytes within the interval.
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(flushInterval)
+			}
+
+		case <-timer.C:
+			w.flush()
+
+		case err := <-errCh:
+			// Drain any remaining data from readCh.
+		drain:
+			for {
+				select {
+				case data := <-readCh:
+					w.mu.Lock()
+					w.buf.Write(data)
+					w.mu.Unlock()
+				default:
+					break drain
+				}
+			}
+			w.flush()
+			if w.cfg.OnReadError != nil {
+				w.cfg.OnReadError(err)
+			}
+			return
+		}
+	}
+}
+
+func (w *inputWriter) flush() {
+	w.mu.Lock()
+	if w.buf.Len() == 0 {
+		w.mu.Unlock()
+		return
+	}
+	data := make([]byte, w.buf.Len())
+	copy(data, w.buf.Bytes())
+	w.buf.Reset()
+	w.mu.Unlock()
+
+	_, _ = w.cfg.Client.WriteInput(context.Background(), &bridgev1.WriteInputRequest{
+		SessionId: w.cfg.SessionID,
+		ClientId:  w.cfg.ClientID,
+		Data:      data,
+	})
+}

--- a/cmd/bridgectl/inputwriter_test.go
+++ b/cmd/bridgectl/inputwriter_test.go
@@ -182,31 +182,52 @@ func TestInputWriterDetachKeyAtStart(t *testing.T) {
 
 func TestInputWriterFlushesOnMaxBatch(t *testing.T) {
 	mock := &mockWriteClient{}
-	// Create input larger than maxBatchSize (4096).
-	input := strings.Repeat("x", maxBatchSize+100)
-	reader := strings.NewReader(input)
+
+	// Use an io.Pipe so we control when data arrives and when EOF is sent.
+	// Write more than maxBatchSize, wait for the size-triggered flush, then
+	// write a second chunk and close.
+	pr, pw := io.Pipe()
 
 	done := make(chan struct{})
 	w := &inputWriter{cfg: inputWriterConfig{
-		Reader:        reader,
+		Reader:        pr,
 		Client:        mock,
 		SessionID:     "sess-1",
 		ClientID:      "client-1",
-		FlushInterval: time.Second, // long interval — flush should happen via size threshold
+		FlushInterval: time.Second, // long interval — flush should happen via size threshold only
 		OnReadError: func(_ error) {
 			close(done)
 		},
 	}}
 
-	w.Run()
-	<-done
+	go w.Run()
 
-	if got := string(mock.allData()); got != input {
-		t.Fatalf("data mismatch: got %d bytes, want %d", len(got), len(input))
+	// Write more than maxBatchSize in one go.
+	first := strings.Repeat("A", maxBatchSize+100)
+	_, _ = pw.Write([]byte(first))
+
+	// Wait for the size-triggered flush to happen.
+	deadline := time.After(2 * time.Second)
+	for len(mock.getCalls()) < 1 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for size-triggered flush")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
 	}
 
-	// Should have flushed at least once before the final EOF flush due to
-	// exceeding maxBatchSize.
+	// Write a second chunk and close.
+	second := "tail"
+	_, _ = pw.Write([]byte(second))
+	_ = pw.Close()
+	<-done
+
+	want := first + second
+	if got := string(mock.allData()); got != want {
+		t.Fatalf("data mismatch: got %d bytes, want %d", len(got), len(want))
+	}
+
 	calls := mock.getCalls()
 	if len(calls) < 2 {
 		t.Errorf("expected at least 2 calls (size-triggered + final), got %d", len(calls))

--- a/cmd/bridgectl/inputwriter_test.go
+++ b/cmd/bridgectl/inputwriter_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	bridgev1 "github.com/markcallen/ai-agent-bridge/gen/bridge/v1"
+)
+
+// mockWriteClient records WriteInput calls for assertions.
+type mockWriteClient struct {
+	mu    sync.Mutex
+	calls []*bridgev1.WriteInputRequest
+}
+
+func (m *mockWriteClient) WriteInput(_ context.Context, req *bridgev1.WriteInputRequest) (*bridgev1.WriteInputResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, req)
+	return &bridgev1.WriteInputResponse{Accepted: true, BytesWritten: uint32(len(req.Data))}, nil
+}
+
+func (m *mockWriteClient) getCalls() []*bridgev1.WriteInputRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*bridgev1.WriteInputRequest, len(m.calls))
+	copy(out, m.calls)
+	return out
+}
+
+func (m *mockWriteClient) allData() []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var buf bytes.Buffer
+	for _, c := range m.calls {
+		buf.Write(c.Data)
+	}
+	return buf.Bytes()
+}
+
+// slowReader returns one byte at a time with a short delay, simulating raw
+// terminal mode keystroke-by-keystroke reads.
+type slowReader struct {
+	data  []byte
+	pos   int
+	delay time.Duration
+}
+
+func (r *slowReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	if r.delay > 0 && r.pos > 0 {
+		time.Sleep(r.delay)
+	}
+	p[0] = r.data[r.pos]
+	r.pos++
+	if r.pos >= len(r.data) {
+		return 1, io.EOF
+	}
+	return 1, nil
+}
+
+func TestInputWriterCoalescesKeystrokes(t *testing.T) {
+	mock := &mockWriteClient{}
+	input := "hello world"
+	reader := &slowReader{data: []byte(input), delay: time.Millisecond}
+
+	var readErr error
+	errDone := make(chan struct{})
+	w := &inputWriter{cfg: inputWriterConfig{
+		Reader:        reader,
+		Client:        mock,
+		SessionID:     "sess-1",
+		ClientID:      "client-1",
+		FlushInterval: 50 * time.Millisecond,
+		OnReadError: func(err error) {
+			readErr = err
+			close(errDone)
+		},
+	}}
+
+	w.Run()
+	<-errDone
+
+	if readErr != io.EOF {
+		t.Fatalf("expected io.EOF, got %v", readErr)
+	}
+
+	// All data should be received.
+	if got := string(mock.allData()); got != input {
+		t.Fatalf("data mismatch: got %q, want %q", got, input)
+	}
+
+	// Coalescing should produce fewer RPCs than individual bytes.
+	calls := mock.getCalls()
+	if len(calls) >= len(input) {
+		t.Errorf("expected fewer RPCs than bytes (%d), got %d calls", len(input), len(calls))
+	}
+
+	// Verify session/client IDs on all calls.
+	for i, c := range calls {
+		if c.SessionId != "sess-1" {
+			t.Errorf("call %d: session_id = %q, want %q", i, c.SessionId, "sess-1")
+		}
+		if c.ClientId != "client-1" {
+			t.Errorf("call %d: client_id = %q, want %q", i, c.ClientId, "client-1")
+		}
+	}
+}
+
+func TestInputWriterDetachKey(t *testing.T) {
+	mock := &mockWriteClient{}
+	// Data with detach key (0x1d) in the middle: "abc" + detachKey + "def"
+	input := []byte{'a', 'b', 'c', 0x1d, 'd', 'e', 'f'}
+	reader := bytes.NewReader(input)
+
+	detached := make(chan struct{})
+	w := &inputWriter{cfg: inputWriterConfig{
+		Reader:        reader,
+		Client:        mock,
+		SessionID:     "sess-1",
+		ClientID:      "client-1",
+		DetachKey:     0x1d,
+		FlushInterval: 5 * time.Millisecond,
+		OnDetach: func() {
+			close(detached)
+		},
+	}}
+
+	w.Run()
+
+	select {
+	case <-detached:
+	case <-time.After(time.Second):
+		t.Fatal("OnDetach was not called")
+	}
+
+	// Only bytes before the detach key should be sent.
+	got := string(mock.allData())
+	if got != "abc" {
+		t.Errorf("expected data before detach key %q, got %q", "abc", got)
+	}
+}
+
+func TestInputWriterDetachKeyAtStart(t *testing.T) {
+	mock := &mockWriteClient{}
+	input := []byte{0x1d, 'a', 'b', 'c'}
+	reader := bytes.NewReader(input)
+
+	detached := make(chan struct{})
+	w := &inputWriter{cfg: inputWriterConfig{
+		Reader:        reader,
+		Client:        mock,
+		SessionID:     "sess-1",
+		ClientID:      "client-1",
+		DetachKey:     0x1d,
+		FlushInterval: 5 * time.Millisecond,
+		OnDetach: func() {
+			close(detached)
+		},
+	}}
+
+	w.Run()
+
+	select {
+	case <-detached:
+	case <-time.After(time.Second):
+		t.Fatal("OnDetach was not called")
+	}
+
+	// No data should be sent when detach key is at position 0.
+	if got := mock.allData(); len(got) != 0 {
+		t.Errorf("expected no data, got %q", got)
+	}
+}
+
+func TestInputWriterFlushesOnMaxBatch(t *testing.T) {
+	mock := &mockWriteClient{}
+	// Create input larger than maxBatchSize (4096).
+	input := strings.Repeat("x", maxBatchSize+100)
+	reader := strings.NewReader(input)
+
+	done := make(chan struct{})
+	w := &inputWriter{cfg: inputWriterConfig{
+		Reader:        reader,
+		Client:        mock,
+		SessionID:     "sess-1",
+		ClientID:      "client-1",
+		FlushInterval: time.Second, // long interval — flush should happen via size threshold
+		OnReadError: func(_ error) {
+			close(done)
+		},
+	}}
+
+	w.Run()
+	<-done
+
+	if got := string(mock.allData()); got != input {
+		t.Fatalf("data mismatch: got %d bytes, want %d", len(got), len(input))
+	}
+
+	// Should have flushed at least once before the final EOF flush due to
+	// exceeding maxBatchSize.
+	calls := mock.getCalls()
+	if len(calls) < 2 {
+		t.Errorf("expected at least 2 calls (size-triggered + final), got %d", len(calls))
+	}
+}
+
+func TestInputWriterNoDetachKeyNoCallback(t *testing.T) {
+	mock := &mockWriteClient{}
+	input := "hello"
+	reader := strings.NewReader(input)
+
+	done := make(chan struct{})
+	w := &inputWriter{cfg: inputWriterConfig{
+		Reader:        reader,
+		Client:        mock,
+		SessionID:     "sess-1",
+		ClientID:      "client-1",
+		FlushInterval: 5 * time.Millisecond,
+		OnReadError: func(_ error) {
+			close(done)
+		},
+	}}
+
+	w.Run()
+	<-done
+
+	if got := string(mock.allData()); got != input {
+		t.Fatalf("data mismatch: got %q, want %q", got, input)
+	}
+}
+
+func TestInputWriterOnReadErrorNil(t *testing.T) {
+	// Verify that a nil OnReadError doesn't panic.
+	mock := &mockWriteClient{}
+	reader := strings.NewReader("hi")
+
+	w := &inputWriter{cfg: inputWriterConfig{
+		Reader:        reader,
+		Client:        mock,
+		SessionID:     "sess-1",
+		ClientID:      "client-1",
+		FlushInterval: 5 * time.Millisecond,
+	}}
+
+	// Should not panic.
+	w.Run()
+
+	// Give flush time to complete.
+	time.Sleep(20 * time.Millisecond)
+	if got := string(mock.allData()); got != "hi" {
+		t.Fatalf("data mismatch: got %q, want %q", got, "hi")
+	}
+}

--- a/cmd/bridgectl/run.go
+++ b/cmd/bridgectl/run.go
@@ -175,32 +175,26 @@ func runSession(dir, providerName, project string, timeout time.Duration) error 
 	}()
 
 	// Forward stdin → session, watching for detach key.
+	// Keystrokes are coalesced into batched WriteInput RPCs to avoid
+	// hitting per-session rate limits when typing quickly.
 	go func() {
-		buf := make([]byte, 1024)
-		for {
-			n, readErr := os.Stdin.Read(buf)
-			if n > 0 {
-				// Check for detach key (ctrl-]).
-				for i := 0; i < n; i++ {
-					if buf[i] == detachKey {
-						detached.Store(true)
-						cancel()
-						return
-					}
+		w := &inputWriter{cfg: inputWriterConfig{
+			Reader:    os.Stdin,
+			Client:    client,
+			SessionID: sessionID,
+			ClientID:  stream.ClientID(),
+			DetachKey: detachKey,
+			OnDetach: func() {
+				detached.Store(true)
+				cancel()
+			},
+			OnReadError: func(err error) {
+				if err != io.EOF {
+					fmt.Fprintf(os.Stderr, "\r\nstdin read failed: %v\r\n", err)
 				}
-				_, _ = client.WriteInput(context.Background(), &bridgev1.WriteInputRequest{
-					SessionId: sessionID,
-					ClientId:  stream.ClientID(),
-					Data:      buf[:n],
-				})
-			}
-			if readErr != nil {
-				if readErr != io.EOF {
-					fmt.Fprintf(os.Stderr, "\r\nstdin read failed: %v\r\n", readErr)
-				}
-				return
-			}
-		}
+			},
+		}}
+		w.Run()
 	}()
 
 	// Receive session output → stdout.
@@ -323,17 +317,12 @@ func runSessionNoTTY(dir, providerName, project string, timeout time.Duration) e
 		case <-ctx.Done():
 			return
 		}
-		buf := make([]byte, 4096)
-		for {
-			n, readErr := os.Stdin.Read(buf)
-			if n > 0 {
-				_, _ = client.WriteInput(context.Background(), &bridgev1.WriteInputRequest{
-					SessionId: sessionID,
-					ClientId:  stream.ClientID(),
-					Data:      buf[:n],
-				})
-			}
-			if readErr != nil {
+		w := &inputWriter{cfg: inputWriterConfig{
+			Reader:    os.Stdin,
+			Client:    client,
+			SessionID: sessionID,
+			ClientID:  stream.ClientID(),
+			OnReadError: func(_ error) {
 				stopCtx, stopCancel := context.WithTimeout(context.Background(), 3*time.Second)
 				_, _ = client.StopSession(stopCtx, &bridgev1.StopSessionRequest{
 					SessionId: sessionID,
@@ -341,9 +330,9 @@ func runSessionNoTTY(dir, providerName, project string, timeout time.Duration) e
 				})
 				stopCancel()
 				cancel()
-				return
-			}
-		}
+			},
+		}}
+		w.Run()
 	}()
 
 	err = stream.RecvAll(ctx, func(ev *bridgev1.AttachSessionEvent) error {

--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -323,33 +323,24 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 
 	if isWriter {
 		go func() {
-			buf := make([]byte, 1024)
-			for {
-				n, readErr := os.Stdin.Read(buf)
-				if n > 0 {
-					for i := 0; i < n; i++ {
-						if buf[i] == detachKey {
-							// Release the writer slot before detaching so another
-							// observer can claim it.
-							_, _ = client.ReleaseWriter(context.Background(), &bridgev1.ReleaseWriterRequest{
-								SessionId: sessionID,
-								ClientId:  stream.ClientID(),
-							})
-							detached.Store(true)
-							cancel()
-							return
-						}
-					}
-					_, _ = client.WriteInput(context.Background(), &bridgev1.WriteInputRequest{
+			w := &inputWriter{cfg: inputWriterConfig{
+				Reader:    os.Stdin,
+				Client:    client,
+				SessionID: sessionID,
+				ClientID:  stream.ClientID(),
+				DetachKey: detachKey,
+				OnDetach: func() {
+					// Release the writer slot before detaching so another
+					// observer can claim it.
+					_, _ = client.ReleaseWriter(context.Background(), &bridgev1.ReleaseWriterRequest{
 						SessionId: sessionID,
 						ClientId:  stream.ClientID(),
-						Data:      buf[:n],
 					})
-				}
-				if readErr != nil {
-					return
-				}
-			}
+					detached.Store(true)
+					cancel()
+				},
+			}}
+			w.Run()
 		}()
 	} else if term.IsTerminal(fd) {
 		// In raw mode ISIG is disabled, so the terminal won't generate

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -255,10 +255,10 @@ func applyDefaults(cfg *Config) {
 		cfg.RateLimits.StartSessionPerClientBurst = 3
 	}
 	if cfg.RateLimits.SendInputPerSessionRPS == 0 {
-		cfg.RateLimits.SendInputPerSessionRPS = 5
+		cfg.RateLimits.SendInputPerSessionRPS = 20
 	}
 	if cfg.RateLimits.SendInputPerSessionBurst == 0 {
-		cfg.RateLimits.SendInputPerSessionBurst = 20
+		cfg.RateLimits.SendInputPerSessionBurst = 50
 	}
 	if cfg.Logging.Level == "" {
 		cfg.Logging.Level = "info"

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -391,10 +391,10 @@ func Start(cfg Config) (*Server, error) {
 		cfg.RateLimits.StartSessionPerClientBurst = 10
 	}
 	if cfg.RateLimits.SendInputPerSessionRPS == 0 {
-		cfg.RateLimits.SendInputPerSessionRPS = 20
+		cfg.RateLimits.SendInputPerSessionRPS = 50
 	}
 	if cfg.RateLimits.SendInputPerSessionBurst == 0 {
-		cfg.RateLimits.SendInputPerSessionBurst = 50
+		cfg.RateLimits.SendInputPerSessionBurst = 100
 	}
 	if cfg.EventBufferSize <= 0 {
 		cfg.EventBufferSize = 8 << 20


### PR DESCRIPTION
## Summary

- Add `inputWriter` that coalesces stdin reads over a 20ms window into batched `WriteInput` RPCs, instead of sending one RPC per keystroke in raw terminal mode
- Raise default `SendInputPerSession` rate limits (local: 20→50 RPS / 50→100 burst; server config: 5→20 RPS / 20→50 burst)
- Apply batching to all three stdin→WriteInput loops in `run.go` (interactive + piped) and `session.go` (attach)

## Test plan

- [ ] Run `bridgectl run` in interactive mode and type rapidly — no dropped characters or `ResourceExhausted` errors
- [ ] Run `bridgectl session attach` as a writer and type rapidly — same behavior
- [ ] Pipe large input via `echo "long text" | bridgectl run --no-tty` — input delivered without rate limit errors
- [ ] Verify detach key (ctrl-]) still works correctly in both `run` and `session attach`
- [ ] `make test` passes (pre-existing failures in `client_renew_test` and `reposetup` are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)