### PR TITLE
feat: add provider fallback handling for model errors

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -217,9 +217,10 @@ sessions:
 }
 
 func TestLoadFeatureFlags(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "bridge.yaml")
-	content := `
+	t.Run("provider_fallbacks true", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bridge.yaml")
+		content := `
 server:
   listen: "127.0.0.1:9445"
 auth:
@@ -237,17 +238,47 @@ sessions:
   stop_grace_period: "10s"
   subscriber_ttl: "30m"
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
 
-	cfg, err := Load(path)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if !cfg.FeatureFlags.ProviderFallbacks {
-		t.Fatal("expected provider_fallbacks to be true")
-	}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !cfg.FeatureFlags.ProviderFallbacks {
+			t.Fatal("expected provider_fallbacks to be true")
+		}
+	})
+
+	t.Run("provider_fallbacks defaults to false", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bridge.yaml")
+		content := `
+server:
+  listen: "127.0.0.1:9445"
+auth:
+  jwt_max_ttl: "5m"
+providers:
+  primary:
+    binary: "cat"
+sessions:
+  idle_timeout: "30m"
+  stop_grace_period: "10s"
+  subscriber_ttl: "30m"
+`
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.FeatureFlags.ProviderFallbacks {
+			t.Fatal("expected provider_fallbacks to default to false")
+		}
+	})
 }
 
 func TestLoadRepoSetupDefaultsAndValidation(t *testing.T) {

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -82,6 +82,10 @@ type Server struct {
 	mu         sync.Mutex
 	stopped    bool
 
+	// providerFallbacks is the resolved fallback map passed to the bridge
+	// server. Nil when the feature flag is disabled.
+	providerFallbacks map[string][]string
+
 	// Certificate renewal (secure mode only).
 	renewCancel              context.CancelFunc               // cancels the renewal goroutine
 	serverSANs               []string                         // SANs for cert re-issuance
@@ -340,7 +344,7 @@ func Start(cfg Config) (*Server, error) {
 				configProviderDefs = fileCfg.Providers
 			}
 			providerRoot = fileCfg.Runtime.ProviderRoot
-			providerFallbacksEnabled = fileCfg.FeatureFlags.ProviderFallbacks
+			providerFallbacksEnabled = providerFallbacksEnabled || fileCfg.FeatureFlags.ProviderFallbacks
 			repoSetupEnabled = fileCfg.RepoSetup.IsEnabled()
 			repoSetupConfigPath = fileCfg.RepoSetup.ConfigPath
 			repoSetupDefaultTimeout = config.ParseDuration(fileCfg.RepoSetup.DefaultTimeout, repoSetupDefaultTimeout)
@@ -836,13 +840,14 @@ func Start(cfg Config) (*Server, error) {
 	logger.Info("server starting", "mode", mode, "addr", listenAddr, "pid", os.Getpid())
 
 	s := &Server{
-		grpcServer: grpcServer,
-		supervisor: sup,
-		store:      store,
-		registry:   registry,
-		listener:   ln,
-		logger:     logger,
-		stateDir:   stateDir,
+		grpcServer:        grpcServer,
+		supervisor:        sup,
+		store:             store,
+		registry:          registry,
+		listener:          ln,
+		logger:            logger,
+		stateDir:          stateDir,
+		providerFallbacks: providerFallbacks,
 	}
 
 	// Construct a CertificateProvider from the security config when the

--- a/internal/localserver/localserver.go
+++ b/internal/localserver/localserver.go
@@ -226,7 +226,15 @@ type Config struct {
 
 	// ProviderFallbacks maps each provider ID to an ordered list of
 	// fallback provider IDs to try when the primary is unavailable.
+	// Fallbacks are only used when ProviderFallbacksEnabled is true or
+	// when the config file sets feature_flags.provider_fallbacks: true.
 	ProviderFallbacks map[string][]string
+
+	// ProviderFallbacksEnabled gates whether provider fallback logic is
+	// active. When false (the default), fallback lists are ignored even if
+	// configured. Set by feature_flags.provider_fallbacks in the config
+	// file or programmatically for tests.
+	ProviderFallbacksEnabled bool
 
 	// RedactPatterns are compiled into a Redactor that scrubs sensitive
 	// values from log output.
@@ -311,6 +319,7 @@ func Start(cfg Config) (*Server, error) {
 	// its zero value.
 	var configProviderDefs map[string]config.ProviderConfig
 	var providerRoot string
+	providerFallbacksEnabled := cfg.ProviderFallbacksEnabled
 	repoSetupEnabled := true
 	repoSetupConfigPath := ".bridgectl.yaml"
 	repoSetupDefaultTimeout := 2 * time.Minute
@@ -331,6 +340,7 @@ func Start(cfg Config) (*Server, error) {
 				configProviderDefs = fileCfg.Providers
 			}
 			providerRoot = fileCfg.Runtime.ProviderRoot
+			providerFallbacksEnabled = fileCfg.FeatureFlags.ProviderFallbacks
 			repoSetupEnabled = fileCfg.RepoSetup.IsEnabled()
 			repoSetupConfigPath = fileCfg.RepoSetup.ConfigPath
 			repoSetupDefaultTimeout = config.ParseDuration(fileCfg.RepoSetup.DefaultTimeout, repoSetupDefaultTimeout)
@@ -538,16 +548,25 @@ func Start(cfg Config) (*Server, error) {
 		logger.Info("registered config provider", "provider", id, "binary", pc.Binary)
 	}
 
-	// Build fallbacks map from config providers (merged with any set on cfg).
-	if cfg.ProviderFallbacks == nil && len(configProviderDefs) > 0 {
-		cfg.ProviderFallbacks = make(map[string][]string)
-	}
-	for id, pc := range configProviderDefs {
-		if len(pc.Fallbacks) > 0 {
-			if _, already := cfg.ProviderFallbacks[id]; !already {
-				cfg.ProviderFallbacks[id] = pc.Fallbacks
+	// Build fallbacks map from config providers (merged with any set on cfg)
+	// only when the provider_fallbacks feature flag is enabled.
+	if providerFallbacksEnabled {
+		logger.Info("provider fallbacks enabled")
+		if cfg.ProviderFallbacks == nil && len(configProviderDefs) > 0 {
+			cfg.ProviderFallbacks = make(map[string][]string)
+		}
+		for id, pc := range configProviderDefs {
+			if len(pc.Fallbacks) > 0 {
+				if _, already := cfg.ProviderFallbacks[id]; !already {
+					cfg.ProviderFallbacks[id] = pc.Fallbacks
+					logger.Info("registered provider fallbacks", "provider", id, "fallbacks", pc.Fallbacks)
+				}
 			}
 		}
+	} else {
+		// Feature flag disabled: clear any fallbacks so the server does not
+		// attempt provider failover.
+		cfg.ProviderFallbacks = nil
 	}
 
 	// Auto-detect additional providers not already registered via config.

--- a/internal/localserver/localserver_test.go
+++ b/internal/localserver/localserver_test.go
@@ -233,6 +233,10 @@ func TestStartWithProviderFallbacksDisabled(t *testing.T) {
 		},
 	})
 	assert.NotNil(t, srv)
+	// The server must have cleared the fallback map because the feature flag
+	// was not enabled. This catches regressions where fallbacks are still
+	// applied despite the flag being off.
+	assert.Nil(t, srv.providerFallbacks, "fallbacks should be nil when feature flag is disabled")
 }
 
 // TestServerAddrLocalMode verifies that Addr() returns a non-empty string in

--- a/internal/localserver/localserver_test.go
+++ b/internal/localserver/localserver_test.go
@@ -211,8 +211,21 @@ func TestStartCustomEventBufferSize(t *testing.T) {
 }
 
 // TestStartWithProviderFallbacks verifies that provider fallback mapping is
-// accepted by Start without error.
+// accepted by Start without error when the feature flag is enabled.
 func TestStartWithProviderFallbacks(t *testing.T) {
+	srv := startLocalServer(t, Config{
+		StateDir:                 t.TempDir(),
+		ProviderFallbacksEnabled: true,
+		ProviderFallbacks: map[string][]string{
+			"claude": {"echo"},
+		},
+	})
+	assert.NotNil(t, srv)
+}
+
+// TestStartWithProviderFallbacksDisabled verifies that fallbacks are cleared
+// when the feature flag is not enabled, even if fallback mappings are provided.
+func TestStartWithProviderFallbacksDisabled(t *testing.T) {
 	srv := startLocalServer(t, Config{
 		StateDir: t.TempDir(),
 		ProviderFallbacks: map[string][]string{

--- a/internal/server/server_lifecycle_test.go
+++ b/internal/server/server_lifecycle_test.go
@@ -298,6 +298,43 @@ func TestBridgeServerStartSessionUsesConfiguredFallbacks(t *testing.T) {
 	}
 }
 
+// TestBridgeServerStartSessionNoFallbackWhenDisabled verifies that a failing
+// primary provider is NOT rescued by a fallback when providerFallbacks is nil
+// (i.e. the feature_flags.provider_fallbacks flag is false).
+func TestBridgeServerStartSessionNoFallbackWhenDisabled(t *testing.T) {
+	registry := bridge.NewRegistry()
+	if err := registry.Register(&serverTestProvider{id: "primary", healthErr: context.DeadlineExceeded}); err != nil {
+		t.Fatalf("Register primary: %v", err)
+	}
+	if err := registry.Register(&serverTestProvider{id: "secondary", version: "1"}); err != nil {
+		t.Fatalf("Register secondary: %v", err)
+	}
+
+	supervisor := bridge.NewSupervisor(registry, bridge.DefaultPolicy(), 1024, time.Minute)
+	defer supervisor.Close()
+
+	// providerFallbacks is nil — simulating feature flag disabled.
+	s := New(supervisor, registry, nil, RateLimitConfig{
+		GlobalRPS:                  10,
+		GlobalBurst:                10,
+		StartSessionPerClientRPS:   10,
+		StartSessionPerClientBurst: 10,
+		SendInputPerSessionRPS:     10,
+		SendInputPerSessionBurst:   10,
+	}, "test-instance", nil, nil, "")
+
+	ctx := auth.ContextWithClaims(context.Background(), &auth.BridgeClaims{ProjectID: "project-a"})
+	_, err := s.StartSession(ctx, &bridgev1.StartSessionRequest{
+		ProjectId: "project-a",
+		SessionId: uuid.NewString(),
+		RepoPath:  t.TempDir(),
+		Provider:  "primary",
+	})
+	if err == nil {
+		t.Fatal("expected StartSession to fail when primary is down and fallbacks are disabled")
+	}
+}
+
 func TestAttachSessionSendsExitEvent(t *testing.T) {
 	registry := bridge.NewRegistry()
 	// The default (non-cat) serverTestProvider runs trueBin which exits


### PR DESCRIPTION
## Summary
- Enforces the `feature_flags.provider_fallbacks` config flag (was parsed but never checked)
- When enabled, providers fall back to configured alternatives on startup failure
- When disabled (default), fallback map is cleared so no fallback occurs
- Adds tests for both enabled and disabled paths

Closes #8

## Test plan
- [ ] `make test` passes
- [ ] Fallback fires when flag enabled and primary fails
- [ ] Fallback does not fire when flag disabled
- [ ] Config validation catches invalid fallback references

🤖 Generated with [Claude Code](https://claude.com/claude-code)