### PR TITLE
chore: exclude e2e scripts from production Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 #   source   - build from Go source (default, for local docker build)
 #   prebuilt - use binaries already compiled by GoReleaser
 ARG BUILD_FROM=source
+ARG INCLUDE_E2E_SCRIPTS=false
 
 # Source build stage
 FROM golang:1.25 AS source
@@ -21,6 +22,19 @@ COPY bridgectl bridge-ca /out/
 
 # Select binary source — BuildKit skips whichever stage is not referenced
 FROM ${BUILD_FROM} AS build
+
+# e2e test helpers — conditional multi-stage selector.
+# When INCLUDE_E2E_SCRIPTS=true, the e2e-scripts stage contains the helper;
+# when false, the stage is empty so the final COPY is a no-op.
+# When true, copy the e2e helper into a staging directory.
+FROM busybox AS e2e-scripts-true
+COPY e2e/scripts/opencode_repl.js /scripts/opencode_repl.js
+
+# When false, create the same path as an empty directory so the COPY is a no-op.
+FROM busybox AS e2e-scripts-false
+RUN mkdir -p /scripts
+
+FROM e2e-scripts-${INCLUDE_E2E_SCRIPTS} AS e2e-scripts
 
 # Runtime stage
 FROM ubuntu:24.04
@@ -67,12 +81,8 @@ RUN chmod +x /app/entrypoint.sh
 
 # e2e test helpers — excluded from production images by default.
 # Pass --build-arg INCLUDE_E2E_SCRIPTS=true to include them (e.g. in e2e compose).
-ARG INCLUDE_E2E_SCRIPTS=false
-RUN --mount=type=bind,source=e2e/scripts/opencode_repl.js,target=/tmp/opencode_repl.js,ro \
-    if [ "$INCLUDE_E2E_SCRIPTS" = "true" ]; then \
-      mkdir -p /app/scripts && \
-      cp /tmp/opencode_repl.js /app/scripts/opencode_repl.js; \
-    fi
+# When false, the e2e-scripts stage is empty so this COPY is a no-op and adds no layer.
+COPY --from=e2e-scripts /scripts/ /app/scripts/
 
 EXPOSE 9445
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,16 @@ COPY config/bridge-docker-stepca.yaml /app/config/bridge-docker-stepca.yaml
 COPY docker-entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
-RUN mkdir -p /app/scripts
-COPY e2e/scripts/opencode_repl.js /app/scripts/opencode_repl.js
+# e2e test helpers — excluded from production images by default.
+# Pass --build-arg INCLUDE_E2E_SCRIPTS=true to include them (e.g. in e2e compose).
+ARG INCLUDE_E2E_SCRIPTS=false
+COPY e2e/scripts/opencode_repl.js /tmp/opencode_repl.js
+RUN mkdir -p /app/scripts && \
+    if [ "$INCLUDE_E2E_SCRIPTS" = "true" ]; then \
+      mv /tmp/opencode_repl.js /app/scripts/opencode_repl.js; \
+    else \
+      rm -f /tmp/opencode_repl.js; \
+    fi
 
 EXPOSE 9445
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,12 +67,10 @@ RUN chmod +x /app/entrypoint.sh
 # e2e test helpers — excluded from production images by default.
 # Pass --build-arg INCLUDE_E2E_SCRIPTS=true to include them (e.g. in e2e compose).
 ARG INCLUDE_E2E_SCRIPTS=false
-COPY e2e/scripts/opencode_repl.js /tmp/opencode_repl.js
-RUN mkdir -p /app/scripts && \
+RUN mkdir -p /app/scripts
+RUN --mount=type=bind,source=e2e/scripts/opencode_repl.js,target=/tmp/opencode_repl.js \
     if [ "$INCLUDE_E2E_SCRIPTS" = "true" ]; then \
-      mv /tmp/opencode_repl.js /app/scripts/opencode_repl.js; \
-    else \
-      rm -f /tmp/opencode_repl.js; \
+      cp /tmp/opencode_repl.js /app/scripts/opencode_repl.js; \
     fi
 
 EXPOSE 9445

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # BUILD_FROM selects the binary source:
 #   source   - build from Go source (default, for local docker build)
 #   prebuilt - use binaries already compiled by GoReleaser
@@ -67,9 +68,9 @@ RUN chmod +x /app/entrypoint.sh
 # e2e test helpers — excluded from production images by default.
 # Pass --build-arg INCLUDE_E2E_SCRIPTS=true to include them (e.g. in e2e compose).
 ARG INCLUDE_E2E_SCRIPTS=false
-RUN mkdir -p /app/scripts
-RUN --mount=type=bind,source=e2e/scripts/opencode_repl.js,target=/tmp/opencode_repl.js \
+RUN --mount=type=bind,source=e2e/scripts/opencode_repl.js,target=/tmp/opencode_repl.js,ro \
     if [ "$INCLUDE_E2E_SCRIPTS" = "true" ]; then \
+      mkdir -p /app/scripts && \
       cp /tmp/opencode_repl.js /app/scripts/opencode_repl.js; \
     fi
 

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
+      args:
+        INCLUDE_E2E_SCRIPTS: "true"
     environment:
       BRIDGE_CONFIG: /app/config/bridge-e2e.yaml
       BRIDGE_CN: bridge


### PR DESCRIPTION
## Summary
- Adds `INCLUDE_E2E_SCRIPTS` build arg (default: false) to Dockerfile
- Production builds no longer include `opencode_repl.js`
- e2e docker-compose passes `INCLUDE_E2E_SCRIPTS=true` so e2e tests still work

Closes #89

## Test plan
- [ ] Production `docker build .` does NOT include `/app/scripts/opencode_repl.js`
- [ ] `make test-e2e` still has the script available (via build arg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)