### PR TITLE
Use user-owned provider runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build proto tools test test-e2e test-step-ca-e2e test-cover test-cover-maintained lint clean certs dev-certs dev-setup agents-setup setup-hosts fmt smoke smoke-apt-local smoke-deb smoke-container smoke-ec2 up down logs up-local down-local logs-local up-step-ca down-step-ca logs-step-ca step-ca-health step-ca-issue-client chat-example chat-claude chat-opencode chat-codex chat-gemini chat-ca-example chat-ca-claude chat-ca-opencode chat-ca-codex chat-ca-gemini sessions-list sessions-watch sessions-attach orchestrator-claude orchestrator-opencode web-install web-dev web-build web-start build-cli test-cli-e2e test-cli-e2e-docker install-user-service check-deps
+.PHONY: build proto tools test test-e2e test-step-ca-e2e test-cover test-cover-maintained lint clean certs dev-certs dev-setup agents-setup setup-hosts fmt smoke smoke-apt-local smoke-deb smoke-provider-runtime-user smoke-container smoke-ec2 up down logs up-local down-local logs-local up-step-ca down-step-ca logs-step-ca step-ca-health step-ca-issue-client chat-example chat-claude chat-opencode chat-codex chat-gemini chat-ca-example chat-ca-claude chat-ca-opencode chat-ca-codex chat-ca-gemini sessions-list sessions-watch sessions-attach orchestrator-claude orchestrator-opencode web-install web-dev web-build web-start build-cli test-cli-e2e test-cli-e2e-docker install-user-service check-deps
 
 BIN_DIR := bin
 BRIDGE_CA := $(BIN_DIR)/ai-agent-bridge-ca
@@ -94,6 +94,9 @@ smoke-apt-local:
 smoke-deb:
 	@if [ -z "$$DEB" ]; then echo "Usage: make smoke-deb DEB=<path-to-.deb> SUITE=<noble|plucky>"; exit 1; fi
 	./scripts/smoke-deb-docker.sh "$$DEB" "$${SUITE:-noble}"
+
+smoke-provider-runtime-user:
+	./scripts/smoke-provider-runtime-user.sh
 
 smoke-container:
 	@if [ -z "$$IMAGE" ]; then echo "Usage: make smoke-container IMAGE=<image>"; exit 1; fi

--- a/PRD.md
+++ b/PRD.md
@@ -288,6 +288,9 @@ The bridge must be installable on supported Ubuntu hosts through a signed apt re
 - No system user or group is created; the bridge runs as the login user.
 - Provide a default packaged config that allows the server to start on a fresh host without bundled provider CLIs or API keys.
 - Provider CLIs and their API credentials remain operator-managed prerequisites and must be documented separately from the package install flow.
+- Provider CLIs that are expected to use native self-updaters must be installed into a user-owned runtime directory. The packaged helper defaults to `$XDG_DATA_HOME/ai-agent-bridge/providers`, or `$HOME/.local/share/ai-agent-bridge/providers` when `XDG_DATA_HOME` is unset.
+- `/opt/ai-agent-bridge` is reserved for explicit root-controlled provider runtimes. Native provider self-updaters must not target this directory unless they run through a controlled privileged updater.
+- `runtime.provider_root` accepts absolute paths after environment expansion for `$HOME`, `${HOME}`, `$XDG_DATA_HOME`, and `${XDG_DATA_HOME}` so per-user provider roots can be documented without hard-coding a login name.
 
 ### Publishing and Hosting
 
@@ -310,6 +313,7 @@ The bridge must be installable on supported Ubuntu hosts through a signed apt re
 - A release tag builds a signed `.deb` for each supported Ubuntu target.
 - The published apt repository is consumable with standard `apt` commands on supported Ubuntu releases.
 - A clean Ubuntu host can install `ai-agent-bridge`, start the systemd service, and pass a basic daemon health check.
+- A clean Ubuntu container can run the packaged provider runtime installer as a non-root login user and install provider CLIs into the user-owned runtime directory without mutating `/opt/ai-agent-bridge`.
 - The release workflow includes smoke coverage that validates apt installation in containers and on an EC2 host.
 - `README.md` and `docs/` describe package installation, runtime prerequisites, and service behavior accurately.
 

--- a/docs/install-ubuntu.md
+++ b/docs/install-ubuntu.md
@@ -71,6 +71,29 @@ systemctl --user start bridge
 
 This split is intentional: the apt package ships the bridge server, not third-party provider binaries or API credentials.
 
