### PR TITLE
Use orchael/bridge-demo as e2e test fixture

### DIFF
--- a/e2e/scripts/test-entrypoint.sh
+++ b/e2e/scripts/test-entrypoint.sh
@@ -21,7 +21,7 @@ if [ -d "/tmp/bridgectl/.git" ]; then
   echo "    Repo already present, pulling latest main..."
   git -C /tmp/bridgectl pull origin main
 else
-  git clone --depth 1 https://github.com/markcallen/cache-cleaner /tmp/bridgectl-src
+  git clone --depth 1 https://github.com/orchael/bridge-demo /tmp/bridgectl-src
   cp -a /tmp/bridgectl-src/. /tmp/bridgectl/
   rm -rf /tmp/bridgectl-src
 fi


### PR DESCRIPTION
## Summary

- Replace `markcallen/cache-cleaner` with `orchael/bridge-demo` as the dummy git repo cloned by the e2e test suite

## Test plan

- [ ] CI passes (e2e tests clone from the new repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)