### PR TITLE
Add refresh button for remotes and fix renew-cert SAN merging

### DIFF
--- a/cmd/bridgectl/server.go
+++ b/cmd/bridgectl/server.go
@@ -528,8 +528,8 @@ immediate renewal (e.g. when the cert has already expired).`,
 					if stepCAProvisionerPasswordFile == "" && fileCfg.StepCA.ProvisionerPasswordFile != "" {
 						stepCAProvisionerPasswordFile = fileCfg.StepCA.ProvisionerPasswordFile
 					}
-					if len(serverSANs) == 0 && fileCfg.Server.Listen != "" {
-						serverSANs = localserver.BuildServerSANs(fileCfg.Server.Listen, nil)
+					if fileCfg.Server.Listen != "" {
+						serverSANs = localserver.BuildServerSANs(fileCfg.Server.Listen, serverSANs)
 					}
 					if fileCfg.Server.CertValidity != "" {
 						certValidity = config.ParseDuration(fileCfg.Server.CertValidity, 0)

--- a/cmd/bridgectl/server_init_test.go
+++ b/cmd/bridgectl/server_init_test.go
@@ -17,6 +17,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"log/slog"
+
+	"github.com/markcallen/ai-agent-bridge/internal/localserver"
+	"github.com/markcallen/ai-agent-bridge/internal/pki"
 )
 
 // selfSignedCA generates a self-signed CA cert and returns (certPEM, key).
@@ -191,6 +196,75 @@ tls:
 	}
 	if !strings.Contains(err.Error(), "must set both tls.cert and tls.key or neither") {
 		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestServerRenewCertMergesConfigSANsWithListenAddr(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("AI_AGENT_BRIDGE_STATE_DIR", stateDir)
+
+	// Bootstrap auto-PKI so renew-cert has a CA and server cert to work with.
+	logger := slog.Default()
+	initialSANs := []string{"server", "127.0.0.1", "localhost"}
+	_, err := localserver.EnsurePKI(stateDir, initialSANs, logger, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a config that sets both server.listen and server.san.
+	configPath := filepath.Join(t.TempDir(), "bridge.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+server:
+  listen: "10.0.0.1:9445"
+  san:
+    - "vpn.example.com"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newServerRenewCertCmd()
+	cmd.SetArgs([]string{"--config", configPath})
+	cmd.SetOut(nil)
+	cmd.SetErr(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	// Load the renewed cert and verify SANs include both the listen
+	// address IP and the configured SAN, plus defaults.
+	cert, err := pki.LoadCert(filepath.Join(stateDir, "certs", "server.crt"))
+	if err != nil {
+		t.Fatalf("LoadCert: %v", err)
+	}
+
+	wantDNS := []string{"vpn.example.com", "server", "localhost"}
+	for _, dns := range wantDNS {
+		found := false
+		for _, san := range cert.DNSNames {
+			if san == dns {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("renewed cert missing DNS SAN %q; got %v", dns, cert.DNSNames)
+		}
+	}
+
+	wantIPs := []string{"10.0.0.1", "127.0.0.1"}
+	for _, ipStr := range wantIPs {
+		wantIP := net.ParseIP(ipStr)
+		found := false
+		for _, ip := range cert.IPAddresses {
+			if ip.Equal(wantIP) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("renewed cert missing IP SAN %s; got %v", ipStr, cert.IPAddresses)
+		}
 	}
 }
 

--- a/examples/web/ui/src/App.tsx
+++ b/examples/web/ui/src/App.tsx
@@ -77,6 +77,16 @@ const styles: Record<string, React.CSSProperties> = {
     outline: 'none',
     width: '240px',
   },
+  refreshBtn: {
+    background: '#0f3460',
+    border: '1px solid #1a4a8a',
+    borderRadius: '4px',
+    color: '#e0e0e0',
+    padding: '4px 8px',
+    fontSize: '14px',
+    cursor: 'pointer',
+    lineHeight: 1,
+  },
   main: {
     flex: 1,
     display: 'flex',
@@ -105,12 +115,23 @@ export default function App() {
   const [showNewSession, setShowNewSession] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
   const [knownRemotes, setKnownRemotes] = useState<RemoteEntry[]>([])
+  const [remotesLoading, setRemotesLoading] = useState(false)
+
+  const refreshRemotes = useCallback(async () => {
+    setRemotesLoading(true)
+    try {
+      const remotes = await listRemotes()
+      setKnownRemotes(remotes)
+    } catch {
+      // ignore
+    } finally {
+      setRemotesLoading(false)
+    }
+  }, [])
 
   useEffect(() => {
-    listRemotes()
-      .then(setKnownRemotes)
-      .catch(() => {})
-  }, [])
+    void refreshRemotes()
+  }, [refreshRemotes])
 
   const remote = mode === 'remote' && remoteHost ? remoteHost : undefined
 
@@ -163,26 +184,36 @@ export default function App() {
           {mode === 'remote' && (
             <>
               {knownRemotes.length > 0 && !customRemote ? (
-                <select
-                  style={styles.select}
-                  value={remoteHost}
-                  onChange={(e) => {
-                    if (e.target.value === '__custom__') {
-                      setCustomRemote(true)
-                      setRemoteHost('')
-                    } else {
-                      setRemoteHost(e.target.value)
-                    }
-                  }}
-                >
-                  <option value="">Select a server...</option>
-                  {knownRemotes.map((r) => (
-                    <option key={r.host} value={r.host}>
-                      {r.name} ({r.host})
-                    </option>
-                  ))}
-                  <option value="__custom__">Other...</option>
-                </select>
+                <>
+                  <select
+                    style={styles.select}
+                    value={remoteHost}
+                    onChange={(e) => {
+                      if (e.target.value === '__custom__') {
+                        setCustomRemote(true)
+                        setRemoteHost('')
+                      } else {
+                        setRemoteHost(e.target.value)
+                      }
+                    }}
+                  >
+                    <option value="">Select a server...</option>
+                    {knownRemotes.map((r) => (
+                      <option key={r.host} value={r.host}>
+                        {r.name} ({r.host})
+                      </option>
+                    ))}
+                    <option value="__custom__">Other...</option>
+                  </select>
+                  <button
+                    style={styles.refreshBtn}
+                    onClick={() => void refreshRemotes()}
+                    disabled={remotesLoading}
+                    title="Refresh remotes from config"
+                  >
+                    {remotesLoading ? '...' : '\u21BB'}
+                  </button>
+                </>
               ) : (
                 <>
                   <input

--- a/examples/web/ui/src/App.tsx
+++ b/examples/web/ui/src/App.tsx
@@ -206,9 +206,14 @@ export default function App() {
                     <option value="__custom__">Other...</option>
                   </select>
                   <button
-                    style={styles.refreshBtn}
+                    type="button"
+                    style={{
+                      ...styles.refreshBtn,
+                      ...(remotesLoading ? { cursor: 'not-allowed', opacity: 0.6 } : {}),
+                    }}
                     onClick={() => void refreshRemotes()}
                     disabled={remotesLoading}
+                    aria-label="Refresh remotes from config"
                     title="Refresh remotes from config"
                   >
                     {remotesLoading ? '...' : '\u21BB'}

--- a/examples/web/ui/src/App.tsx
+++ b/examples/web/ui/src/App.tsx
@@ -228,6 +228,19 @@ export default function App() {
                     value={remoteHost}
                     onChange={(e) => setRemoteHost(e.target.value)}
                   />
+                  <button
+                    type="button"
+                    style={{
+                      ...styles.refreshBtn,
+                      ...(remotesLoading ? { cursor: 'not-allowed', opacity: 0.6 } : {}),
+                    }}
+                    onClick={() => void refreshRemotes()}
+                    disabled={remotesLoading}
+                    aria-label="Refresh remotes from config"
+                    title="Refresh remotes from config"
+                  >
+                    {remotesLoading ? '...' : '\u21BB'}
+                  </button>
                   {knownRemotes.length > 0 && (
                     <button
                       style={{ ...styles.input, width: 'auto', cursor: 'pointer' }}


### PR DESCRIPTION
## Summary

- Add a refresh button (↻) next to the remotes dropdown in the web UI so users can reload the remotes list from `remotes.yaml` without a page reload
- Fix a bug in `bridgectl server renew-cert` where configured `server.san` entries prevented `BuildServerSANs()` from merging the listen address IP and default SANs, causing renewed certs to be missing expected SANs

## Test plan

- [ ] Open the web UI, switch to Remote mode, verify the ↻ button appears next to the dropdown
- [ ] Edit `~/.ai-agent-bridge/remotes.yaml` to add/remove a remote, click ↻, verify the dropdown updates
- [ ] Run `bridgectl server renew-cert` with both `server.san` and `server.listen` configured, verify the renewed cert includes all SANs (listen IP, configured SANs, server, localhost, 127.0.0.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)