### PR TITLE
test: fill unit test coverage gaps for validation, limits, and timeouts

### DIFF
--- a/cmd/bridge-ca/subcommands_test.go
+++ b/cmd/bridge-ca/subcommands_test.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+var (
+	cachedBin     string
+	cachedBinOnce sync.Once
+	cachedBinErr  error
+)
+
+// buildBridgeCA compiles the bridge-ca binary once (cached across all tests)
+// and returns the path.
+func buildBridgeCA(t *testing.T) string {
+	t.Helper()
+	cachedBinOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "bridge-ca-test-*")
+		if err != nil {
+			cachedBinErr = err
+			return
+		}
+		bin := filepath.Join(dir, "bridge-ca")
+		build := exec.Command("go", "build", "-o", bin, ".")
+		build.Dir = "."
+		build.Stdout = os.Stdout
+		build.Stderr = os.Stderr
+		if err := build.Run(); err != nil {
+			cachedBinErr = err
+			return
+		}
+		cachedBin = bin
+	})
+	if cachedBinErr != nil {
+		t.Fatalf("build bridge-ca: %v", cachedBinErr)
+	}
+	return cachedBin
+}
+
+// TestInitSubcommand verifies the init subcommand creates a CA cert and key.
+// Issue #153: bridge-ca subcommand unit tests.
+func TestInitSubcommand(t *testing.T) {
+	bin := buildBridgeCA(t)
+	outDir := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(bin, "init", "--name", "test-ca", "--out", outDir)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bridge-ca init failed: %v\nstderr: %s", err, stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "CA certificate:") {
+		t.Errorf("expected 'CA certificate:' in output, got: %s", output)
+	}
+	if !strings.Contains(output, "CA private key:") {
+		t.Errorf("expected 'CA private key:' in output, got: %s", output)
+	}
+
+	// Verify files were created.
+	certPath := filepath.Join(outDir, "ca.crt")
+	keyPath := filepath.Join(outDir, "ca.key")
+	if _, err := os.Stat(certPath); err != nil {
+		t.Errorf("CA cert not found at %s: %v", certPath, err)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Errorf("CA key not found at %s: %v", keyPath, err)
+	}
+}
+
+// TestInitSubcommandMissingName verifies that init fails when --name is omitted.
+func TestInitSubcommandMissingName(t *testing.T) {
+	bin := buildBridgeCA(t)
+	cmd := exec.Command(bin, "init")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected bridge-ca init to fail without --name")
+	}
+	if !strings.Contains(stderr.String(), "--name is required") {
+		t.Errorf("expected '--name is required' in stderr, got: %s", stderr.String())
+	}
+}
+
+// TestIssueSubcommand verifies the issue subcommand creates a certificate.
+func TestIssueSubcommand(t *testing.T) {
+	bin := buildBridgeCA(t)
+	caDir := t.TempDir()
+	certDir := t.TempDir()
+
+	// First create a CA.
+	initCmd := exec.Command(bin, "init", "--name", "test-ca", "--out", caDir)
+	if err := initCmd.Run(); err != nil {
+		t.Fatalf("init CA: %v", err)
+	}
+
+	// Issue a server cert.
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(bin, "issue",
+		"--type", "server",
+		"--cn", "test-server",
+		"--san", "localhost",
+		"--ca", filepath.Join(caDir, "ca.crt"),
+		"--ca-key", filepath.Join(caDir, "ca.key"),
+		"--out", certDir,
+	)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bridge-ca issue failed: %v\nstderr: %s", err, stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Certificate:") {
+		t.Errorf("expected 'Certificate:' in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Private key:") {
+		t.Errorf("expected 'Private key:' in output, got: %s", output)
+	}
+}
+
+// TestIssueSubcommandMissingFlags verifies that issue fails when required
+// flags are omitted.
+func TestIssueSubcommandMissingFlags(t *testing.T) {
+	bin := buildBridgeCA(t)
+	cmd := exec.Command(bin, "issue")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected bridge-ca issue to fail without required flags")
+	}
+	if !strings.Contains(stderr.String(), "required") {
+		t.Errorf("expected 'required' in stderr, got: %s", stderr.String())
+	}
+}
+
+// TestIssueSubcommandInvalidType verifies that issue fails with an invalid
+// --type value.
+func TestIssueSubcommandInvalidType(t *testing.T) {
+	bin := buildBridgeCA(t)
+	caDir := t.TempDir()
+	certDir := t.TempDir()
+
+	initCmd := exec.Command(bin, "init", "--name", "test-ca", "--out", caDir)
+	if err := initCmd.Run(); err != nil {
+		t.Fatalf("init CA: %v", err)
+	}
+
+	cmd := exec.Command(bin, "issue",
+		"--type", "invalid",
+		"--cn", "test",
+		"--ca", filepath.Join(caDir, "ca.crt"),
+		"--ca-key", filepath.Join(caDir, "ca.key"),
+		"--out", certDir,
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected bridge-ca issue to fail with invalid type")
+	}
+	if !strings.Contains(stderr.String(), "server") || !strings.Contains(stderr.String(), "client") {
+		t.Errorf("expected error about server/client type, got: %s", stderr.String())
+	}
+}
+
+// TestBundleSubcommand verifies the bundle subcommand concatenates certs.
+func TestBundleSubcommand(t *testing.T) {
+	bin := buildBridgeCA(t)
+	caDir := t.TempDir()
+	bundlePath := filepath.Join(t.TempDir(), "bundle.crt")
+
+	// Create a CA to have a cert to bundle.
+	initCmd := exec.Command(bin, "init", "--name", "test-ca", "--out", caDir)
+	if err := initCmd.Run(); err != nil {
+		t.Fatalf("init CA: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(bin, "bundle",
+		"--out", bundlePath,
+		filepath.Join(caDir, "ca.crt"),
+	)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bridge-ca bundle failed: %v\nstderr: %s", err, stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Trust bundle:") {
+		t.Errorf("expected 'Trust bundle:' in output, got: %s", output)
+	}
+
+	if _, err := os.Stat(bundlePath); err != nil {
+		t.Errorf("bundle file not found at %s: %v", bundlePath, err)
+	}
+}
+
+// TestBundleSubcommandMissingFlags verifies that bundle fails when --out
+// or cert paths are omitted.
+func TestBundleSubcommandMissingFlags(t *testing.T) {
+	bin := buildBridgeCA(t)
+	cmd := exec.Command(bin, "bundle")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected bridge-ca bundle to fail without flags")
+	}
+	if !strings.Contains(stderr.String(), "required") {
+		t.Errorf("expected 'required' in stderr, got: %s", stderr.String())
+	}
+}
+
+// TestJWTKeygenSubcommand verifies the jwt-keygen subcommand creates a keypair.
+func TestJWTKeygenSubcommand(t *testing.T) {
+	bin := buildBridgeCA(t)
+	outDir := t.TempDir()
+	basePath := filepath.Join(outDir, "jwt-test")
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(bin, "jwt-keygen", "--out", basePath)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bridge-ca jwt-keygen failed: %v\nstderr: %s", err, stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Public key:") {
+		t.Errorf("expected 'Public key:' in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Private key:") {
+		t.Errorf("expected 'Private key:' in output, got: %s", output)
+	}
+
+	pubPath := basePath + ".pub"
+	privPath := basePath + ".key"
+	if _, err := os.Stat(pubPath); err != nil {
+		t.Errorf("public key not found at %s: %v", pubPath, err)
+	}
+	if _, err := os.Stat(privPath); err != nil {
+		t.Errorf("private key not found at %s: %v", privPath, err)
+	}
+}
+
+// TestUnknownSubcommand verifies that an unknown command exits non-zero.
+func TestUnknownSubcommand(t *testing.T) {
+	bin := buildBridgeCA(t)
+	cmd := exec.Command(bin, "nonexistent")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit for unknown subcommand")
+	}
+}
+
+// TestHelpSubcommand verifies that help exits with code 0.
+func TestHelpSubcommand(t *testing.T) {
+	bin := buildBridgeCA(t)
+	cmd := exec.Command(bin, "help")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bridge-ca help exited non-zero: %v", err)
+	}
+}
+
+// TestNoArgsExitsNonZero verifies that running with no arguments exits non-zero.
+func TestNoArgsExitsNonZero(t *testing.T) {
+	bin := buildBridgeCA(t)
+	cmd := exec.Command(bin)
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit with no arguments")
+	}
+}
+
+// TestVerifySubcommand verifies the verify subcommand (happy path and error).
+func TestVerifySubcommand(t *testing.T) {
+	bin := buildBridgeCA(t)
+	caDir := t.TempDir()
+	certDir := t.TempDir()
+
+	// Create a CA and issue a cert.
+	initCmd := exec.Command(bin, "init", "--name", "test-ca", "--out", caDir)
+	if err := initCmd.Run(); err != nil {
+		t.Fatalf("init CA: %v", err)
+	}
+
+	issueCmd := exec.Command(bin, "issue",
+		"--type", "server",
+		"--cn", "test-server",
+		"--ca", filepath.Join(caDir, "ca.crt"),
+		"--ca-key", filepath.Join(caDir, "ca.key"),
+		"--out", certDir,
+	)
+	if err := issueCmd.Run(); err != nil {
+		t.Fatalf("issue cert: %v", err)
+	}
+
+	t.Run("valid cert verifies against CA", func(t *testing.T) {
+		cmd := exec.Command(bin, "verify",
+			"--cert", filepath.Join(certDir, "test-server.crt"),
+			"--bundle", filepath.Join(caDir, "ca.crt"),
+		)
+		var stdout bytes.Buffer
+		cmd.Stdout = &stdout
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("verify failed: %v", err)
+		}
+		if !strings.Contains(stdout.String(), "OK") {
+			t.Errorf("expected 'OK' in verify output, got: %s", stdout.String())
+		}
+	})
+
+	t.Run("verify with missing flags fails", func(t *testing.T) {
+		cmd := exec.Command(bin, "verify")
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err == nil {
+			t.Fatal("expected verify to fail without flags")
+		}
+		if !strings.Contains(stderr.String(), "required") {
+			t.Errorf("expected 'required' in stderr, got: %s", stderr.String())
+		}
+	})
+}
+
+// TestIssueClientCert verifies that client certificates can be issued.
+func TestIssueClientCert(t *testing.T) {
+	bin := buildBridgeCA(t)
+	caDir := t.TempDir()
+	certDir := t.TempDir()
+
+	initCmd := exec.Command(bin, "init", "--name", "test-ca", "--out", caDir)
+	if err := initCmd.Run(); err != nil {
+		t.Fatalf("init CA: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	cmd := exec.Command(bin, "issue",
+		"--type", "client",
+		"--cn", "test-client",
+		"--ca", filepath.Join(caDir, "ca.crt"),
+		"--ca-key", filepath.Join(caDir, "ca.key"),
+		"--out", certDir,
+	)
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bridge-ca issue client cert failed: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Certificate:") {
+		t.Errorf("expected 'Certificate:' in output")
+	}
+}

