### PR TITLE
feat: show agent working directory in web UI sessions list

### DIFF
--- a/examples/web/server/server.go
+++ b/examples/web/server/server.go
@@ -123,6 +123,7 @@ func (s *server) listSessions(w http.ResponseWriter, r *http.Request) {
 		Provider  string `json:"provider"`
 		Status    string `json:"status"`
 		CreatedAt string `json:"createdAt"`
+		RepoPath  string `json:"repoPath"`
 	}
 
 	sessions := make([]sessionInfo, 0, len(resp.GetSessions()))
@@ -137,6 +138,7 @@ func (s *server) listSessions(w http.ResponseWriter, r *http.Request) {
 			Provider:  ss.GetProvider(),
 			Status:    ss.GetStatus().String(),
 			CreatedAt: createdAt,
+			RepoPath:  ss.GetRepoPath(),
 		})
 	}
 

--- a/examples/web/ui/src/api.ts
+++ b/examples/web/ui/src/api.ts
@@ -6,6 +6,7 @@ export interface Session {
   provider: string
   status: string
   createdAt: string
+  repoPath: string
 }
 
 export interface SessionEvent {

--- a/examples/web/ui/src/components/SessionList.tsx
+++ b/examples/web/ui/src/components/SessionList.tsx
@@ -143,6 +143,22 @@ function formatDate(iso: string): string {
   }
 }
 