+## Provider Runtime
+
+Provider CLIs that self-update should be installed as the same login user that runs the bridge service:
+
+```bash
+/usr/lib/ai-agent-bridge/install-provider-runtime
+```
+
+By default this installs providers into `$XDG_DATA_HOME/ai-agent-bridge/providers`, or `~/.local/share/ai-agent-bridge/providers` when `XDG_DATA_HOME` is unset. Configure the bridge with the same root:
+
+```yaml
+runtime:
+  provider_root: "$HOME/.local/share/ai-agent-bridge/providers"
+```
+
+Use `/opt/ai-agent-bridge` only for an explicitly root-controlled, pinned provider runtime:
+
+```bash
+sudo INSTALL_DIR=/opt/ai-agent-bridge /usr/lib/ai-agent-bridge/install-provider-runtime
+```
+
+Native provider updaters should not target `/opt/ai-agent-bridge` unless they run through a controlled privileged updater.
+
 ## Verifying The Service
 
 ```bash

--- a/docs/service.md
+++ b/docs/service.md
@@ -228,13 +228,13 @@ Controls how the bridge locates provider CLIs and the Node.js runtime. These set
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `provider_root` | `""` (daemon CWD) | Absolute path to the directory that contains `.nvmrc` and provider `node_modules`. When set: (1) Node.js version validation reads `{provider_root}/.nvmrc` instead of the daemon working directory; (2) a relative `binary` path (one that contains a `/`) resolves against `provider_root`; (3) bare standalone relative path arguments (e.g. `./node_modules/foo/bin/cli.js`) resolve against `provider_root`. Plain command names looked up via `PATH` (e.g. `node`) and embedded flag values (e.g. `--config=./foo`) are not affected. Use this when the daemon runs as a systemd service with a different `WorkingDirectory` than where provider CLIs are installed. |
+| `provider_root` | `""` (daemon CWD) | Absolute path to the directory that contains `.nvmrc` and provider `node_modules`. `$HOME`, `${HOME}`, `$XDG_DATA_HOME`, and `${XDG_DATA_HOME}` are expanded before validation. When set: (1) Node.js version validation reads `{provider_root}/.nvmrc` instead of the daemon working directory; (2) a relative `binary` path (one that contains a `/`) resolves against `provider_root`; (3) bare standalone relative path arguments (e.g. `./node_modules/foo/bin/cli.js`) resolve against `provider_root`. Plain command names looked up via `PATH` (e.g. `node`) and embedded flag values (e.g. `--config=./foo`) are not affected. Use this when the daemon runs as a systemd service with a different `WorkingDirectory` than where provider CLIs are installed. |
 
 Example:
 
 ```yaml
 runtime:
-  provider_root: "/opt/ai-agent-bridge"
+  provider_root: "$HOME/.local/share/ai-agent-bridge/providers"
 
 providers:
   codex:
@@ -247,8 +247,9 @@ providers:
 ```
 
 In this example, `./node_modules/@openai/codex/bin/codex.js` resolves to
-`/opt/ai-agent-bridge/node_modules/@openai/codex/bin/codex.js` regardless of
-where the daemon process is launched from.
+`$HOME/.local/share/ai-agent-bridge/providers/node_modules/@openai/codex/bin/codex.js`
+after environment expansion, regardless of where the daemon process is launched
+from.
 
 #### `repo_setup`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,6 +172,9 @@ func Load(path string) (*Config, error) {
 	}
 
 	applyDefaults(cfg)
+	if err := expandRuntimeConfig(cfg); err != nil {
+		return nil, err
+	}
 	if err := validate(cfg); err != nil {
 		return nil, err
 	}
@@ -275,6 +278,39 @@ func applyDefaults(cfg *Config) {
 	if cfg.RepoSetup.MaxTimeout == "" {
 		cfg.RepoSetup.MaxTimeout = "15m"
 	}
+}
+
+func expandRuntimeConfig(cfg *Config) error {
+	if cfg.Runtime.ProviderRoot == "" {
+		return nil
+	}
+	expanded, err := expandProviderRoot(cfg.Runtime.ProviderRoot)
+	if err != nil {
+		return err
+	}
+	cfg.Runtime.ProviderRoot = expanded
+	return nil
+}
+
+func expandProviderRoot(root string) (string, error) {
+	var missing []string
+	expanded := os.Expand(root, func(name string) string {
+		switch name {
+		case "HOME", "XDG_DATA_HOME":
+			value := os.Getenv(name)
+			if value == "" {
+				missing = append(missing, name)
+			}
+			return value
+		default:
+			missing = append(missing, name)
+			return ""
+		}
+	})
+	if len(missing) > 0 {
+		return "", fmt.Errorf("config: runtime.provider_root references unset or unsupported environment variable %q", missing[0])
+	}
+	return expanded, nil
 }
 
 func validate(cfg *Config) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -484,6 +484,11 @@ sessions:
 }
 
 func TestLoadRuntimeProviderRoot(t *testing.T) {
+	homeDir := t.TempDir()
+	xdgDir := filepath.Join(t.TempDir(), "xdg-data")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("XDG_DATA_HOME", xdgDir)
+
 	tests := []struct {
 		name     string
 		content  string
@@ -505,6 +510,70 @@ sessions:
   subscriber_ttl: "30m"
 `,
 			wantRoot: "/opt/ai-agent-bridge",
