### PR TITLE
docs: deprecate bridge-ca in favor of auto-PKI and Step CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Providers are configured in `config/bridge-dev.yaml`. See [docs/docs/reference/c
 
 ## bridge-ca: Certificate and Key Management (Deprecated)
 
-> **Deprecated:** `bridge-ca` is deprecated. For new deployments, use `bridgectl server start` which auto-generates PKI, or use the [Step CA integration](docs/docs/security/step-ca.md) for automated certificate lifecycle management. The `cross-sign` and `verify` subcommands remain available during the deprecation period. `bridge-ca` will be removed in the next major release. See [#154](https://github.com/orchael/ai-agent-bridge/issues/154) for details.
+> **Deprecated:** `bridge-ca` is deprecated. For new deployments, use `bridgectl server start` which auto-generates PKI, or use the [Step CA integration](docs/docs/security/step-ca.md) for automated certificate lifecycle management. The `cross-sign` and `verify` subcommands remain available during the deprecation period. `bridge-ca` will be removed in the next major release. See [#154](https://github.com/orchael/bridgectl/issues/154) for details.
 
 ```bash
 bridge-ca init          # Initialize a new ECDSA P-384 CA

--- a/README.md
+++ b/README.md
@@ -354,7 +354,9 @@ Providers are configured in `config/bridge-dev.yaml`. See [docs/docs/reference/c
 
 ---
 
-## bridge-ca: Certificate and Key Management
+## bridge-ca: Certificate and Key Management (Deprecated)
+
+> **Deprecated:** `bridge-ca` is deprecated. For new deployments, use `bridgectl server start` which auto-generates PKI, or use the [Step CA integration](docs/docs/security/step-ca.md) for automated certificate lifecycle management. The `cross-sign` and `verify` subcommands remain available during the deprecation period. `bridge-ca` will be removed in the next major release. See [#154](https://github.com/orchael/ai-agent-bridge/issues/154) for details.
 
 ```bash
 bridge-ca init          # Initialize a new ECDSA P-384 CA

--- a/cmd/bridge-ca/main.go
+++ b/cmd/bridge-ca/main.go
@@ -12,6 +12,14 @@ import (
 var version = "dev"
 
 func main() {
+	// Deprecated: bridge-ca is deprecated. Use 'bridgectl server start' (auto-PKI)
+	// or Step CA integration instead. bridge-ca will be removed in the next major
+	// release. The 'cross-sign' and 'verify' subcommands remain available during
+	// the deprecation period.
+	fmt.Fprintln(os.Stderr, "WARNING: bridge-ca is deprecated. Use 'bridgectl server start' (auto-PKI) or Step CA integration instead.")
+	fmt.Fprintln(os.Stderr, "See https://github.com/orchael/ai-agent-bridge/issues/154 for details.")
+	fmt.Fprintln(os.Stderr, "")
+
 	if len(os.Args) < 2 {
 		usage()
 		os.Exit(1)
@@ -47,6 +55,11 @@ func main() {
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `bridge-ca - Certificate Authority management for bridgectl
+
+DEPRECATED: bridge-ca is deprecated. Use 'bridgectl server start' (auto-PKI)
+or Step CA integration for all new deployments. The 'cross-sign' and 'verify'
+subcommands remain available during the deprecation period. bridge-ca will be
+removed in the next major release.
 
 Commands:
   init         Initialize a new CA

--- a/cmd/bridge-ca/main.go
+++ b/cmd/bridge-ca/main.go
@@ -17,6 +17,7 @@ func main() {
 	// release. The 'cross-sign' and 'verify' subcommands remain available during
 	// the deprecation period.
 	fmt.Fprintln(os.Stderr, "WARNING: bridge-ca is deprecated. Use 'bridgectl server start' (auto-PKI) or Step CA integration instead.")
+	fmt.Fprintln(os.Stderr, "The 'cross-sign' and 'verify' subcommands remain available during the deprecation period.")
 	fmt.Fprintln(os.Stderr, "See https://github.com/orchael/ai-agent-bridge/issues/154 for details.")
 	fmt.Fprintln(os.Stderr, "")
 

--- a/cmd/bridge-ca/main.go
+++ b/cmd/bridge-ca/main.go
@@ -18,7 +18,7 @@ func main() {
 	// the deprecation period.
 	fmt.Fprintln(os.Stderr, "WARNING: bridge-ca is deprecated. Use 'bridgectl server start' (auto-PKI) or Step CA integration instead.")
 	fmt.Fprintln(os.Stderr, "The 'cross-sign' and 'verify' subcommands remain available during the deprecation period.")
-	fmt.Fprintln(os.Stderr, "See https://github.com/orchael/ai-agent-bridge/issues/154 for details.")
+	fmt.Fprintln(os.Stderr, "See https://github.com/orchael/bridgectl/issues/154 for details.")
 	fmt.Fprintln(os.Stderr, "")
 
 	if len(os.Args) < 2 {

--- a/cmd/bridge-ca/version_test.go
+++ b/cmd/bridge-ca/version_test.go
@@ -9,7 +9,8 @@ import (
 	"testing"
 )
 
-func TestVersionFlag(t *testing.T) {
+func buildBridgeCA(t *testing.T) string {
+	t.Helper()
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "bridge-ca")
 
@@ -20,6 +21,11 @@ func TestVersionFlag(t *testing.T) {
 	if err := build.Run(); err != nil {
 		t.Fatalf("build failed: %v", err)
 	}
+	return bin
+}
+
+func TestVersionFlag(t *testing.T) {
+	bin := buildBridgeCA(t)
 
 	var stdout, stderr bytes.Buffer
 	cmd := exec.Command(bin, "--version")
@@ -30,6 +36,39 @@ func TestVersionFlag(t *testing.T) {
 	}
 	if !strings.HasPrefix(stdout.String(), "bridge-ca ") {
 		t.Errorf("unexpected --version stdout: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "deprecated") {
+		t.Errorf("expected deprecation warning on stderr, got: %q", stderr.String())
+	}
+}
+
+func TestHelpShowsDeprecation(t *testing.T) {
+	bin := buildBridgeCA(t)
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(bin, "help")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("help exited non-zero: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "DEPRECATED") {
+		t.Errorf("expected DEPRECATED in usage output, got: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "deprecated") {
+		t.Errorf("expected deprecation warning on stderr, got: %q", stderr.String())
+	}
+}
+
+func TestNoArgsExitsNonZero(t *testing.T) {
+	bin := buildBridgeCA(t)
+
+	var stderr bytes.Buffer
+	cmd := exec.Command(bin)
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit with no args")
 	}
 	if !strings.Contains(stderr.String(), "deprecated") {
 		t.Errorf("expected deprecation warning on stderr, got: %q", stderr.String())

--- a/cmd/bridge-ca/version_test.go
+++ b/cmd/bridge-ca/version_test.go
@@ -21,14 +21,17 @@ func TestVersionFlag(t *testing.T) {
 		t.Fatalf("build failed: %v", err)
 	}
 
-	var out bytes.Buffer
+	var stdout, stderr bytes.Buffer
 	cmd := exec.Command(bin, "--version")
-	cmd.Stdout = &out
-	cmd.Stderr = &out
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		t.Fatalf("--version exited non-zero: %v\n%s", err, out.String())
+		t.Fatalf("--version exited non-zero: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
 	}
-	if !strings.HasPrefix(out.String(), "bridge-ca ") {
-		t.Errorf("unexpected --version output: %q", out.String())
+	if !strings.HasPrefix(stdout.String(), "bridge-ca ") {
+		t.Errorf("unexpected --version stdout: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "deprecated") {
+		t.Errorf("expected deprecation warning on stderr, got: %q", stderr.String())
 	}
 }

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -84,3 +84,27 @@ Remote session commands accept:
 | `--key <path>` | Client private key override. |
 | `--jwt-key <path>` | JWT signing private key override. |
 | `--server-name <name>` | TLS server name override when dialing by IP or alternate DNS name. |
+
+## bridge-ca (Deprecated)
+
+:::warning Deprecated
+`bridge-ca` is deprecated. Use `bridgectl server start` (auto-PKI) or [Step CA integration](/docs/security/step-ca) for all new deployments. `bridge-ca` will be removed in the next major release. See [#154](https://github.com/orchael/ai-agent-bridge/issues/154).
+:::
+
+`bridge-ca` is a standalone certificate management CLI. It was the primary way to set up PKI before `bridgectl server start` gained auto-PKI support and Step CA integration was added.
+
+For new deployments:
+- **Single machine / development**: `bridgectl server start` auto-generates a self-signed CA and server/client certificates.
+- **Multi-machine / production**: Use [Step CA integration](/docs/security/step-ca) for automated enrollment, short-lived certificates, and renewal.
+- **Existing enterprise CA**: Use the [filesystem provider](/docs/security/existing-ca) with certificates from your PKI.
+
+The `cross-sign` and `verify` subcommands remain available during the deprecation period as they have no equivalent in the current auto-PKI or Step CA workflows.
+
+```bash
+bridge-ca init          # Initialize a new ECDSA P-384 CA
+bridge-ca issue         # Issue a server or client certificate
+bridge-ca cross-sign    # Cross-sign an external CA for multi-tenant trust
+bridge-ca bundle        # Build a trust bundle from multiple CA certs
+bridge-ca jwt-keygen    # Generate an Ed25519 keypair for JWT signing
+bridge-ca verify        # Verify a certificate against a trust bundle
+```

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -88,15 +88,15 @@ Remote session commands accept:
 ## bridge-ca (Deprecated)
 
 :::warning Deprecated
-`bridge-ca` is deprecated. Use `bridgectl server start` (auto-PKI) or [Step CA integration](/docs/security/step-ca) for all new deployments. `bridge-ca` will be removed in the next major release. See [#154](https://github.com/orchael/ai-agent-bridge/issues/154).
+`bridge-ca` is deprecated. Use `bridgectl server start` (auto-PKI) or [Step CA integration](../security/step-ca) for all new deployments. `bridge-ca` will be removed in the next major release. See [#154](https://github.com/orchael/ai-agent-bridge/issues/154).
 :::
 
 `bridge-ca` is a standalone certificate management CLI. It was the primary way to set up PKI before `bridgectl server start` gained auto-PKI support and Step CA integration was added.
 
 For new deployments:
 - **Single machine / development**: `bridgectl server start` auto-generates a self-signed CA and server/client certificates.
-- **Multi-machine / production**: Use [Step CA integration](/docs/security/step-ca) for automated enrollment, short-lived certificates, and renewal.
-- **Existing enterprise CA**: Use the [filesystem provider](/docs/security/existing-ca) with certificates from your PKI.
+- **Multi-machine / production**: Use [Step CA integration](../security/step-ca) for automated enrollment, short-lived certificates, and renewal.
+- **Existing enterprise CA**: Use the [filesystem provider](../security/existing-ca) with certificates from your PKI.
 
 The `cross-sign` and `verify` subcommands remain available during the deprecation period as they have no equivalent in the current auto-PKI or Step CA workflows.
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -88,7 +88,7 @@ Remote session commands accept:
 ## bridge-ca (Deprecated)
 
 :::warning Deprecated
-`bridge-ca` is deprecated. Use `bridgectl server start` (auto-PKI) or [Step CA integration](../security/step-ca) for all new deployments. `bridge-ca` will be removed in the next major release. See [#154](https://github.com/orchael/ai-agent-bridge/issues/154).
+`bridge-ca` is deprecated. Use `bridgectl server start` (auto-PKI) or [Step CA integration](../security/step-ca) for all new deployments. `bridge-ca` will be removed in the next major release. See [#154](https://github.com/orchael/bridgectl/issues/154).
 :::
 
 `bridge-ca` is a standalone certificate management CLI. It was the primary way to set up PKI before `bridgectl server start` gained auto-PKI support and Step CA integration was added.


### PR DESCRIPTION
## Summary
- Marks `bridge-ca` (`ai-agent-bridge-ca`) as deprecated in documentation
- Adds runtime deprecation warning when `bridge-ca` is invoked
- Recommends `bridgectl server start` (auto-PKI) or Step CA integration for all new deployments
- Keeps `cross-sign` and `verify` subcommands available during deprecation period
- Does NOT remove `cmd/bridge-ca` — removal deferred to next major release

Closes #154

## Test plan
- [ ] `make test` passes
- [ ] `bridge-ca` prints deprecation notice on startup
- [ ] Documentation points users to auto-PKI / Step CA path

🤖 Generated with [Claude Code](https://claude.com/claude-code)