### PR TITLE
Fix mTLS renewal always failing with missing client certificate

### DIFF
--- a/internal/localserver/stepca_native.go
+++ b/internal/localserver/stepca_native.go
@@ -286,11 +286,21 @@ func renewCertMTLS(stepCA *StepCAConfig, certPath, keyPath string, logger *slog.
 	pool.AppendCertsFromPEM(rootPEM)
 
 	// Create an mTLS transport that presents our existing cert.
+	// Use GetClientCertificate instead of Certificates so the cert is
+	// always sent regardless of the server's acceptable-CA list. When
+	// the cert PEM on disk contains only the leaf (no intermediate),
+	// Go's default matching logic finds no issuer match against the
+	// root-only acceptable-CA list and silently sends an empty
+	// certificate — causing Step CA to return "missing client
+	// certificate". GetClientCertificate bypasses that matching and
+	// lets Step CA decide whether to accept the cert.
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			RootCAs:      pool,
-			MinVersion:   tls.VersionTLS12,
+			GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				return &cert, nil
+			},
+			RootCAs:    pool,
+			MinVersion: tls.VersionTLS12,
 		},
 	}
 

--- a/internal/localserver/stepca_native_test.go
+++ b/internal/localserver/stepca_native_test.go
@@ -1,11 +1,24 @@
 package localserver
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -201,4 +214,170 @@ func TestReadProvisionerPassword_MissingFile(t *testing.T) {
 	_, err := readProvisionerPassword("/nonexistent/path/pw.txt")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "read password file")
+}
+
+// TestGetClientCertificate_LeafOnlyPEM is a regression test for the "missing
+// client certificate" bug. When the cert PEM contains only the leaf (no
+// intermediate chain), tls.Config.Certificates fails to match the cert
+// against the server's acceptable-CA list (which contains the root, not the
+// intermediate). GetClientCertificate bypasses that matching and always
+// presents the cert.
+func TestGetClientCertificate_LeafOnlyPEM(t *testing.T) {
+	// Create a root CA.
+	rootKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	rootTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Root CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTmpl, rootTmpl, &rootKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	rootCert, err := x509.ParseCertificate(rootDER)
+	require.NoError(t, err)
+
+	// Create an intermediate CA signed by root.
+	interKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	interTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "Test Intermediate CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	interDER, err := x509.CreateCertificate(rand.Reader, interTmpl, rootCert, &interKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	interCert, err := x509.ParseCertificate(interDER)
+	require.NoError(t, err)
+
+	// Issue a leaf cert signed by the intermediate.
+	leafKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "leaf"},
+		DNSNames:     []string{"leaf"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, interCert, &leafKey.PublicKey, interKey)
+	require.NoError(t, err)
+
+	// Write leaf-only PEM (no intermediate chain) and key to temp files.
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "leaf.crt")
+	keyPath := filepath.Join(dir, "leaf.key")
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0o644))
+
+	keyDER, err := x509.MarshalECPrivateKey(leafKey)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+
+	// Server CA pool contains only the root — this is what Step CA does.
+	// The intermediate's subject != root's subject, so a leaf-only chain
+	// has no cert whose issuer matches the root's subject.
+	clientCAPool := x509.NewCertPool()
+	clientCAPool.AddCert(rootCert)
+
+	// Issue a server cert for the test TLS server.
+	serverKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	serverTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(4),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTmpl, rootCert, &serverKey.PublicKey, rootKey)
+	require.NoError(t, err)
+
+	serverTLSCert := tls.Certificate{
+		Certificate: [][]byte{serverDER},
+		PrivateKey:  serverKey,
+	}
+
+	// Helper: start a TLS server that records whether a client cert was received.
+	// Uses RequestClientCert so the server sends a CertificateRequest with the
+	// root-only ClientCAs (triggering Go's acceptable-CA matching on the client)
+	// but does not reject the connection when the cert is missing or unverifiable.
+	startServer := func(t *testing.T) (*httptest.Server, *atomic.Bool) {
+		t.Helper()
+		sawClientCert := &atomic.Bool{}
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+				sawClientCert.Store(true)
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+		srv := httptest.NewUnstartedServer(handler)
+		srv.TLS = &tls.Config{
+			Certificates: []tls.Certificate{serverTLSCert},
+			ClientAuth:   tls.RequestClientCert,
+			ClientCAs:    clientCAPool,
+			MinVersion:   tls.VersionTLS12,
+		}
+		srv.StartTLS()
+		t.Cleanup(srv.Close)
+		return srv, sawClientCert
+	}
+
+	// Load the leaf-only cert+key.
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	require.NoError(t, err)
+
+	serverPool := x509.NewCertPool()
+	serverPool.AddCert(rootCert)
+
+	t.Run("Certificates_does_not_send_leaf_only_cert", func(t *testing.T) {
+		srv, sawCert := startServer(t)
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates: []tls.Certificate{cert},
+				RootCAs:      serverPool,
+				MinVersion:   tls.VersionTLS12,
+			},
+		}
+		client := &http.Client{Transport: tr}
+		resp, err := client.Get(srv.URL)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.False(t, sawCert.Load(),
+			"Certificates should NOT send a leaf-only cert when the server's "+
+				"acceptable-CA list contains only the root")
+	})
+
+	t.Run("GetClientCertificate_always_sends_cert", func(t *testing.T) {
+		srv, sawCert := startServer(t)
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+					return &cert, nil
+				},
+				RootCAs:    serverPool,
+				MinVersion: tls.VersionTLS12,
+			},
+		}
+		client := &http.Client{Transport: tr}
+		resp, err := client.Get(srv.URL)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.True(t, sawCert.Load(),
+			"GetClientCertificate should always send the cert, even leaf-only")
+	})
 }


### PR DESCRIPTION
## Summary

- Fix recurring mTLS renewal failed warnings caused by Go TLS client silently dropping the client certificate when the cert PEM lacks the intermediate chain
- Switch from tls.Config.Certificates to GetClientCertificate in the mTLS renewal transport so the cert is always presented regardless of Step CA acceptable-CA list
- The fallback to JWK/ACME still worked, but this eliminates the unnecessary fallback on every renewal cycle

## Root Cause

When WriteCertPEM writes only the leaf cert (because resp.CaPEM.Certificate is nil), tls.LoadX509KeyPair loads a single-cert chain. During the TLS handshake, Go checks whether the cert issuer DN matches Step CA acceptable-CA list (which contains the root CA subject). The leaf issuer is the intermediate CA -- no match -- so Go sends an empty certificate message and Step CA returns missing client certificate.

## Test plan

- [x] go build ./... passes
- [x] make fmt clean
- [x] go test -race ./internal/localserver/ -- all existing mTLS renewal tests pass
- [ ] Deploy and verify the WARN log no longer appears on renewal cycles

Generated with [Claude Code](https://claude.com/claude-code)