+function shortDir(repoPath: string): string {
+  if (!repoPath) return ''
+  // Replace common home directory prefixes with ~/
+  const homePatterns = [
+    /^\/Users\/[^/]+\//,   // macOS: /Users/<user>/
+    /^\/home\/[^/]+\//,    // Linux: /home/<user>/
+    /^\/root\//,           // Linux root
+  ]
+  for (const pattern of homePatterns) {
+    if (pattern.test(repoPath)) {
+      return repoPath.replace(pattern, '~/')
+    }
+  }
+  return repoPath
+}
+
 export default function SessionList({ remote, onAttach, onWatch, onNewSession }: Props) {
   const [sessions, setSessions] = useState<Session[]>([])
   const [loading, setLoading] = useState(false)
@@ -200,6 +216,7 @@ export default function SessionList({ remote, onAttach, onWatch, onNewSession }:
                 <th style={styles.th}>Session ID</th>
                 <th style={styles.th}>Project</th>
                 <th style={styles.th}>Provider</th>
+                <th style={styles.th}>Directory</th>
                 <th style={styles.th}>Status</th>
                 <th style={styles.th}>Created</th>
                 <th style={styles.th}>Actions</th>
@@ -215,6 +232,11 @@ export default function SessionList({ remote, onAttach, onWatch, onNewSession }:
                   </td>
                   <td style={styles.td}>{s.projectId}</td>
                   <td style={styles.td}>{s.provider}</td>
+                  <td style={styles.td}>
+                    <span style={styles.mono} title={s.repoPath}>
+                      {shortDir(s.repoPath)}
+                    </span>
+                  </td>
                   <td style={styles.td}>
                     <span style={statusStyle(s.status)}>{s.status}</span>
                   </td>

--- a/gen/bridge/v1/bridge.pb.go
+++ b/gen/bridge/v1/bridge.pb.go
@@ -525,6 +525,8 @@ type GetSessionResponse struct {
 	ActiveWriterClientId string `protobuf:"bytes,16,opt,name=active_writer_client_id,json=activeWriterClientId,proto3" json:"active_writer_client_id,omitempty"`
 	// observer_count is the number of read-only observers currently attached.
 	ObserverCount int32 `protobuf:"varint,17,opt,name=observer_count,json=observerCount,proto3" json:"observer_count,omitempty"`
+	// repo_path is the working directory the agent session is running in.
+	RepoPath      string `protobuf:"bytes,18,opt,name=repo_path,json=repoPath,proto3" json:"repo_path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -676,6 +678,13 @@ func (x *GetSessionResponse) GetObserverCount() int32 {
 		return x.ObserverCount
 	}
 	return 0
+}
+
+func (x *GetSessionResponse) GetRepoPath() string {
+	if x != nil {
+		return x.RepoPath
+	}
+	return ""
 }
 
 type ListSessionsRequest struct {
@@ -2027,7 +2036,7 @@ const file_bridge_v1_bridge_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x01(\x0e2\x18.bridge.v1.SessionStatusR\x06status\"2\n" +
 	"\x11GetSessionRequest\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x01 \x01(\tR\tsessionId\"\xf8\x04\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"\x95\x05\n" +
 	"\x12GetSessionResponse\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x1d\n" +
@@ -2051,7 +2060,8 @@ const file_bridge_v1_bridge_proto_rawDesc = "" +
 	"\x04cols\x18\x0e \x01(\rR\x04cols\x12\x12\n" +
 	"\x04rows\x18\x0f \x01(\rR\x04rows\x125\n" +
 	"\x17active_writer_client_id\x18\x10 \x01(\tR\x14activeWriterClientId\x12%\n" +
-	"\x0eobserver_count\x18\x11 \x01(\x05R\robserverCount\"4\n" +
+	"\x0eobserver_count\x18\x11 \x01(\x05R\robserverCount\x12\x1b\n" +
+	"\trepo_path\x18\x12 \x01(\tR\brepoPath\"4\n" +
 	"\x13ListSessionsRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\"Q\n" +

--- a/internal/bridge/provider.go
+++ b/internal/bridge/provider.go
@@ -64,6 +64,7 @@ type SessionInfo struct {
 	SessionID        string
 	ProjectID        string
 	Provider         string
+	RepoPath         string
 	State            SessionState
 	ProcessID        int
 	CreatedAt        time.Time

--- a/internal/bridge/supervisor.go
+++ b/internal/bridge/supervisor.go
@@ -469,6 +469,7 @@ func (s *Supervisor) Start(ctx context.Context, cfg SessionConfig) (*SessionInfo
 			SessionID: cfg.SessionID,
 			ProjectID: cfg.ProjectID,
 			Provider:  provider.ID(),
+			RepoPath:  cfg.RepoPath,
 			State:     SessionStateRunning,
 			CreatedAt: now,
 			Cols:      cfg.InitialCols,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -538,6 +538,7 @@ func sessionInfoToProto(info *bridge.SessionInfo) *bridgev1.GetSessionResponse {
 		SessionId:            info.SessionID,
 		ProjectId:            info.ProjectID,
 		Provider:             info.Provider,
+		RepoPath:             info.RepoPath,
 		Status:               mapState(info.State),
 		CreatedAt:            timestamppb.New(info.CreatedAt),
 		Error:                info.Error,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -269,18 +269,20 @@ func newServerWithSupervisor(t *testing.T) (*BridgeServer, *bridge.Supervisor) {
 	return s, sup
 }
 
-func startServerSession(t *testing.T, s *BridgeServer, sessionID string) {
+func startServerSession(t *testing.T, s *BridgeServer, sessionID string) string {
 	t.Helper()
+	repoPath := t.TempDir()
 	ctx := auth.ContextWithClaims(context.Background(), &auth.BridgeClaims{ProjectID: "proj"})
 	_, err := s.StartSession(ctx, &bridgev1.StartSessionRequest{
 		ProjectId: "proj",
 		SessionId: sessionID,
-		RepoPath:  t.TempDir(),
+		RepoPath:  repoPath,
 		Provider:  "cat",
 	})
 	if err != nil {
 		t.Fatalf("StartSession: %v", err)
 	}
+	return repoPath
 }
 
 const (
@@ -372,7 +374,7 @@ func TestMapBridgeErrorWriterConflict(t *testing.T) {
 func TestStopWriteResizeRPCs(t *testing.T) {
 	s, sup := newServerWithSupervisor(t)
 	const sid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-	startServerSession(t, s, sid)
+	repoPath := startServerSession(t, s, sid)
 
 	ctx := auth.ContextWithClaims(context.Background(), &auth.BridgeClaims{ProjectID: "proj"})
 
@@ -417,6 +419,9 @@ func TestStopWriteResizeRPCs(t *testing.T) {
 	}
 	if resp.GetSessionId() != sid {
 		t.Errorf("GetSession id=%q want %q", resp.GetSessionId(), sid)
+	}
+	if resp.GetRepoPath() != repoPath {
+		t.Errorf("GetSession repo_path=%q want %q", resp.GetRepoPath(), repoPath)
 	}
 
 	// StopSession happy path.

--- a/proto/bridge/v1/bridge.proto
+++ b/proto/bridge/v1/bridge.proto
@@ -131,6 +131,8 @@ message GetSessionResponse {
   string active_writer_client_id = 16;
   // observer_count is the number of read-only observers currently attached.
   int32 observer_count = 17;
+  // repo_path is the working directory the agent session is running in.
+  string repo_path = 18;
 }
 
 message ListSessionsRequest {


### PR DESCRIPTION
## Summary
- Add `repo_path` field to `GetSessionResponse` proto and thread it through `SessionInfo`, the gRPC server, web HTTP API, and frontend
- Display a "Directory" column in the web UI sessions list showing where each agent is running
- Replace home directory prefixes (`/Users/<user>/`, `/home/<user>/`, `/root/`) with `~/` for readability; full path available via tooltip

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/bridge/... ./internal/server/...` passes
- [x] `make fmt` clean
- [x] Pre-commit hooks pass (gofmt, goimports, golangci-lint)
- [ ] Start a session via the web UI and verify the Directory column shows `~/...` path
- [ ] Hover the directory cell to verify the full path tooltip
- [ ] Verify sessions created before this change show an empty directory (graceful zero-value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)