+		},
+		{
+			name: "provider_root expands braced home variable",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+runtime:
+  provider_root: "${HOME}/.local/share/ai-agent-bridge/providers"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`,
+			wantRoot: filepath.Join(homeDir, ".local/share/ai-agent-bridge/providers"),
+		},
+		{
+			name: "provider_root expands home variable",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+runtime:
+  provider_root: "$HOME/.local/share/ai-agent-bridge/providers"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`,
+			wantRoot: filepath.Join(homeDir, ".local/share/ai-agent-bridge/providers"),
+		},
+		{
+			name: "provider_root expands xdg data variable",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+runtime:
+  provider_root: "$XDG_DATA_HOME/ai-agent-bridge/providers"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`,
+			wantRoot: filepath.Join(xdgDir, "ai-agent-bridge/providers"),
+		},
+		{
+			name: "provider_root expands braced xdg data variable",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+runtime:
+  provider_root: "${XDG_DATA_HOME}/ai-agent-bridge/providers"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`,
+			wantRoot: filepath.Join(xdgDir, "ai-agent-bridge/providers"),
 		},
 		{
 			name: "provider_root absent",
@@ -529,6 +598,22 @@ auth:
   jwt_max_ttl: "5m"
 runtime:
   provider_root: "relative/path"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`,
+			wantErr: true,
+		},
+		{
+			name: "provider_root unresolved variable rejected",
+			content: `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+runtime:
+  provider_root: "$BRIDGE_PROVIDER_ROOT/providers"
 sessions:
   idle_timeout: "30m"
   stop_grace_period: "10s"

--- a/packaging/examples/bridge-example.yaml
+++ b/packaging/examples/bridge-example.yaml
@@ -7,7 +7,7 @@
 # This profile:
 #   - binds to 127.0.0.1:9445 in SECURE mode (mTLS + JWT via auto-generated PKI)
 #   - persistence is disabled by default; uncomment db_path to enable it
-#   - resolves provider CLIs from /opt/ai-agent-bridge (the provider runtime root)
+#   - resolves provider CLIs from the user-owned provider runtime root
 #
 # SECURITY MODES:
 #   - No server.listen (unix socket): local-only, no authentication required.
@@ -63,7 +63,7 @@ persistence:
   # Use an absolute path; ~ is not expanded. Omit to disable persistence.
 
 runtime:
-  provider_root: "/opt/ai-agent-bridge"
+  provider_root: "$HOME/.local/share/ai-agent-bridge/providers"
 
 repo_setup:
   enabled: true
@@ -74,8 +74,8 @@ repo_setup:
 # Enable one or more providers below. Credentials are read from the environment
 # (injected via /etc/ai-agent-bridge/agents.env at service startup).
 #
-# Run /usr/lib/ai-agent-bridge/install-provider-runtime to install the CLIs
-# before enabling any provider here.
+# Run /usr/lib/ai-agent-bridge/install-provider-runtime as the bridge login user
+# to install the CLIs before enabling any provider here.
 
 providers:
 
@@ -83,7 +83,7 @@ providers:
 #
 #   codex:
 #     binary: "/usr/bin/node"
-#     args: ["/opt/ai-agent-bridge/node_modules/@openai/codex/bin/codex.js"]
+#     args: ["./node_modules/@openai/codex/bin/codex.js"]
 #     startup_timeout: "60s"
 #     startup_probe: "output"
 #     required_env: ["OPENAI_API_KEY"]
@@ -92,7 +92,7 @@ providers:
 # Uncomment to enable Claude Code (requires CLAUDE_CODE_OAUTH_TOKEN in agents.env):
 #
 #   claude:
-#     binary: "/opt/ai-agent-bridge/node_modules/@anthropic-ai/claude-code/bin/claude.exe"
+#     binary: "./node_modules/@anthropic-ai/claude-code/bin/claude.exe"
 #     args: []
 #     startup_timeout: "60s"
 #     startup_probe: "output"
@@ -103,7 +103,7 @@ providers:
 # OpenCode ships as a native binary installed via npm — no Node.js invocation needed.
 #
 #   opencode:
-#     binary: "/opt/ai-agent-bridge/node_modules/.bin/opencode"
+#     binary: "./node_modules/.bin/opencode"
 #     args: []
 #     startup_timeout: "45s"
 #     startup_probe: "output"
@@ -112,7 +112,7 @@ providers:
 #
 #   gemini:
 #     binary: "/usr/bin/node"
-#     args: ["/opt/ai-agent-bridge/node_modules/@google/gemini-cli/dist/index.js"]
+#     args: ["./node_modules/@google/gemini-cli/dist/index.js"]
 #     startup_timeout: "60s"
 #     startup_probe: "output"
 #     required_env: ["GOOGLE_API_KEY"]

--- a/packaging/install-provider-runtime
+++ b/packaging/install-provider-runtime
@@ -53,6 +53,11 @@ for arg in "$@"; do
   esac
 done
 
+case "$INSTALL_DIR" in
+  /*) ;;
+  *) die "INSTALL_DIR must be an absolute path, got ${INSTALL_DIR}" ;;
+esac
+
 # ── Node.js version check ──────────────────────────────────────────────────
 
 node_major() {

--- a/packaging/install-provider-runtime
+++ b/packaging/install-provider-runtime
@@ -6,22 +6,42 @@
 #   install-provider-runtime --verify     Check installed versions; no changes.
 #
 # This script:
-#   1. Verifies (or installs) Node.js REQUIRED_NODE_MAJOR on the system PATH.
+#   1. Verifies Node.js REQUIRED_NODE_MAJOR on the system PATH.
 #   2. Copies the packaged runtime manifest from MANIFEST_DIR to INSTALL_DIR.
 #   3. Runs npm ci --omit=dev --no-audit --no-fund to install pinned provider CLIs.
 #   4. Verifies each installed CLI binary is present and reports its version.
-#   5. Ensures INSTALL_DIR is owned root:root and not writable by group/other.
+#   5. Ensures INSTALL_DIR is not writable by group/other.
 #
 # The script is safe to re-run; a failed install does not remove a previously
 # working runtime at INSTALL_DIR.
+#
+# By default, INSTALL_DIR is user-owned:
+#   $XDG_DATA_HOME/ai-agent-bridge/providers
+#   or $HOME/.local/share/ai-agent-bridge/providers when XDG_DATA_HOME is unset.
+#
+# Set INSTALL_DIR=/opt/ai-agent-bridge explicitly for a root-controlled runtime.
 #
 # MANIFEST_DIR and INSTALL_DIR may be overridden for testing:
 #   MANIFEST_DIR=/custom/src INSTALL_DIR=/custom/dst install-provider-runtime
 
 set -eu
 
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+say() { printf '==> %s\n' "$*"; }
+
+default_install_dir() {
+  if [ -n "${XDG_DATA_HOME:-}" ]; then
+    printf '%s\n' "${XDG_DATA_HOME}/ai-agent-bridge/providers"
+    return
+  fi
+  if [ -z "${HOME:-}" ]; then
+    die "HOME is required when INSTALL_DIR is not set"
+  fi
+  printf '%s\n' "${HOME}/.local/share/ai-agent-bridge/providers"
+}
+
 MANIFEST_DIR="${MANIFEST_DIR:-/usr/share/ai-agent-bridge/provider-runtime}"
-INSTALL_DIR="${INSTALL_DIR:-/opt/ai-agent-bridge}"
+INSTALL_DIR="${INSTALL_DIR:-$(default_install_dir)}"
 REQUIRED_NODE_MAJOR=24
 export DEBIAN_FRONTEND=noninteractive
 
@@ -33,15 +53,6 @@ for arg in "$@"; do
   esac
 done
 
-die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
-say() { printf '==> %s\n' "$*"; }
-
-# ── Root check ────────────────────────────────────────────────────────────────
-
-if [ "$(id -u)" -ne 0 ]; then
-  die "install-provider-runtime must be run as root (use sudo)"
-fi
-
 # ── Node.js version check ──────────────────────────────────────────────────
 
 node_major() {
@@ -49,6 +60,9 @@ node_major() {
 }
 
 if ! command -v node >/dev/null 2>&1; then
+  if [ "$(id -u)" -ne 0 ]; then
+    die "node not found on PATH; install Node.js ${REQUIRED_NODE_MAJOR} before running install-provider-runtime as this user"
+  fi
   if [ "$VERIFY_ONLY" -eq 1 ]; then
     die "node not found on PATH; install Node.js ${REQUIRED_NODE_MAJOR} first"
   fi
@@ -109,8 +123,10 @@ if [ "$VERIFY_ONLY" -eq 0 ]; then
   mv "$STAGE_DIR/node_modules" "$INSTALL_DIR/node_modules"
   rm -rf "$OLD_DIR" "$STAGE_DIR"
 
-  say "Fixing ownership of ${INSTALL_DIR}..."
-  chown -R root:root "$INSTALL_DIR"
+  if [ "$(id -u)" -eq 0 ]; then
+    say "Fixing ownership of ${INSTALL_DIR}..."
+    chown -R root:root "$INSTALL_DIR"
+  fi
   chmod -R go-w "$INSTALL_DIR"
 fi
 

--- a/scripts/smoke-provider-runtime-user.sh
+++ b/scripts/smoke-provider-runtime-user.sh
@@ -92,6 +92,15 @@ if ! docker exec "$CONTAINER" test -f /tmp/provider-runtime-smoke-ready >/dev/nu
 fi
 
 docker exec "$CONTAINER" su - ubuntu -c \
+  'if PATH=/tmp/fakebin:$PATH INSTALL_DIR=relative/providers /usr/lib/ai-agent-bridge/install-provider-runtime >/tmp/relative-install-dir.out 2>&1; then cat /tmp/relative-install-dir.out >&2; exit 1; fi'
+docker exec "$CONTAINER" su - ubuntu -c \
+  'grep -q "INSTALL_DIR must be an absolute path" /tmp/relative-install-dir.out'
+docker exec "$CONTAINER" su - ubuntu -c \
+  'if PATH=/tmp/fakebin:$PATH XDG_DATA_HOME=relative-data /usr/lib/ai-agent-bridge/install-provider-runtime >/tmp/relative-xdg-data-home.out 2>&1; then cat /tmp/relative-xdg-data-home.out >&2; exit 1; fi'
+docker exec "$CONTAINER" su - ubuntu -c \
+  'grep -q "INSTALL_DIR must be an absolute path" /tmp/relative-xdg-data-home.out'
+
+docker exec "$CONTAINER" su - ubuntu -c \
   'PATH=/tmp/fakebin:$PATH /usr/lib/ai-agent-bridge/install-provider-runtime'
 
 docker exec "$CONTAINER" su - ubuntu -c \

--- a/scripts/smoke-provider-runtime-user.sh
+++ b/scripts/smoke-provider-runtime-user.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds the Debian package, installs it in an Ubuntu container, and verifies
+# that the packaged provider runtime installer can run as a non-root login user.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+PACKAGES_DIR="$TMP_DIR/packages"
+CONTAINER="provider-runtime-user-smoke-$$"
+
+: "${SUITE:=noble}"
+: "${GOCACHE:=/tmp/ai-agent-bridge-go-build}"
+: "${GOFLAGS:=-buildvcs=false}"
+
+export GOCACHE
+export GOFLAGS
+
+cleanup() {
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+case "$SUITE" in
+  noble)  IMAGE="ubuntu:24.04" ;;
+  plucky) IMAGE="ubuntu:25.04" ;;
+  *)
+    echo "PROVIDER RUNTIME USER SMOKE FAILED: unsupported suite=$SUITE" >&2
+    exit 1
+    ;;
+esac
+
+VERSION="0.0.0-provider-runtime-smoke" OUTPUT_DIR="$PACKAGES_DIR" "$ROOT_DIR/scripts/build-deb.sh"
+DEB_PATH="$PACKAGES_DIR/ai-agent-bridge_0.0.0-provider-runtime-smoke_amd64.deb"
+DEB_BASENAME="$(basename "$DEB_PATH")"
+
+docker run -d \
+  --name "$CONTAINER" \
+  -v "$DEB_PATH:/tmp/$DEB_BASENAME:ro" \
+  "$IMAGE" \
+  bash -lc '
+    set -euo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    dpkg -i /tmp/'"$DEB_BASENAME"' || true
+    apt-get install -f -y -qq
+    if ! id -u ubuntu >/dev/null 2>&1; then
+      useradd -m -s /bin/bash ubuntu
+    fi
+    install -d -m 0755 /tmp/fakebin
+    cat >/tmp/fakebin/node <<'"'"'EOF_NODE'"'"'
+#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "v24.0.0"
+  exit 0
+fi
+exit 0
+EOF_NODE
+    cat >/tmp/fakebin/npm <<'"'"'EOF_NPM'"'"'
+#!/bin/sh
+set -eu
+if [ "$1" != "ci" ]; then
+  echo "unexpected npm command: $*" >&2
+  exit 1
+fi
+mkdir -p node_modules/.bin
+for cli in claude codex opencode gemini; do
+  cat >"node_modules/.bin/$cli" <<EOF_CLI
+#!/bin/sh
+echo "$cli smoke-version"
+EOF_CLI
+  chmod 0755 "node_modules/.bin/$cli"
+done
+EOF_NPM
+    chmod 0755 /tmp/fakebin/node /tmp/fakebin/npm
+    touch /tmp/provider-runtime-smoke-ready
+    tail -f /dev/null
+  ' >/dev/null
+
+for _ in $(seq 1 60); do
+  if docker exec "$CONTAINER" test -f /tmp/provider-runtime-smoke-ready >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! docker exec "$CONTAINER" test -f /tmp/provider-runtime-smoke-ready >/dev/null 2>&1; then
+  docker logs "$CONTAINER" >&2 || true
+  echo "PROVIDER RUNTIME USER SMOKE FAILED: container setup did not complete" >&2
+  exit 1
+fi
+
+docker exec "$CONTAINER" su - ubuntu -c \
+  'PATH=/tmp/fakebin:$PATH /usr/lib/ai-agent-bridge/install-provider-runtime'
+
+docker exec "$CONTAINER" su - ubuntu -c \
+  'test -x "$HOME/.local/share/ai-agent-bridge/providers/node_modules/.bin/codex"'
+docker exec "$CONTAINER" su - ubuntu -c \
+  'test -w "$HOME/.local/share/ai-agent-bridge/providers"'
+docker exec "$CONTAINER" sh -c \
+  'test ! -d /opt/ai-agent-bridge'
+
+echo "PROVIDER RUNTIME USER SMOKE PASSED: suite=$SUITE"

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -13,3 +13,10 @@
 - Early signal missed: The packaged default config is localhost-only by design, but the first smoke harness assumed host-to-container access over a published port.
 - Preventative rule: When a packaged service defaults to loopback-only binding, run health verification inside the target environment or through an explicit tunnel instead of relying on Docker port publishing.
 - Validation added (test/check/alert): Updated `scripts/smoke-apt-local.sh` to execute the gRPC healthcheck inside each Ubuntu container, matching packaged service behavior.
+
+## 2026-08-14 Detached Docker Smoke Setup
+- Incident/bug: The provider runtime smoke test tried to exec into a detached Ubuntu container before package/user setup had completed.
+- Root cause pattern: `docker run -d` returns after the container starts, not after an inline bootstrap script reaches its steady state.
+- Early signal missed: The first harness assumed a missing packaged file meant package contents were wrong, but the generated `.deb` contained the file.
+- Preventative rule: Detached container smoke tests must create and wait on an explicit readiness marker before running assertions or follow-up exec commands.
+- Validation added (test/check/alert): `scripts/smoke-provider-runtime-user.sh` waits for `/tmp/provider-runtime-smoke-ready` before running the non-root provider runtime installer.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -109,3 +109,55 @@ Evidence:
 
 Note:
 - `scripts/test-go-coverage.sh` initially failed under sandboxed `/tmp` caches due blocked module downloads, then failed under elevated network because the filesystem was full. The maintained coverage gate passed after pruning Docker build cache and using existing home Go caches.
+
+---
+
+# User-Owned Provider Runtime
+
+Mode: Approval-Required, approved by user request on 2026-08-14.
+
+Governing PRD section: `7.6 Debian/Ubuntu Distribution`.
+
+Scope:
+- Make the packaged provider runtime installer default to a user-owned runtime directory for self-updating provider CLIs.
+- Preserve `/opt/ai-agent-bridge` as an explicit root-controlled runtime path for pinned provider installs.
+- Update package docs and examples so native provider updaters do not target root-owned `/opt` by default.
+- Add unit coverage for config expansion/validation and Linux e2e coverage for the packaged installer path.
+
+Constraints:
+- The bridge package must still boot without provider CLIs or API keys.
+- Do not install third-party provider CLIs during `apt install`.
+- Keep existing `runtime.provider_root` semantics for absolute paths and relative provider binary/arg resolution.
+- Do not require root for user-owned provider runtime installs.
+
+Tradeoffs:
+- User-owned runtime directories fit fast-moving native provider updaters but reduce package-level version pinning.
+- Root-owned `/opt/ai-agent-bridge` remains useful for reproducible deployments that accept privileged updates.
+
+Risks:
+- Provider runtime installs rely on Node.js being present for unprivileged runs; root-only Node bootstrap must not obscure that requirement.
+- `$HOME` and `XDG_DATA_HOME` expansion must be deterministic and fail clearly when it cannot produce an absolute path.
+
+Test Strategy:
+- Add config unit tests proving `runtime.provider_root` expands `$HOME`, `${HOME}`, `$XDG_DATA_HOME`, and rejects unresolved or relative values.
+- Add installer e2e coverage in an Ubuntu container proving a non-root user can install the provider runtime into a user-owned directory and verify stubbed provider CLIs.
+- Run focused Go tests plus the new Linux e2e script.
+
+Rollback:
+- Set `INSTALL_DIR=/opt/ai-agent-bridge` when running `/usr/lib/ai-agent-bridge/install-provider-runtime`.
+- Revert the installer default and docs if user-owned provider self-updates are no longer supported.
+
+Execution Checklist:
+- [x] Update `PRD.md` with user-owned provider runtime acceptance criteria.
+- [x] Add failing config unit tests for runtime root expansion.
+- [x] Add Linux e2e coverage for non-root provider runtime installation.
+- [x] Implement installer default path and root/user behavior.
+- [x] Update Ubuntu install docs and packaged example config.
+- [x] Run formatting, unit tests, and Linux e2e verification.
+- [x] Record evidence and any lessons.
+
+Evidence:
+- `go test ./internal/config -run TestLoadRuntimeProviderRoot -count=1` failed before implementation because `${HOME}` and `$XDG_DATA_HOME` were not expanded.
+- `go test ./internal/config -count=1` -> passed.
+- `go test ./...` -> passed.
+- `SUITE=noble scripts/smoke-provider-runtime-user.sh` -> passed with Docker escalation; verified non-root install to `/home/ubuntu/.local/share/ai-agent-bridge/providers` and no `/opt/ai-agent-bridge` directory.


### PR DESCRIPTION
## Summary
- default the packaged provider runtime installer to a user-owned XDG/HOME data directory
- keep /opt/ai-agent-bridge available only via explicit INSTALL_DIR for root-controlled pinned runtimes
- expand runtime.provider_root for HOME/XDG_DATA_HOME and update Ubuntu docs/examples
- add Linux Docker smoke coverage for non-root provider runtime installation

## Tests
- go test ./internal/config -count=1
- go test ./...
- SUITE=noble scripts/smoke-provider-runtime-user.sh
- commit hooks: trim trailing whitespace, end-of-file, YAML, merge conflict, gofmt, goimports, golangci-lint
- pre-push hook: go-test

## Config / Operational Impact
- Provider CLIs that self-update now install by default under $XDG_DATA_HOME/ai-agent-bridge/providers or $HOME/.local/share/ai-agent-bridge/providers.
- Operators can still use sudo INSTALL_DIR=/opt/ai-agent-bridge /usr/lib/ai-agent-bridge/install-provider-runtime for controlled root-owned provider runtimes.
- runtime.provider_root now supports $HOME, ${HOME}, $XDG_DATA_HOME, and ${XDG_DATA_HOME} expansion before absolute-path validation.