--- a/cmd/bridge-ca/subcommands_test.go
+++ b/cmd/bridge-ca/subcommands_test.go
@@ -12,9 +12,19 @@ import (
 
 var (
 	cachedBin     string
+	cachedBinDir  string
 	cachedBinOnce sync.Once
 	cachedBinErr  error
 )
+
+// TestMain cleans up the cached build directory after all tests complete.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if cachedBinDir != "" {
+		_ = os.RemoveAll(cachedBinDir)
+	}
+	os.Exit(code)
+}
 
 // buildBridgeCA compiles the bridge-ca binary once (cached across all tests)
 // and returns the path.
@@ -26,6 +36,7 @@ func buildBridgeCA(t *testing.T) string {
 			cachedBinErr = err
 			return
 		}
+		cachedBinDir = dir
 		bin := filepath.Join(dir, "bridge-ca")
 		build := exec.Command("go", "build", "-o", bin, ".")
 		build.Dir = "."

--- a/internal/bridge/policy_validation_test.go
+++ b/internal/bridge/policy_validation_test.go
@@ -1,0 +1,234 @@
+package bridge
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestInputSizeValidation verifies that WriteInput caps payloads at
+// policy.MaxInputBytes (default 64 KB) and returns ErrInputTooLarge.
+// Issue #153: input size validation.
+func TestInputSizeValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxBytes  int
+		inputSize int
+		wantErr   error
+	}{
+		{
+			name:      "under limit is accepted",
+			maxBytes:  100,
+			inputSize: 50,
+			wantErr:   nil,
+		},
+		{
+			name:      "at limit is accepted",
+			maxBytes:  100,
+			inputSize: 100,
+			wantErr:   nil,
+		},
+		{
+			name:      "over limit returns ErrInputTooLarge",
+			maxBytes:  100,
+			inputSize: 101,
+			wantErr:   ErrInputTooLarge,
+		},
+		{
+			name:      "default 64KB limit accepts 64KB",
+			maxBytes:  65536,
+			inputSize: 65536,
+			wantErr:   nil,
+		},
+		{
+			name:      "default 64KB limit rejects 64KB+1",
+			maxBytes:  65536,
+			inputSize: 65537,
+			wantErr:   ErrInputTooLarge,
+		},
+		{
+			name:      "zero maxBytes means unlimited",
+			maxBytes:  0,
+			inputSize: 1 << 20, // 1 MB
+			wantErr:   nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := Policy{MaxInputBytes: tc.maxBytes}
+			data := make([]byte, tc.inputSize)
+
+			err := policy.ValidateInputBytes(data)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("ValidateInputBytes: unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("ValidateInputBytes error=%v want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestInputSizeValidationText verifies ValidateInput (string variant).
+func TestInputSizeValidationText(t *testing.T) {
+	tests := []struct {
+		name      string
+		maxBytes  int
+		inputSize int
+		wantErr   error
+	}{
+		{
+			name:      "text under limit is accepted",
+			maxBytes:  10,
+			inputSize: 10,
+			wantErr:   nil,
+		},
+		{
+			name:      "text over limit returns ErrInputTooLarge",
+			maxBytes:  10,
+			inputSize: 11,
+			wantErr:   ErrInputTooLarge,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := Policy{MaxInputBytes: tc.maxBytes}
+			text := string(make([]byte, tc.inputSize))
+
+			err := policy.ValidateInput(text)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("ValidateInput: unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("ValidateInput error=%v want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestSessionLimitsPerProject verifies that max_per_project is enforced.
+// Issue #153: session limits.
+func TestSessionLimitsPerProject(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxProject   int
+		maxGlobal    int
+		projectCount int
+		globalCount  int
+		wantErr      error
+	}{
+		{
+			name:         "under project limit is allowed",
+			maxProject:   5,
+			maxGlobal:    20,
+			projectCount: 4,
+			globalCount:  4,
+			wantErr:      nil,
+		},
+		{
+			name:         "at project limit is rejected",
+			maxProject:   5,
+			maxGlobal:    20,
+			projectCount: 5,
+			globalCount:  5,
+			wantErr:      ErrSessionLimitReached,
+		},
+		{
+			name:         "over project limit is rejected",
+			maxProject:   2,
+			maxGlobal:    20,
+			projectCount: 3,
+			globalCount:  5,
+			wantErr:      ErrSessionLimitReached,
+		},
+		{
+			name:         "under global limit but at project limit is rejected",
+			maxProject:   1,
+			maxGlobal:    100,
+			projectCount: 1,
+			globalCount:  1,
+			wantErr:      ErrSessionLimitReached,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := Policy{MaxPerProject: tc.maxProject, MaxGlobal: tc.maxGlobal}
+			err := policy.CheckSessionLimits(tc.projectCount, tc.globalCount)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("CheckSessionLimits: unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("CheckSessionLimits error=%v want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestSessionLimitsGlobal verifies that max_global is enforced.
+// Issue #153: session limits.
+func TestSessionLimitsGlobal(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxProject   int
+		maxGlobal    int
+		projectCount int
+		globalCount  int
+		wantErr      error
+	}{
+		{
+			name:         "under global limit is allowed",
+			maxProject:   10,
+			maxGlobal:    5,
+			projectCount: 0,
+			globalCount:  4,
+			wantErr:      nil,
+		},
+		{
+			name:         "at global limit is rejected",
+			maxProject:   10,
+			maxGlobal:    5,
+			projectCount: 0,
+			globalCount:  5,
+			wantErr:      ErrSessionLimitReached,
+		},
+		{
+			name:         "over global limit is rejected",
+			maxProject:   100,
+			maxGlobal:    2,
+			projectCount: 0,
+			globalCount:  3,
+			wantErr:      ErrSessionLimitReached,
+		},
+		{
+			name:         "zero maxGlobal means unlimited",
+			maxProject:   100,
+			maxGlobal:    0,
+			projectCount: 0,
+			globalCount:  10000,
+			wantErr:      nil,
+		},
+		{
+			name:         "zero maxProject means unlimited",
+			maxProject:   0,
+			maxGlobal:    100,
+			projectCount: 10000,
+			globalCount:  0,
+			wantErr:      nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := Policy{MaxPerProject: tc.maxProject, MaxGlobal: tc.maxGlobal}
+			err := policy.CheckSessionLimits(tc.projectCount, tc.globalCount)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("CheckSessionLimits: unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("CheckSessionLimits error=%v want %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/bridge/supervisor_limits_test.go
+++ b/internal/bridge/supervisor_limits_test.go
@@ -1,0 +1,292 @@
+package bridge
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestWriteInputOversizedPayload verifies that WriteInput rejects payloads
+// exceeding policy.MaxInputBytes and returns ErrInputTooLarge.
+// Issue #153: input size validation.
+func TestWriteInputOversizedPayload(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(&testProvider{id: "fake"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	maxInputBytes := 64 // very small for testing
+	policy := Policy{
+		MaxPerProject: 10,
+		MaxGlobal:     20,
+		MaxInputBytes: maxInputBytes,
+	}
+	supervisor := NewSupervisor(registry, policy, 1024, time.Minute)
+	defer supervisor.Close()
+
+	repo := t.TempDir()
+	if _, err := supervisor.Start(context.Background(), SessionConfig{
+		ProjectID:   "project-a",
+		SessionID:   "session-input",
+		RepoPath:    repo,
+		Options:     map[string]string{"provider": "fake"},
+		InitialCols: 80,
+		InitialRows: 24,
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Attach as writer so WriteInput is allowed.
+	if _, err := supervisor.Attach("session-input", "client-a", 0, AttachRoleWriter); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		size    int
+		wantErr error
+	}{
+		{
+			name:    "under limit succeeds",
+			size:    maxInputBytes - 1,
+			wantErr: nil,
+		},
+		{
+			name:    "at limit succeeds",
+			size:    maxInputBytes,
+			wantErr: nil,
+		},
+		{
+			name:    "over limit returns ErrInputTooLarge",
+			size:    maxInputBytes + 1,
+			wantErr: ErrInputTooLarge,
+		},
+		{
+			name:    "much larger returns ErrInputTooLarge",
+			size:    maxInputBytes * 10,
+			wantErr: ErrInputTooLarge,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := make([]byte, tc.size)
+			for i := range data {
+				data[i] = 'x'
+			}
+			_, err := supervisor.WriteInput("session-input", "client-a", data)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("WriteInput: unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("WriteInput error=%v want %v", err, tc.wantErr)
+			}
+		})
+	}
+
+	_ = supervisor.Stop("session-input", true)
+}
+
+// TestSessionLimitPerProjectEnforcement verifies that the supervisor refuses
+// to start sessions beyond max_per_project.
+// Issue #153: session limits.
+func TestSessionLimitPerProjectEnforcement(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(&testProvider{id: "fake"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	policy := Policy{
+		MaxPerProject: 2,
+		MaxGlobal:     10,
+		MaxInputBytes: 65536,
+	}
+	supervisor := NewSupervisor(registry, policy, 1024, time.Minute)
+	defer supervisor.Close()
+
+	repo := t.TempDir()
+
+	// Start two sessions for project-a (at the limit).
+	for i, sid := range []string{"limit-proj-1", "limit-proj-2"} {
+		if _, err := supervisor.Start(context.Background(), SessionConfig{
+			ProjectID: "project-a",
+			SessionID: sid,
+			RepoPath:  repo,
+			Options:   map[string]string{"provider": "fake"},
+		}); err != nil {
+			t.Fatalf("Start session %d: %v", i+1, err)
+		}
+	}
+
+	// Third session for the same project should fail.
+	_, err := supervisor.Start(context.Background(), SessionConfig{
+		ProjectID: "project-a",
+		SessionID: "limit-proj-3",
+		RepoPath:  repo,
+		Options:   map[string]string{"provider": "fake"},
+	})
+	if !errors.Is(err, ErrSessionLimitReached) {
+		t.Fatalf("expected ErrSessionLimitReached, got: %v", err)
+	}
+
+	// A different project should still be able to start a session.
+	if _, err := supervisor.Start(context.Background(), SessionConfig{
+		ProjectID: "project-b",
+		SessionID: "limit-proj-b-1",
+		RepoPath:  repo,
+		Options:   map[string]string{"provider": "fake"},
+	}); err != nil {
+		t.Fatalf("Start for project-b: %v", err)
+	}
+
+	// Clean up.
+	for _, sid := range []string{"limit-proj-1", "limit-proj-2", "limit-proj-b-1"} {
+		_ = supervisor.Stop(sid, true)
+	}
+}
+
+// TestSessionLimitGlobalEnforcement verifies that the supervisor refuses to
+// start sessions beyond max_global.
+// Issue #153: session limits.
+func TestSessionLimitGlobalEnforcement(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(&testProvider{id: "fake"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	policy := Policy{
+		MaxPerProject: 10,
+		MaxGlobal:     3,
+		MaxInputBytes: 65536,
+	}
+	supervisor := NewSupervisor(registry, policy, 1024, time.Minute)
+	defer supervisor.Close()
+
+	repo := t.TempDir()
+
+	// Start three sessions across different projects.
+	for i, id := range []string{"limit-g-1", "limit-g-2", "limit-g-3"} {
+		if _, err := supervisor.Start(context.Background(), SessionConfig{
+			ProjectID: "project-" + id,
+			SessionID: id,
+			RepoPath:  repo,
+			Options:   map[string]string{"provider": "fake"},
+		}); err != nil {
+			t.Fatalf("Start session %d: %v", i+1, err)
+		}
+	}
+
+	// Fourth session (any project) should fail.
+	_, err := supervisor.Start(context.Background(), SessionConfig{
+		ProjectID: "project-new",
+		SessionID: "limit-g-4",
+		RepoPath:  repo,
+		Options:   map[string]string{"provider": "fake"},
+	})
+	if !errors.Is(err, ErrSessionLimitReached) {
+		t.Fatalf("expected ErrSessionLimitReached (global), got: %v", err)
+	}
+
+	// Clean up.
+	for _, sid := range []string{"limit-g-1", "limit-g-2", "limit-g-3"} {
+		_ = supervisor.Stop(sid, true)
+	}
+}
+
+// TestListSessionsFiltersByProject verifies List returns only sessions
+// matching the requested project_id.
+// Issue #153: ListSessions.
+func TestListSessionsFiltersByProject(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(&testProvider{id: "fake"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	supervisor := NewSupervisor(registry, DefaultPolicy(), 1024, time.Minute)
+	defer supervisor.Close()
+
+	repo := t.TempDir()
+
+	// Start sessions for two projects.
+	for _, cfg := range []struct {
+		projectID, sessionID string
+	}{
+		{"proj-x", "list-x-1"},
+		{"proj-x", "list-x-2"},
+		{"proj-y", "list-y-1"},
+	} {
+		if _, err := supervisor.Start(context.Background(), SessionConfig{
+			ProjectID: cfg.projectID,
+			SessionID: cfg.sessionID,
+			RepoPath:  repo,
+			Options:   map[string]string{"provider": "fake"},
+		}); err != nil {
+			t.Fatalf("Start %s: %v", cfg.sessionID, err)
+		}
+	}
+
+	// List for proj-x: should return 2.
+	listX := supervisor.List("proj-x")
+	if len(listX) != 2 {
+		t.Fatalf("List(proj-x) len=%d want 2", len(listX))
+	}
+
+	// List for proj-y: should return 1.
+	listY := supervisor.List("proj-y")
+	if len(listY) != 1 {
+		t.Fatalf("List(proj-y) len=%d want 1", len(listY))
+	}
+
+	// List for all (empty project_id): should return 3.
+	listAll := supervisor.List("")
+	if len(listAll) != 3 {
+		t.Fatalf("List('') len=%d want 3", len(listAll))
+	}
+
+	// Clean up.
+	for _, sid := range []string{"list-x-1", "list-x-2", "list-y-1"} {
+		_ = supervisor.Stop(sid, true)
+	}
+}
+
+// TestResizeSessionUpdatesSize verifies that Resize updates cols/rows.
+// Issue #153: ResizeSession.
+func TestResizeSessionUpdatesSize(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(&testProvider{id: "fake"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	supervisor := NewSupervisor(registry, DefaultPolicy(), 1024, time.Minute)
+	defer supervisor.Close()
+
+	if _, err := supervisor.Start(context.Background(), SessionConfig{
+		ProjectID:   "project-a",
+		SessionID:   "resize-session",
+		RepoPath:    t.TempDir(),
+		Options:     map[string]string{"provider": "fake"},
+		InitialCols: 80,
+		InitialRows: 24,
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if _, err := supervisor.Attach("resize-session", "client-a", 0, AttachRoleWriter); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	if err := supervisor.Resize("resize-session", "client-a", 200, 50); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	info, err := supervisor.Get("resize-session")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if info.Cols != 200 || info.Rows != 50 {
+		t.Fatalf("size=%dx%d want 200x50", info.Cols, info.Rows)
+	}
+
+	_ = supervisor.Stop("resize-session", true)
+}

--- a/internal/server/ratelimit_test.go
+++ b/internal/server/ratelimit_test.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRateLimitEnforcement verifies that the token bucket rate limiter
+// rejects requests that exceed the configured RPS and burst.
+// Issue #153: rate limiting.
+func TestRateLimitEnforcement(t *testing.T) {
+	tests := []struct {
+		name       string
+		rate       float64
+		burst      int
+		numCalls   int
+		wantDenied bool
+	}{
+		{
+			name:       "single call within burst is allowed",
+			rate:       1,
+			burst:      1,
+			numCalls:   1,
+			wantDenied: false,
+		},
+		{
+			name:       "two calls with burst=1 denies second",
+			rate:       1,
+			burst:      1,
+			numCalls:   2,
+			wantDenied: true,
+		},
+		{
+			name:       "burst=5 allows 5 immediate calls",
+			rate:       1,
+			burst:      5,
+			numCalls:   5,
+			wantDenied: false,
+		},
+		{
+			name:       "burst=5 denies 6th immediate call",
+			rate:       1,
+			burst:      5,
+			numCalls:   6,
+			wantDenied: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Now()
+			bucket := newTokenBucket(tc.rate, tc.burst, now)
+
+			var denied bool
+			for i := 0; i < tc.numCalls; i++ {
+				if !bucket.allow(now) {
+					denied = true
+				}
+			}
+
+			if tc.wantDenied && !denied {
+				t.Fatal("expected at least one denial, all calls were allowed")
+			}
+			if !tc.wantDenied && denied {
+				t.Fatal("expected all calls allowed, but at least one was denied")
+			}
+		})
+	}
+}
+
+// TestRateLimitTokenRefill verifies tokens refill over time.
+func TestRateLimitTokenRefill(t *testing.T) {
+	now := time.Now()
+	bucket := newTokenBucket(10, 1, now) // 10 RPS, burst 1
+
+	// Drain the single token.
+	if !bucket.allow(now) {
+		t.Fatal("first allow should succeed")
+	}
+	// Immediately after, should be denied.
+	if bucket.allow(now) {
+		t.Fatal("second immediate allow should fail")
+	}
+	// After 200ms at 10 RPS, 2 tokens should have refilled (only 1 needed).
+	after := now.Add(200 * time.Millisecond)
+	if !bucket.allow(after) {
+		t.Fatal("allow after token refill should succeed")
+	}
+}
+
+// TestKeyedLimiterIsolatesKeys verifies that different keys have independent buckets.
+func TestKeyedLimiterIsolatesKeys(t *testing.T) {
+	limiter := newKeyedLimiter(1, 1)
+
+	// Key "a" uses its token.
+	if !limiter.allow("a") {
+		t.Fatal("first allow for key 'a' should succeed")
+	}
+	// Key "a" is now exhausted.
+	if limiter.allow("a") {
+		t.Fatal("second allow for key 'a' should fail")
+	}
+	// Key "b" should still have its token.
+	if !limiter.allow("b") {
+		t.Fatal("first allow for key 'b' should succeed")
+	}
+}
+
+// TestCircuitBreakerTripsAfterThreshold verifies that the circuit breaker
+// trips after circuitBreakerThreshold consecutive violations, banning the
+// key for circuitBreakerBanDuration.
+// Issue #153: rate limiting circuit breaker.
+func TestCircuitBreakerTripsAfterThreshold(t *testing.T) {
+	now := time.Now()
+	bucket := newTokenBucket(1, 1, now)
+
+	// Drain the only token so all subsequent calls are violations.
+	bucket.allow(now)
+
+	// Drive violations right up to the threshold.
+	for i := 0; i < circuitBreakerThreshold-1; i++ {
+		bucket.allow(now)
+		if bucket.isBanned(now) {
+			t.Fatalf("circuit breaker tripped too early at violation %d", i+1)
+		}
+	}
+
+	// The next violation should trip the breaker.
+	bucket.allow(now)
+	if !bucket.isBanned(now) {
+		t.Fatal("circuit breaker did not trip after threshold violations")
+	}
+
+	// During the ban, allow returns false.
+	if bucket.allow(now.Add(time.Second)) {
+		t.Fatal("allow should return false during ban")
+	}
+
+	// After the ban duration, the ban lifts.
+	afterBan := now.Add(circuitBreakerBanDuration + time.Second)
+	if bucket.isBanned(afterBan) {
+		t.Fatal("bucket still banned after ban duration elapsed")
+	}
+}
+
+// TestNilLimiterAllowsAll verifies that a nil keyedLimiter does not block.
+func TestNilLimiterAllowsAll(t *testing.T) {
+	var limiter *keyedLimiter
+	if !limiter.allow("any-key") {
+		t.Fatal("nil limiter should allow all")
+	}
+	if limiter.banned("any-key") {
+		t.Fatal("nil limiter should never be banned")
+	}
+}
+
+// TestZeroRateLimiterAllowsAll verifies that a zero-rate limiter allows all.
+func TestZeroRateLimiterAllowsAll(t *testing.T) {
+	limiter := newKeyedLimiter(0, 0)
+	if !limiter.allow("any-key") {
+		t.Fatal("zero-rate limiter should allow all")
+	}
+}

--- a/internal/server/session_rpc_test.go
+++ b/internal/server/session_rpc_test.go
@@ -1,0 +1,272 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	bridgev1 "github.com/orchael/bridgectl/gen/bridge/v1"
+	"github.com/orchael/bridgectl/internal/auth"
+	"github.com/orchael/bridgectl/internal/bridge"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestSessionIDFormatValidationRPC verifies that StartSession, StopSession,
+// GetSession, WriteInput, and ResizeSession all reject non-UUID session_id
+// with INVALID_ARGUMENT.
+// Issue #153: session ID format validation.
+func TestSessionIDFormatValidationRPC(t *testing.T) {
+	registry := bridge.NewRegistry()
+	if err := registry.Register(&serverTestProvider{id: "cat", version: "1"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	supervisor := bridge.NewSupervisor(registry, bridge.DefaultPolicy(), 1024, time.Minute)
+	defer supervisor.Close()
+
+	s := New(supervisor, registry, nil, RateLimitConfig{
+		GlobalRPS:                  100,
+		GlobalBurst:                100,
+		StartSessionPerClientRPS:   100,
+		StartSessionPerClientBurst: 100,
+		SendInputPerSessionRPS:     100,
+		SendInputPerSessionBurst:   100,
+	}, "test", nil, nil, "")
+
+	ctx := auth.ContextWithClaims(context.Background(), &auth.BridgeClaims{ProjectID: "proj"})
+
+	badIDs := []string{
+		"not-a-uuid",
+		"12345",
+		"",
+		"zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz",
+	}
+
+	for _, badID := range badIDs {
+		t.Run("StartSession/"+badID, func(t *testing.T) {
+			_, err := s.StartSession(ctx, &bridgev1.StartSessionRequest{
+				ProjectId: "proj",
+				SessionId: badID,
+				RepoPath:  t.TempDir(),
+				Provider:  "cat",
+			})
+			if badID == "" {
+				// Empty string is caught by validateStringField first.
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("code=%v want InvalidArgument", status.Code(err))
+				}
+			} else {
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("StartSession(%q) code=%v want InvalidArgument", badID, status.Code(err))
+				}
+			}
+		})
+
+		if badID == "" {
+			continue // Skip empty string for these RPCs (caught by required check).
+		}
+
+		t.Run("StopSession/"+badID, func(t *testing.T) {
+			_, err := s.StopSession(ctx, &bridgev1.StopSessionRequest{SessionId: badID})
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("StopSession(%q) code=%v want InvalidArgument", badID, status.Code(err))
+			}
+		})
+
+		t.Run("GetSession/"+badID, func(t *testing.T) {
+			_, err := s.GetSession(ctx, &bridgev1.GetSessionRequest{SessionId: badID})
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("GetSession(%q) code=%v want InvalidArgument", badID, status.Code(err))
+			}
+		})
+
+		t.Run("WriteInput/"+badID, func(t *testing.T) {
+			_, err := s.WriteInput(ctx, &bridgev1.WriteInputRequest{
+				SessionId: badID,
+				ClientId:  "client-a",
+				Data:      []byte("test"),
+			})
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("WriteInput(%q) code=%v want InvalidArgument", badID, status.Code(err))
+			}
+		})
+
+		t.Run("ResizeSession/"+badID, func(t *testing.T) {
+			_, err := s.ResizeSession(ctx, &bridgev1.ResizeSessionRequest{
+				SessionId: badID,
+				ClientId:  "client-a",
+				Cols:      80,
+				Rows:      24,
+			})
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("ResizeSession(%q) code=%v want InvalidArgument", badID, status.Code(err))
+			}
+		})
+	}
+}
+
+// TestGlobalRateLimitExhausted verifies that the global rate limiter
+// returns ResourceExhausted when the limit is exceeded.
+// Issue #153: rate limiting.
+func TestGlobalRateLimitExhausted(t *testing.T) {
+	registry := bridge.NewRegistry()
+	if err := registry.Register(&serverTestProvider{id: "cat", version: "1"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	supervisor := bridge.NewSupervisor(registry, bridge.DefaultPolicy(), 1024, time.Minute)
+	defer supervisor.Close()
+
+	// Very tight rate limit: 1 RPS, burst 1.
+	s := New(supervisor, registry, nil, RateLimitConfig{
+		GlobalRPS:                  1,
+		GlobalBurst:                1,
+		StartSessionPerClientRPS:   100,
+		StartSessionPerClientBurst: 100,
+		SendInputPerSessionRPS:     100,
+		SendInputPerSessionBurst:   100,
+	}, "test", nil, nil, "")
+
+	ctx := auth.ContextWithClaims(context.Background(), &auth.BridgeClaims{ProjectID: "proj"})
+
+	// First call should succeed (consumes the burst token).
+	_, err := s.GetSession(ctx, &bridgev1.GetSessionRequest{SessionId: uuid.NewString()})
+	// The first call may return NotFound (session does not exist) but not
+	// ResourceExhausted.
+	if status.Code(err) == codes.ResourceExhausted {
+		t.Fatal("first call was rate limited, expected it to pass")
+	}
+
+	// Rapid subsequent calls should eventually be rate limited.
+	var rateLimited bool
+	for i := 0; i < 50; i++ {
+		_, err := s.GetSession(ctx, &bridgev1.GetSessionRequest{SessionId: uuid.NewString()})
+		if status.Code(err) == codes.ResourceExhausted {
+			rateLimited = true
+			break
+		}
+	}
+	if !rateLimited {
+		t.Fatal("expected at least one ResourceExhausted response after burst")
+	}
+}
+
+// TestListSessionsRPC verifies the ListSessions RPC returns sessions filtered
+// by project.
+// Issue #153: ListSessions.
+func TestListSessionsRPC(t *testing.T) {
+	registry := bridge.NewRegistry()
+	if err := registry.Register(&serverTestProvider{id: "cat", version: "1"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	supervisor := bridge.NewSupervisor(registry, bridge.DefaultPolicy(), 1024, time.Minute)
+	defer supervisor.Close()
+
+	s := New(supervisor, registry, nil, RateLimitConfig{
+		GlobalRPS:                  100,
+		GlobalBurst:                100,
+		StartSessionPerClientRPS:   100,
+		StartSessionPerClientBurst: 100,
+		SendInputPerSessionRPS:     100,
+		SendInputPerSessionBurst:   100,
+	}, "test", nil, nil, "")
+
+	ctx := auth.ContextWithClaims(context.Background(), &auth.BridgeClaims{ProjectID: "proj-list"})
+
+	// Start two sessions.
+	sid1 := uuid.NewString()
+	sid2 := uuid.NewString()
+	for _, sid := range []string{sid1, sid2} {
+		if _, err := s.StartSession(ctx, &bridgev1.StartSessionRequest{
+			ProjectId: "proj-list",
+			SessionId: sid,
+			RepoPath:  t.TempDir(),
+			Provider:  "cat",
+		}); err != nil {
+			t.Fatalf("StartSession %s: %v", sid, err)
+		}
+	}
+
+	listResp, err := s.ListSessions(ctx, &bridgev1.ListSessionsRequest{ProjectId: "proj-list"})
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(listResp.GetSessions()) != 2 {
+		t.Fatalf("ListSessions returned %d sessions, want 2", len(listResp.GetSessions()))
+	}
+
+	// Verify both session IDs are present.
+	ids := map[string]bool{}
+	for _, sess := range listResp.GetSessions() {
+		ids[sess.GetSessionId()] = true
+	}
+	if !ids[sid1] || !ids[sid2] {
+		t.Fatalf("expected both session IDs in response, got: %v", ids)
+	}
+
+	// Clean up.
+	for _, sid := range []string{sid1, sid2} {
+		_, _ = s.StopSession(ctx, &bridgev1.StopSessionRequest{SessionId: sid, Force: true})
+	}
+}
+
+// TestWriteInputRateLimitExhausted verifies that the per-session write rate
+// limiter returns ResourceExhausted when the limit is exceeded.
+// Issue #153: rate limiting.
+func TestWriteInputRateLimitExhausted(t *testing.T) {
+	registry := bridge.NewRegistry()
+	if err := registry.Register(&serverTestProvider{id: "cat", version: "1"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	supervisor := bridge.NewSupervisor(registry, bridge.DefaultPolicy(), 1024, time.Minute)
+	defer supervisor.Close()
+
+	// Very tight write rate limit: 1 RPS, burst 2.
+	s := New(supervisor, registry, nil, RateLimitConfig{
+		GlobalRPS:                  1000,
+		GlobalBurst:                1000,
+		StartSessionPerClientRPS:   1000,
+		StartSessionPerClientBurst: 1000,
+		SendInputPerSessionRPS:     1,
+		SendInputPerSessionBurst:   2,
+	}, "test", nil, nil, "")
+
+	ctx := auth.ContextWithClaims(context.Background(), &auth.BridgeClaims{ProjectID: "proj"})
+	sid := uuid.NewString()
+
+	if _, err := s.StartSession(ctx, &bridgev1.StartSessionRequest{
+		ProjectId:   "proj",
+		SessionId:   sid,
+		RepoPath:    t.TempDir(),
+		Provider:    "cat",
+		InitialCols: 80,
+		InitialRows: 24,
+	}); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	// Attach the client as writer via the supervisor.
+	if _, err := supervisor.Attach(sid, "cli", 0, bridge.AttachRoleWriter); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	// Send enough writes to exhaust the burst.
+	var rateLimited bool
+	for i := 0; i < 50; i++ {
+		_, err := s.WriteInput(ctx, &bridgev1.WriteInputRequest{
+			SessionId: sid,
+			ClientId:  "cli",
+			Data:      []byte("x"),
+		})
+		if status.Code(err) == codes.ResourceExhausted {
+			rateLimited = true
+			break
+		}
+	}
+	if !rateLimited {
+		t.Fatal("expected ResourceExhausted for write input after burst")
+	}
+
+	_ = supervisor.Stop(sid, true)
+}

--- a/internal/server/validation_test.go
+++ b/internal/server/validation_test.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestSessionIDFormatValidation verifies that non-UUID session IDs are
+// rejected with INVALID_ARGUMENT.
+// Issue #153: session ID format validation.
+func TestSessionIDFormatValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantOK  bool
+		wantMsg string
+	}{
+		{
+			name:   "valid UUID",
+			value:  "550e8400-e29b-41d4-a716-446655440000",
+			wantOK: true,
+		},
+		{
+			name:   "valid UUID uppercase",
+			value:  "550E8400-E29B-41D4-A716-446655440000",
+			wantOK: true,
+		},
+		{
+			name:    "empty string",
+			value:   "",
+			wantOK:  false,
+			wantMsg: "session_id is required",
+		},
+		{
+			name:    "plain text",
+			value:   "not-a-uuid",
+			wantOK:  false,
+			wantMsg: "must be a valid UUID",
+		},
+		{
+			name:    "numeric only",
+			value:   "12345",
+			wantOK:  false,
+			wantMsg: "must be a valid UUID",
+		},
+		{
+			name:   "UUID without dashes (accepted by google/uuid)",
+			value:  "550e8400e29b41d4a716446655440000",
+			wantOK: true,
+		},
+		{
+			name:    "partial UUID",
+			value:   "550e8400-e29b-41d4",
+			wantOK:  false,
+			wantMsg: "must be a valid UUID",
+		},
+		{
+			name:    "UUID with extra chars",
+			value:   "550e8400-e29b-41d4-a716-446655440000-extra",
+			wantOK:  false,
+			wantMsg: "must be a valid UUID",
+		},
+		{
+			name:    "control characters",
+			value:   "550e8400-e29b-41d4\x00a716-446655440000",
+			wantOK:  false,
+			wantMsg: "control characters",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateUUIDField("session_id", tc.value)
+			if tc.wantOK {
+				if err != nil {
+					t.Fatalf("validateUUIDField(%q) unexpected error: %v", tc.value, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateUUIDField(%q) expected error, got nil", tc.value)
+			}
+			if got := status.Code(err); got != codes.InvalidArgument {
+				t.Fatalf("validateUUIDField(%q) code=%v want %v", tc.value, got, codes.InvalidArgument)
+			}
+		})
+	}
+}
+
+// TestByteFieldValidation verifies that oversized byte payloads are rejected.
+// Issue #153: input size validation at the server layer.
+func TestByteFieldValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		maxLen  int
+		wantErr bool
+	}{
+		{
+			name:    "empty is rejected",
+			data:    []byte{},
+			maxLen:  100,
+			wantErr: true,
+		},
+		{
+			name:    "under limit is accepted",
+			data:    []byte("hello"),
+			maxLen:  100,
+			wantErr: false,
+		},
+		{
+			name:    "at limit is accepted",
+			data:    make([]byte, 100),
+			maxLen:  100,
+			wantErr: false,
+		},
+		{
+			name:    "over limit is rejected",
+			data:    make([]byte, 101),
+			maxLen:  100,
+			wantErr: true,
+		},
+		{
+			name:    "1MB limit rejects 1MB+1",
+			data:    make([]byte, 1<<20+1),
+			maxLen:  1 << 20,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set first byte to non-zero for non-empty payloads to avoid "is required" error.
+			if len(tc.data) > 0 {
+				tc.data[0] = 'x'
+			}
+			err := validateByteField("data", tc.data, tc.maxLen)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateByteField: expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateByteField: unexpected error: %v", err)
+			}
+			if tc.wantErr && err != nil {
+				if got := status.Code(err); got != codes.InvalidArgument {
+					t.Fatalf("validateByteField code=%v want %v", got, codes.InvalidArgument)
+				}
+			}
+		})
+	}
+}

--- a/internal/server/validation_test.go
+++ b/internal/server/validation_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"strings"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -84,6 +85,11 @@ func TestSessionIDFormatValidation(t *testing.T) {
 			}
 			if got := status.Code(err); got != codes.InvalidArgument {
 				t.Fatalf("validateUUIDField(%q) code=%v want %v", tc.value, got, codes.InvalidArgument)
+			}
+			if tc.wantMsg != "" {
+				if msg := status.Convert(err).Message(); !strings.Contains(msg, tc.wantMsg) {
+					t.Errorf("validateUUIDField(%q) message=%q, want substring %q", tc.value, msg, tc.wantMsg)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Adds unit tests for WriteInput payload size validation (policy.MaxInputBytes enforcement, default 64 KB)
- Adds unit tests for session ID UUID format validation (non-UUID rejected with INVALID_ARGUMENT)
- Adds unit tests for per-project and global session limit enforcement (ErrSessionLimitReached)
- Adds unit tests for rate limit enforcement (token bucket, circuit breaker, keyed limiter isolation)
- Adds server-level rate limit integration tests (global RPS exhaustion, per-session write RPS exhaustion)
- Adds unit tests for bridge-ca subcommands (init, issue, bundle, jwt-keygen, verify, help, error paths)
- Adds unit tests for ListSessions filtering by project_id
- Adds unit tests for ResizeSession updating cols/rows

Closes #153

## Test plan
- [x] `make test` passes with all new tests (684 tests, 0 new failures; pre-existing flaky `TestRunClientRenewOmitsDefaultRootWhenEndpointUsesDifferentTLSRoot` unrelated to these changes)
- [x] New tests cover the acceptance criteria from issue #153
- [x] All pre-commit hooks pass (gofmt, goimports, golangci-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)