### PR TITLE
Fix session takeover attachment ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
 
       - name: Install Go tooling
         run: |
-          go install golang.org/x/tools/cmd/goimports@latest
+          # Match go.mod; newer goimports releases may require a newer Go toolchain.
+          go install golang.org/x/tools/cmd/goimports@v0.44.0
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.0
 
       - name: Run lint

--- a/PRD.md
+++ b/PRD.md
@@ -173,6 +173,7 @@ Takeover acceptance criteria:
 - Once writer access is ready, the CLI synchronizes the session PTY with the current terminal size, including a resize that occurred while attachment or claiming was pending.
 - Ctrl-] releases the new writer slot and exits cleanly. Failed attachment or writer claims return a command error and must not start forwarding terminal input.
 - Failed observer attachments also return a command error.
+- A stream that ends before acknowledging attachment returns a command error. Failed writer startup discards queued terminal input before restoring the terminal, so keystrokes cannot be interpreted by the parent shell.
 
 ---
 

--- a/PRD.md
+++ b/PRD.md
@@ -173,7 +173,7 @@ Takeover acceptance criteria:
 - Once writer access is ready, the CLI synchronizes the session PTY with the current terminal size, including a resize that occurred while attachment or claiming was pending.
 - Ctrl-] releases the new writer slot and exits cleanly. Failed attachment or writer claims return a command error and must not start forwarding terminal input.
 - Failed observer attachments also return a command error.
-- A stream that ends before acknowledging attachment returns a command error. Failed writer startup discards queued terminal input before restoring the terminal, so keystrokes cannot be interpreted by the parent shell.
+- A stream that ends before acknowledging attachment returns a command error, including server-originated cancellation; local user cancellation remains a clean exit. Writer exit discards queued terminal input before restoring the terminal, so keystrokes cannot be interpreted by the parent shell.
 
 ---
 

--- a/PRD.md
+++ b/PRD.md
@@ -161,11 +161,16 @@ Human operators can observe and interact with any running session without stoppi
 
 Writer transition protocol:
 1. Human runs `bridgectl session attach --take-over <id>`.
+   The CLI opens an observer stream and waits for the server's `ATTACHED` event before calling `ClaimWriter` with force enabled. Input and resize requests begin only after the claim succeeds; a failed claim is returned as a command error.
 2. Server sends a `WRITER_CLAIMED` event to all observers including the SDK.
 3. Human types, resizes, or reads.
 4. Human presses Ctrl-] or `bridgectl session attach --release <id>`.
 5. Server sends a `WRITER_RELEASED` event to all observers.
 6. SDK may re-claim the writer slot via `ClaimWriter` RPC.
+
+Takeover acceptance criteria:
+- A CLI takeover replaces an existing writer without a spurious permission error, preserves the previous client's observer stream, and can send input to the running provider.
+- Ctrl-] releases the new writer slot and exits cleanly. Failed attachment or writer claims return a command error and must not start forwarding terminal input.
 
 ---
 

--- a/PRD.md
+++ b/PRD.md
@@ -170,7 +170,9 @@ Writer transition protocol:
 
 Takeover acceptance criteria:
 - A CLI takeover replaces an existing writer without a spurious permission error, preserves the previous client's observer stream, and can send input to the running provider.
+- Once writer access is ready, the CLI synchronizes the session PTY with the current terminal size, including a resize that occurred while attachment or claiming was pending.
 - Ctrl-] releases the new writer slot and exits cleanly. Failed attachment or writer claims return a command error and must not start forwarding terminal input.
+- Failed observer attachments also return a command error.
 
 ---
 

--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -292,6 +292,7 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 	isWriter := role == bridgev1.AttachRole_ATTACH_ROLE_WRITER || takeOver
 	var detached atomic.Bool
 	var writerReady atomic.Bool
+	var attachmentReady bool
 	var claimErr error
 	var sessionExit string
 
@@ -299,19 +300,22 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	setupSigwinch(sigCh)
 	defer signal.Stop(sigCh)
+	resize := func() {
+		c, r := currentTTYSize()
+		_, _ = client.ResizeSession(ctx, &bridgev1.ResizeSessionRequest{
+			SessionId: sessionID,
+			ClientId:  stream.ClientID(),
+			Cols:      c,
+			Rows:      r,
+		})
+	}
 
 	go func() {
 		handleAttachSignals(ctx, sigCh, isWriter, func() {
 			if !writerReady.Load() {
 				return
 			}
-			c, r := currentTTYSize()
-			_, _ = client.ResizeSession(context.Background(), &bridgev1.ResizeSessionRequest{
-				SessionId: sessionID,
-				ClientId:  stream.ClientID(),
-				Cols:      c,
-				Rows:      r,
-			})
+			resize()
 		}, cancel)
 	}()
 
@@ -361,6 +365,7 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 	err = stream.RecvAll(ctx, func(ev *bridgev1.AttachSessionEvent) error {
 		switch ev.Type {
 		case bridgev1.AttachEventType_ATTACH_EVENT_TYPE_ATTACHED:
+			attachmentReady = true
 			// AttachSession only prepares the SDK wrapper; RecvAll opens the
 			// stream. The server must confirm attachment before we claim or write.
 			if isWriter && !writerReady.Load() {
@@ -376,6 +381,7 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 					}
 				}
 				writerReady.Store(true)
+				resize()
 				startWriter()
 			}
 			return nil
@@ -414,7 +420,7 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 		fmt.Fprintf(os.Stderr, "\r\n%s\r\n", sessionExit)
 		return nil
 	}
-	if isWriter && !writerReady.Load() && err != nil && !isCanceledStreamError(err) {
+	if !attachmentReady && err != nil && !isCanceledStreamError(err) {
 		return fmt.Errorf("attach: %w", err)
 	}
 	if err != nil {

--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -256,9 +256,9 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 		var restoreOnce sync.Once
 		restore = func() {
 			restoreOnce.Do(func() {
-				if !isObserver && !writerReady.Load() {
-					// No input reader ran during startup. Do not return queued
-					// raw-mode keystrokes to the parent shell after a failure.
+				if !isObserver {
+					// Discard unread keystrokes on every writer exit, including
+					// when the stream ends before its input goroutine starts.
 					if err := discardTerminalInput(fd); err != nil {
 						fmt.Fprintf(os.Stderr, "discard terminal input: %v\r\n", err)
 					}
@@ -307,7 +307,10 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	setupSigwinch(sigCh)
 	defer signal.Stop(sigCh)
+	var resizeMu sync.Mutex
 	resize := func() {
+		resizeMu.Lock()
+		defer resizeMu.Unlock()
 		c, r := currentTTYSize()
 		_, _ = client.ResizeSession(ctx, &bridgev1.ResizeSessionRequest{
 			SessionId: sessionID,
@@ -427,7 +430,7 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 		fmt.Fprintf(os.Stderr, "\r\n%s\r\n", sessionExit)
 		return nil
 	}
-	if !attachmentReady && !isCanceledStreamError(err) {
+	if !attachmentReady && ctx.Err() == nil {
 		if err == nil {
 			return fmt.Errorf("attach: stream ended before attachment was acknowledged")
 		}

--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -240,6 +240,7 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 
 	fd := int(os.Stdin.Fd())
 	isObserver := role == bridgev1.AttachRole_ATTACH_ROLE_OBSERVER && !takeOver
+	var writerReady atomic.Bool
 	var restore func()
 	if term.IsTerminal(fd) {
 		// When stdin is a TTY, enable raw mode for both writers and observers.
@@ -255,6 +256,13 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 		var restoreOnce sync.Once
 		restore = func() {
 			restoreOnce.Do(func() {
+				if !isObserver && !writerReady.Load() {
+					// No input reader ran during startup. Do not return queued
+					// raw-mode keystrokes to the parent shell after a failure.
+					if err := discardTerminalInput(fd); err != nil {
+						fmt.Fprintf(os.Stderr, "discard terminal input: %v\r\n", err)
+					}
+				}
 				_ = term.Restore(fd, oldState)
 			})
 		}
@@ -291,7 +299,6 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 
 	isWriter := role == bridgev1.AttachRole_ATTACH_ROLE_WRITER || takeOver
 	var detached atomic.Bool
-	var writerReady atomic.Bool
 	var attachmentReady bool
 	var claimErr error
 	var sessionExit string
@@ -420,7 +427,10 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 		fmt.Fprintf(os.Stderr, "\r\n%s\r\n", sessionExit)
 		return nil
 	}
-	if !attachmentReady && err != nil && !isCanceledStreamError(err) {
+	if !attachmentReady && !isCanceledStreamError(err) {
+		if err == nil {
+			return fmt.Errorf("attach: stream ended before attachment was acknowledged")
+		}
 		return fmt.Errorf("attach: %w", err)
 	}
 	if err != nil {

--- a/cmd/bridgectl/session.go
+++ b/cmd/bridgectl/session.go
@@ -289,20 +289,10 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 		return fmt.Errorf("attach: %w", err)
 	}
 
-	if takeOver {
-		_, claimErr := client.ClaimWriter(ctx, &bridgev1.ClaimWriterRequest{
-			SessionId: sessionID,
-			ClientId:  clientID,
-			Force:     true,
-		})
-		if claimErr != nil {
-			restore()
-			return fmt.Errorf("claim writer: %w", claimErr)
-		}
-	}
-
 	isWriter := role == bridgev1.AttachRole_ATTACH_ROLE_WRITER || takeOver
 	var detached atomic.Bool
+	var writerReady atomic.Bool
+	var claimErr error
 	var sessionExit string
 
 	sigCh := make(chan os.Signal, 2)
@@ -312,6 +302,9 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 
 	go func() {
 		handleAttachSignals(ctx, sigCh, isWriter, func() {
+			if !writerReady.Load() {
+				return
+			}
 			c, r := currentTTYSize()
 			_, _ = client.ResizeSession(context.Background(), &bridgev1.ResizeSessionRequest{
 				SessionId: sessionID,
@@ -322,7 +315,7 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 		}, cancel)
 	}()
 
-	if isWriter {
+	startWriter := func() {
 		go func() {
 			w := &inputWriter{cfg: inputWriterConfig{
 				Reader:    os.Stdin,
@@ -343,7 +336,8 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 			}}
 			w.Run()
 		}()
-	} else if term.IsTerminal(fd) {
+	}
+	if !isWriter && term.IsTerminal(fd) {
 		// In raw mode ISIG is disabled, so the terminal won't generate
 		// SIGINT for Ctrl+C. Read stdin and handle it manually.
 		go func() {
@@ -366,6 +360,25 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 
 	err = stream.RecvAll(ctx, func(ev *bridgev1.AttachSessionEvent) error {
 		switch ev.Type {
+		case bridgev1.AttachEventType_ATTACH_EVENT_TYPE_ATTACHED:
+			// AttachSession only prepares the SDK wrapper; RecvAll opens the
+			// stream. The server must confirm attachment before we claim or write.
+			if isWriter && !writerReady.Load() {
+				if takeOver {
+					_, claimErr = client.ClaimWriter(ctx, &bridgev1.ClaimWriterRequest{
+						SessionId: sessionID,
+						ClientId:  clientID,
+						Force:     true,
+					})
+					if claimErr != nil {
+						claimErr = fmt.Errorf("claim writer: %w", claimErr)
+						return claimErr
+					}
+				}
+				writerReady.Store(true)
+				startWriter()
+			}
+			return nil
 		case bridgev1.AttachEventType_ATTACH_EVENT_TYPE_OUTPUT:
 			_, writeErr := os.Stdout.Write(ev.Payload)
 			return writeErr
@@ -388,6 +401,9 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 		}
 	})
 	restore()
+	if claimErr != nil {
+		return claimErr
+	}
 
 	if detached.Load() {
 		fmt.Fprintf(os.Stderr, "\r\nDetached from session %s\r\n", sessionID)
@@ -397,6 +413,9 @@ func attachSession(sessionID string, role bridgev1.AttachRole, takeOver bool, re
 	if sessionExit != "" {
 		fmt.Fprintf(os.Stderr, "\r\n%s\r\n", sessionExit)
 		return nil
+	}
+	if isWriter && !writerReady.Load() && err != nil && !isCanceledStreamError(err) {
+		return fmt.Errorf("attach: %w", err)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\r\nsession ended: %v\r\n", err)

--- a/cmd/bridgectl/terminal_input_bsd.go
+++ b/cmd/bridgectl/terminal_input_bsd.go
@@ -1,0 +1,9 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
+
+package main
+
+import "golang.org/x/sys/unix"
+
+func discardTerminalInput(fd int) error {
+	return unix.IoctlSetPointerInt(fd, unix.TIOCFLUSH, unix.TCIFLUSH)
+}

--- a/cmd/bridgectl/terminal_input_sysv.go
+++ b/cmd/bridgectl/terminal_input_sysv.go
@@ -1,0 +1,9 @@
+//go:build linux || aix || solaris
+
+package main
+
+import "golang.org/x/sys/unix"
+
+func discardTerminalInput(fd int) error {
+	return unix.IoctlSetInt(fd, unix.TCFLSH, unix.TCIFLUSH)
+}

--- a/cmd/bridgectl/terminal_input_windows.go
+++ b/cmd/bridgectl/terminal_input_windows.go
@@ -1,0 +1,7 @@
+package main
+
+import "golang.org/x/sys/windows"
+
+func discardTerminalInput(fd int) error {
+	return windows.FlushConsoleInputBuffer(windows.Handle(fd))
+}

--- a/docs/docs/guides/session-workflow.md
+++ b/docs/docs/guides/session-workflow.md
@@ -31,6 +31,7 @@ sequenceDiagram
 | Observer | Yes | No | Dashboards, reviewers, and humans watching progress. |
 
 When an operator attaches with `--take-over`, the existing writer is demoted and all observers receive a writer-change event.
+The CLI waits for the server to confirm its observer attachment before claiming the writer slot, then enables terminal input and resizing after the claim succeeds.
 
 ## Start from Go
 

--- a/e2e/bridgectl/cli_test.go
+++ b/e2e/bridgectl/cli_test.go
@@ -51,7 +51,17 @@ func TestMain(m *testing.M) {
 		bin += ".exe"
 	}
 
-	cmd := exec.Command("go", "build", "-o", bin, "../../cmd/bridgectl")
+	buildArgs := []string{"build", "-o", bin}
+	if coverDir := os.Getenv("BRIDGECTL_CLI_COVERAGE_DIR"); coverDir != "" {
+		// Subprocess coverage must be collected separately from the test
+		// binary's profile; the coverage script merges these CLI counters.
+		buildArgs = append(buildArgs, "-cover", "-covermode=atomic", "-coverpkg=github.com/orchael/bridgectl/cmd/bridgectl")
+		if err := os.Setenv("GOCOVERDIR", coverDir); err != nil {
+			panic(err)
+		}
+	}
+	buildArgs = append(buildArgs, "../../cmd/bridgectl")
+	cmd := exec.Command("go", buildArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/e2e/bridgectl/takeover_unix_test.go
+++ b/e2e/bridgectl/takeover_unix_test.go
@@ -48,6 +48,7 @@ func (s *CLISuite) TestCLITakeover() {
 	master, tty, err := pty.Open()
 	s.Require().NoError(err)
 	defer func() { _ = master.Close(); _ = tty.Close() }()
+	s.Require().NoError(pty.Setsize(master, &pty.Winsize{Cols: 120, Rows: 40}))
 	outputPath := filepath.Join(s.T().TempDir(), "cli-output")
 	output, err := os.Create(outputPath)
 	s.Require().NoError(err)
@@ -79,6 +80,10 @@ waitForWriter:
 			}
 		}
 	}
+	s.Require().Eventually(func() bool {
+		info, getErr := client.GetSession(ctx, &bridgev1.GetSessionRequest{SessionId: sessionID})
+		return getErr == nil && info.Cols == 120 && info.Rows == 40
+	}, time.Second, 10*time.Millisecond, "takeover must synchronize the current terminal size")
 	_, err = master.Write([]byte("takeover-input-marker\n"))
 	s.Require().NoError(err)
 	s.Require().Eventually(func() bool {
@@ -108,10 +113,11 @@ waitForWriter:
 
 type rejectingTakeoverServer struct {
 	bridgev1.UnimplementedBridgeServiceServer
-	claimStarted chan *bridgev1.ClaimWriterRequest
-	rejectClaim  chan struct{}
-	earlyInput   chan string
-	attached     chan *bridgev1.AttachSessionRequest
+	claimStarted  chan *bridgev1.ClaimWriterRequest
+	rejectClaim   chan struct{}
+	earlyInput    chan string
+	attached      chan *bridgev1.AttachSessionRequest
+	allowAttached chan struct{}
 }
 
 func (s *CLISuite) TestCLITakeoverMissingSession() {
@@ -126,12 +132,14 @@ func (s *CLISuite) TestCLITakeoverMissingSession() {
 	defer func() { _ = master.Close(); _ = tty.Close() }()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, cliBinary, "session", "attach", uuid.NewString(), "--take-over")
-	cmd.Stdin = tty
-	output, err := cmd.CombinedOutput()
-	s.Require().Error(err, "failed attachment must return a command error: %s", output)
-	s.Require().NoError(ctx.Err(), "CLI must exit without waiting for timeout")
-	s.Assert().Contains(string(output), "session not found")
+	for _, flag := range []string{"--take-over", "--observe"} {
+		cmd := exec.CommandContext(ctx, cliBinary, "session", "attach", uuid.NewString(), flag)
+		cmd.Stdin = tty
+		output, err := cmd.CombinedOutput()
+		s.Require().Error(err, "%s: failed attachment must return a command error: %s", flag, output)
+		s.Require().NoError(ctx.Err(), "CLI must exit without waiting for timeout")
+		s.Assert().Contains(string(output), "session not found")
+	}
 }
 
 func (s *rejectingTakeoverServer) Health(context.Context, *bridgev1.HealthRequest) (*bridgev1.HealthResponse, error) {
@@ -140,6 +148,11 @@ func (s *rejectingTakeoverServer) Health(context.Context, *bridgev1.HealthReques
 
 func (s *rejectingTakeoverServer) AttachSession(req *bridgev1.AttachSessionRequest, stream grpc.ServerStreamingServer[bridgev1.AttachSessionEvent]) error {
 	s.attached <- req
+	select {
+	case <-s.allowAttached:
+	case <-stream.Context().Done():
+		return stream.Context().Err()
+	}
 	if err := stream.Send(&bridgev1.AttachSessionEvent{Type: bridgev1.AttachEventType_ATTACH_EVENT_TYPE_ATTACHED}); err != nil {
 		return err
 	}
@@ -177,10 +190,11 @@ func (s *CLISuite) TestCLITakeoverClaimFailure() {
 	listener, err := net.Listen("unix", filepath.Join(stateDir, "server.sock"))
 	s.Require().NoError(err)
 	rpc := &rejectingTakeoverServer{
-		claimStarted: make(chan *bridgev1.ClaimWriterRequest, 1),
-		rejectClaim:  make(chan struct{}),
-		earlyInput:   make(chan string, 16),
-		attached:     make(chan *bridgev1.AttachSessionRequest, 1),
+		claimStarted:  make(chan *bridgev1.ClaimWriterRequest, 1),
+		rejectClaim:   make(chan struct{}),
+		earlyInput:    make(chan string, 16),
+		attached:      make(chan *bridgev1.AttachSessionRequest, 1),
+		allowAttached: make(chan struct{}),
 	}
 	server := grpc.NewServer()
 	bridgev1.RegisterBridgeServiceServer(server, rpc)
@@ -201,17 +215,26 @@ func (s *CLISuite) TestCLITakeoverClaimFailure() {
 	var waitErr error
 	go func() { waitErr = cmd.Wait(); close(done) }()
 	defer func() { cancel(); <-done }()
+	var attach *bridgev1.AttachSessionRequest
+	select {
+	case attach = <-rpc.attached:
+	case <-done:
+		s.T().Fatalf("CLI exited before attaching: %v\n%s", waitErr, output.String())
+	case <-ctx.Done():
+		s.T().Fatal("CLI never opened attachment stream")
+	}
+	select {
+	case <-rpc.claimStarted:
+		s.T().Fatal("CLI claimed writer before the ATTACHED event")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(rpc.allowAttached)
 	select {
 	case claim := <-rpc.claimStarted:
 		s.Assert().True(claim.Force)
-		select {
-		case attach := <-rpc.attached:
-			s.Assert().Equal(bridgev1.AttachRole_ATTACH_ROLE_OBSERVER, attach.Role)
-			s.Assert().Equal(attach.ClientId, claim.ClientId)
-			s.Assert().Equal(attach.SessionId, claim.SessionId)
-		default:
-			s.T().Fatal("claim was sent before attachment")
-		}
+		s.Assert().Equal(bridgev1.AttachRole_ATTACH_ROLE_OBSERVER, attach.Role)
+		s.Assert().Equal(attach.ClientId, claim.ClientId)
+		s.Assert().Equal(attach.SessionId, claim.SessionId)
 	case <-ctx.Done():
 		s.T().Fatal("CLI never claimed writer")
 	case <-done:

--- a/e2e/bridgectl/takeover_unix_test.go
+++ b/e2e/bridgectl/takeover_unix_test.go
@@ -18,6 +18,7 @@ import (
 	bridgev1 "github.com/orchael/bridgectl/gen/bridge/v1"
 	"github.com/orchael/bridgectl/internal/localserver"
 	"github.com/orchael/bridgectl/pkg/bridgeclient"
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -118,6 +119,7 @@ type rejectingTakeoverServer struct {
 	earlyInput    chan string
 	attached      chan *bridgev1.AttachSessionRequest
 	allowAttached chan struct{}
+	eof           bool
 }
 
 func (s *CLISuite) TestCLITakeoverMissingSession() {
@@ -147,6 +149,9 @@ func (s *rejectingTakeoverServer) Health(context.Context, *bridgev1.HealthReques
 }
 
 func (s *rejectingTakeoverServer) AttachSession(req *bridgev1.AttachSessionRequest, stream grpc.ServerStreamingServer[bridgev1.AttachSessionEvent]) error {
+	if s.eof {
+		return nil
+	}
 	s.attached <- req
 	select {
 	case <-s.allowAttached:
@@ -257,4 +262,31 @@ func (s *CLISuite) TestCLITakeoverClaimFailure() {
 		s.T().Fatal("CLI did not exit after rejected claim")
 	}
 	s.Assert().Empty(rpc.earlyInput, "failed claim must not enable terminal forwarding")
+	readable, err := unix.Poll([]unix.PollFd{{Fd: int32(tty.Fd()), Events: unix.POLLIN}}, 100)
+	s.Require().NoError(err)
+	s.Assert().Zero(readable, "failed takeover must discard queued input before returning to the parent shell")
+}
+
+func (s *CLISuite) TestCLITakeoverUnacknowledgedEOF() {
+	if testing.Short() {
+		s.T().Skip("skipping in short mode")
+	}
+	stateDir := s.testStateDir()
+	listener, err := net.Listen("unix", filepath.Join(stateDir, "server.sock"))
+	s.Require().NoError(err)
+	server := grpc.NewServer()
+	bridgev1.RegisterBridgeServiceServer(server, &rejectingTakeoverServer{eof: true})
+	go func() { _ = server.Serve(listener) }()
+	defer server.Stop()
+	master, tty, err := pty.Open()
+	s.Require().NoError(err)
+	defer func() { _ = master.Close(); _ = tty.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, cliBinary, "session", "attach", uuid.NewString(), "--take-over")
+	cmd.Stdin = tty
+	output, err := cmd.CombinedOutput()
+	s.Require().Error(err, "unacknowledged attachment must fail: %s", output)
+	s.Require().NoError(ctx.Err())
+	s.Assert().Contains(string(output), "before attachment was acknowledged")
 }

--- a/e2e/bridgectl/takeover_unix_test.go
+++ b/e2e/bridgectl/takeover_unix_test.go
@@ -120,6 +120,7 @@ type rejectingTakeoverServer struct {
 	attached      chan *bridgev1.AttachSessionRequest
 	allowAttached chan struct{}
 	eof           bool
+	attachErr     error
 }
 
 func (s *CLISuite) TestCLITakeoverMissingSession() {
@@ -150,7 +151,7 @@ func (s *rejectingTakeoverServer) Health(context.Context, *bridgev1.HealthReques
 
 func (s *rejectingTakeoverServer) AttachSession(req *bridgev1.AttachSessionRequest, stream grpc.ServerStreamingServer[bridgev1.AttachSessionEvent]) error {
 	if s.eof {
-		return nil
+		return s.attachErr
 	}
 	s.attached <- req
 	select {
@@ -267,26 +268,37 @@ func (s *CLISuite) TestCLITakeoverClaimFailure() {
 	s.Assert().Zero(readable, "failed takeover must discard queued input before returning to the parent shell")
 }
 
-func (s *CLISuite) TestCLITakeoverUnacknowledgedEOF() {
+func (s *CLISuite) TestCLITakeoverUnacknowledgedStream() {
 	if testing.Short() {
 		s.T().Skip("skipping in short mode")
 	}
-	stateDir := s.testStateDir()
-	listener, err := net.Listen("unix", filepath.Join(stateDir, "server.sock"))
-	s.Require().NoError(err)
-	server := grpc.NewServer()
-	bridgev1.RegisterBridgeServiceServer(server, &rejectingTakeoverServer{eof: true})
-	go func() { _ = server.Serve(listener) }()
-	defer server.Stop()
-	master, tty, err := pty.Open()
-	s.Require().NoError(err)
-	defer func() { _ = master.Close(); _ = tty.Close() }()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, cliBinary, "session", "attach", uuid.NewString(), "--take-over")
-	cmd.Stdin = tty
-	output, err := cmd.CombinedOutput()
-	s.Require().Error(err, "unacknowledged attachment must fail: %s", output)
-	s.Require().NoError(ctx.Err())
-	s.Assert().Contains(string(output), "before attachment was acknowledged")
+	for _, tc := range []struct {
+		name    string
+		err     error
+		message string
+	}{
+		{"EOF", nil, "before attachment was acknowledged"},
+		{"server canceled", status.Error(codes.Canceled, "server canceled attachment"), "Canceled"},
+	} {
+		s.Run(tc.name, func() {
+			stateDir := s.testStateDir()
+			listener, err := net.Listen("unix", filepath.Join(stateDir, "server.sock"))
+			s.Require().NoError(err)
+			server := grpc.NewServer()
+			bridgev1.RegisterBridgeServiceServer(server, &rejectingTakeoverServer{eof: true, attachErr: tc.err})
+			go func() { _ = server.Serve(listener) }()
+			defer server.Stop()
+			master, tty, err := pty.Open()
+			s.Require().NoError(err)
+			defer func() { _ = master.Close(); _ = tty.Close() }()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, cliBinary, "session", "attach", uuid.NewString(), "--take-over")
+			cmd.Stdin = tty
+			output, err := cmd.CombinedOutput()
+			s.Require().Error(err, "unacknowledged attachment must fail: %s", output)
+			s.Require().NoError(ctx.Err())
+			s.Assert().Contains(string(output), tc.message)
+		})
+	}
 }

--- a/e2e/bridgectl/takeover_unix_test.go
+++ b/e2e/bridgectl/takeover_unix_test.go
@@ -1,0 +1,237 @@
+//go:build !windows
+
+package cli_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/google/uuid"
+	bridgev1 "github.com/orchael/bridgectl/gen/bridge/v1"
+	"github.com/orchael/bridgectl/internal/localserver"
+	"github.com/orchael/bridgectl/pkg/bridgeclient"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestCLITakeover exercises PRD Human Interjection through the real CLI and SDK.
+// SDK-only handoff tests cannot catch a CLI claim made before RecvAll opens the stream.
+func (s *CLISuite) TestCLITakeover() {
+	if testing.Short() {
+		s.T().Skip("skipping in short mode")
+	}
+	stateDir := s.testStateDir()
+	srv, err := localserver.Start(localserver.Config{StateDir: stateDir})
+	s.Require().NoError(err)
+	defer srv.Stop()
+	client, err := bridgeclient.New(bridgeclient.WithTarget(srv.Target()))
+	s.Require().NoError(err)
+	defer func() { _ = client.Close() }()
+	client.SetProject("test")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	sessionID := s.startEchoSession(ctx, client, s.T().TempDir())
+	oldWriter := uuid.NewString()
+	_, attached, events, stopRecv := s.attachAndCollectEvents(ctx, client, sessionID, oldWriter, bridgev1.AttachRole_ATTACH_ROLE_WRITER)
+	defer stopRecv()
+	s.waitForAttach(attached)
+
+	master, tty, err := pty.Open()
+	s.Require().NoError(err)
+	defer func() { _ = master.Close(); _ = tty.Close() }()
+	outputPath := filepath.Join(s.T().TempDir(), "cli-output")
+	output, err := os.Create(outputPath)
+	s.Require().NoError(err)
+	defer func() { _ = output.Close() }()
+	cmd := exec.CommandContext(ctx, cliBinary, "session", "attach", sessionID, "--take-over")
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = tty, output, output
+	s.Require().NoError(cmd.Start())
+	done := make(chan struct{})
+	var waitErr error
+	go func() { waitErr = cmd.Wait(); close(done) }()
+	defer func() { cancel(); <-done }()
+
+	// Fail immediately if the buggy CLI exits with "claim writer: permission denied".
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+waitForWriter:
+	for {
+		select {
+		case <-done:
+			data, _ := os.ReadFile(outputPath)
+			s.T().Fatalf("takeover exited before acquiring writer: %v\n%s", waitErr, data)
+		case <-ctx.Done():
+			s.T().Fatal("timed out waiting for CLI takeover")
+		case <-ticker.C:
+			info, getErr := client.GetSession(ctx, &bridgev1.GetSessionRequest{SessionId: sessionID})
+			s.Require().NoError(getErr)
+			if info.ActiveWriterClientId != "" && info.ActiveWriterClientId != oldWriter {
+				break waitForWriter
+			}
+		}
+	}
+	_, err = master.Write([]byte("takeover-input-marker\n"))
+	s.Require().NoError(err)
+	s.Require().Eventually(func() bool {
+		var output strings.Builder
+		for _, ev := range events() {
+			if ev.Type == bridgev1.AttachEventType_ATTACH_EVENT_TYPE_OUTPUT {
+				output.Write(ev.Payload)
+			}
+		}
+		return strings.Contains(output.String(), "takeover-input-marker")
+	}, 5*time.Second, 10*time.Millisecond, "old writer must remain an observer and receive CLI input output")
+	s.Assert().True(hasEventType(events(), bridgev1.AttachEventType_ATTACH_EVENT_TYPE_WRITER_RELEASED))
+	s.Assert().True(hasEventType(events(), bridgev1.AttachEventType_ATTACH_EVENT_TYPE_WRITER_CLAIMED))
+
+	_, err = master.Write([]byte{0x1d}) // Ctrl-]
+	s.Require().NoError(err)
+	select {
+	case <-done:
+		s.Require().NoError(waitErr)
+	case <-ctx.Done():
+		s.T().Fatal("CLI did not detach")
+	}
+	info, err := client.GetSession(ctx, &bridgev1.GetSessionRequest{SessionId: sessionID})
+	s.Require().NoError(err)
+	s.Assert().Empty(info.ActiveWriterClientId)
+}
+
+type rejectingTakeoverServer struct {
+	bridgev1.UnimplementedBridgeServiceServer
+	claimStarted chan *bridgev1.ClaimWriterRequest
+	rejectClaim  chan struct{}
+	earlyInput   chan string
+	attached     chan *bridgev1.AttachSessionRequest
+}
+
+func (s *CLISuite) TestCLITakeoverMissingSession() {
+	if testing.Short() {
+		s.T().Skip("skipping in short mode")
+	}
+	srv, err := localserver.Start(localserver.Config{StateDir: s.testStateDir()})
+	s.Require().NoError(err)
+	defer srv.Stop()
+	master, tty, err := pty.Open()
+	s.Require().NoError(err)
+	defer func() { _ = master.Close(); _ = tty.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, cliBinary, "session", "attach", uuid.NewString(), "--take-over")
+	cmd.Stdin = tty
+	output, err := cmd.CombinedOutput()
+	s.Require().Error(err, "failed attachment must return a command error: %s", output)
+	s.Require().NoError(ctx.Err(), "CLI must exit without waiting for timeout")
+	s.Assert().Contains(string(output), "session not found")
+}
+
+func (s *rejectingTakeoverServer) Health(context.Context, *bridgev1.HealthRequest) (*bridgev1.HealthResponse, error) {
+	return &bridgev1.HealthResponse{Status: "serving"}, nil
+}
+
+func (s *rejectingTakeoverServer) AttachSession(req *bridgev1.AttachSessionRequest, stream grpc.ServerStreamingServer[bridgev1.AttachSessionEvent]) error {
+	s.attached <- req
+	if err := stream.Send(&bridgev1.AttachSessionEvent{Type: bridgev1.AttachEventType_ATTACH_EVENT_TYPE_ATTACHED}); err != nil {
+		return err
+	}
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+func (s *rejectingTakeoverServer) ClaimWriter(ctx context.Context, req *bridgev1.ClaimWriterRequest) (*bridgev1.ClaimWriterResponse, error) {
+	s.claimStarted <- req
+	select {
+	case <-s.rejectClaim:
+		return nil, status.Error(codes.PermissionDenied, "test claim rejected")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (s *rejectingTakeoverServer) WriteInput(context.Context, *bridgev1.WriteInputRequest) (*bridgev1.WriteInputResponse, error) {
+	s.earlyInput <- "input"
+	return &bridgev1.WriteInputResponse{}, nil
+}
+
+func (s *rejectingTakeoverServer) ResizeSession(context.Context, *bridgev1.ResizeSessionRequest) (*bridgev1.ResizeSessionResponse, error) {
+	s.earlyInput <- "resize"
+	return &bridgev1.ResizeSessionResponse{}, nil
+}
+
+// A rejected takeover must exit unsuccessfully and never forward input or resize
+// while the claim is pending, even if the terminal already has input queued.
+func (s *CLISuite) TestCLITakeoverClaimFailure() {
+	if testing.Short() {
+		s.T().Skip("skipping in short mode")
+	}
+	stateDir := s.testStateDir()
+	listener, err := net.Listen("unix", filepath.Join(stateDir, "server.sock"))
+	s.Require().NoError(err)
+	rpc := &rejectingTakeoverServer{
+		claimStarted: make(chan *bridgev1.ClaimWriterRequest, 1),
+		rejectClaim:  make(chan struct{}),
+		earlyInput:   make(chan string, 16),
+		attached:     make(chan *bridgev1.AttachSessionRequest, 1),
+	}
+	server := grpc.NewServer()
+	bridgev1.RegisterBridgeServiceServer(server, rpc)
+	go func() { _ = server.Serve(listener) }()
+	defer server.Stop()
+
+	master, tty, err := pty.Open()
+	s.Require().NoError(err)
+	defer func() { _ = master.Close(); _ = tty.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, cliBinary, "session", "attach", uuid.NewString(), "--take-over")
+	cmd.Stdin = tty
+	var output strings.Builder
+	cmd.Stdout, cmd.Stderr = &output, &output
+	s.Require().NoError(cmd.Start())
+	done := make(chan struct{})
+	var waitErr error
+	go func() { waitErr = cmd.Wait(); close(done) }()
+	defer func() { cancel(); <-done }()
+	select {
+	case claim := <-rpc.claimStarted:
+		s.Assert().True(claim.Force)
+		select {
+		case attach := <-rpc.attached:
+			s.Assert().Equal(bridgev1.AttachRole_ATTACH_ROLE_OBSERVER, attach.Role)
+			s.Assert().Equal(attach.ClientId, claim.ClientId)
+			s.Assert().Equal(attach.SessionId, claim.SessionId)
+		default:
+			s.T().Fatal("claim was sent before attachment")
+		}
+	case <-ctx.Done():
+		s.T().Fatal("CLI never claimed writer")
+	case <-done:
+		s.T().Fatalf("CLI exited before claiming writer: %v\n%s", waitErr, output.String())
+	}
+	_, err = master.Write([]byte("must-not-forward\n"))
+	s.Require().NoError(err)
+	s.Require().NoError(cmd.Process.Signal(syscall.SIGWINCH))
+	select {
+	case operation := <-rpc.earlyInput:
+		s.T().Fatalf("CLI sent %s before claim succeeded", operation)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(rpc.rejectClaim)
+	select {
+	case <-done:
+		s.Require().Error(waitErr)
+		s.Assert().Contains(output.String(), "claim writer: permission denied")
+	case <-ctx.Done():
+		s.T().Fatal("CLI did not exit after rejected claim")
+	}
+	s.Assert().Empty(rpc.earlyInput, "failed claim must not enable terminal forwarding")
+}

--- a/scripts/test-go-coverage.sh
+++ b/scripts/test-go-coverage.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 export GOCACHE="${GOCACHE:-/tmp/go-build}"
 export GOMODCACHE="${GOMODCACHE:-/tmp/go-mod}"
 
+# Include the real CLI exercised by the e2e suite in the coverage report.
+cli_coverage_dir="$(mktemp -d)"
+trap 'rm -rf "$cli_coverage_dir"' EXIT
+export BRIDGECTL_CLI_COVERAGE_DIR="$cli_coverage_dir"
+
 mapfile -t packages < <(go list ./... | grep -v '/node_modules/')
 
 if [ "${#packages[@]}" -eq 0 ]; then
@@ -12,3 +17,6 @@ if [ "${#packages[@]}" -eq 0 ]; then
 fi
 
 go test -race -covermode=atomic -coverprofile=coverage.out "${packages[@]}"
+go tool covdata textfmt -i="$cli_coverage_dir" -o="$cli_coverage_dir/cli.out"
+# Both profiles use atomic counters; repeated blocks are additive.
+tail -n +2 "$cli_coverage_dir/cli.out" >> coverage.out

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,11 @@
 # Lessons
 
+## 2026-09-10 CLI Takeover Stream Ordering
+- Incident/bug: `session attach --take-over` claimed the writer slot before opening its observer stream, returning `permission denied`.
+- Root cause pattern: SDK `AttachSession` constructs a lazy wrapper; `RecvAll` performs the actual RPC. Existing handoff tests attached through the SDK and never exercised CLI ordering.
+- Preventative rule: Gate dependent session RPCs on the server's `ATTACHED` event and test operator workflows through the real CLI with a PTY.
+- Validation added: CLI takeover regression reproduces the original error, then verifies writer transfer, input, observer continuity, and detach; rejected-claim coverage checks error propagation and input/resize gating.
+
 ## 2026-03-30 PTY Transport Test Execution
 - Incident/bug: A provider unit test that executed a temp script failed inside the sandbox with `operation not permitted`.
 - Root cause pattern: Tests that shell out in this environment can fail for sandbox reasons unrelated to application logic.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -266,3 +266,8 @@ PR #218 review cycle 3:
 - Server-originated Canceled before ATTACHED: score 2, fixed by checking the local context rather than classifying every Canceled status as a user cancellation; added a failing-then-passing CLI regression.
 - Illumos build tag: score 0, no change. `GOOS=illumos GOARCH=amd64 go list -f '{{.GoFiles}}' ./cmd/bridgectl` selects `terminal_input_sysv.go` because illumos satisfies Solaris build tags.
 - Also addressed review notes by serializing dimension sampling and resize RPCs, discarding unread input on every writer exit regardless of reader startup timing, and clarifying the historical test count.
+
+Final CI coverage integration:
+- Codecov patch coverage initially reported 0% because the e2e suite built a CLI without coverage instrumentation, even though it exercised the changed code.
+- The coverage job now instruments the real CLI, collects subprocess counters in a temporary directory, and appends their atomic profile to the Go test profile. This measures the existing end-to-end assertions without lowering coverage gates.
+- `make test-cover` passed with subprocess instrumentation: `attachSession` is 77.4% covered and the Linux input-discard helper is 100% covered. Lint and shell syntax checks passed.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -245,7 +245,7 @@ Scope: CLI sequencing and regression coverage; preserve server permission checks
 Evidence:
 - Before the fix, `go test ./e2e/bridgectl -run 'TestCLISuite/TestCLITakeover$' -count=1` failed with `claim writer: permission denied`.
 - Missing-session regression initially failed because the CLI printed NotFound but exited successfully.
-- `go test ./e2e/bridgectl -run 'TestCLISuite/TestCLITakeover' -race -count=1` passed all three cases after the fix.
+- `go test ./e2e/bridgectl -run 'TestCLISuite/TestCLITakeover' -race -count=1` passed the initial three cases after the fix; the final suite includes four matching tests with EOF and server-cancellation subcases.
 - `make fmt`, `make test`, and `make lint` passed; lint reported zero issues.
 - `make test-cover-maintained` passed at 78.2% (75% minimum).
 - `pnpm --dir docs build` passed.
@@ -261,3 +261,8 @@ PR #218 review cycle 2:
 - Both new assertions failed before the fixes: a poll found queued input after rejected takeover, and unacknowledged EOF exited successfully.
 - Flush pending terminal input before restoring a writer terminal when startup never became ready, and return an attachment error for unacknowledged EOF.
 - After the cycle 2 fixes, all four takeover cases passed with race detection; `make test` and `make lint` passed again.
+
+PR #218 review cycle 3:
+- Server-originated Canceled before ATTACHED: score 2, fixed by checking the local context rather than classifying every Canceled status as a user cancellation; added a failing-then-passing CLI regression.
+- Illumos build tag: score 0, no change. `GOOS=illumos GOARCH=amd64 go list -f '{{.GoFiles}}' ./cmd/bridgectl` selects `terminal_input_sysv.go` because illumos satisfies Solaris build tags.
+- Also addressed review notes by serializing dimension sampling and resize RPCs, discarding unread input on every writer exit regardless of reader startup timing, and clarifying the historical test count.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -255,3 +255,9 @@ PR #218 review cycle 1:
 - Scored both Copilot threads 2 (behavior fix with validation): observer attachment errors and terminal resize synchronization.
 - Added assertions that failed before the review fixes, then passed for observer NotFound errors and initial terminal dimensions. Delayed the fake server's ATTACHED event to verify a claim cannot precede acknowledgement.
 - CI's lint tooling install failed before lint ran: goimports@latest requires Go 1.26, while CI uses Go 1.25.7. Pinned goimports to v0.44.0, matching go.mod and supporting Go 1.25.
+
+PR #218 review cycle 2:
+- Scored both Copilot threads 2 (localized behavior fixes with regression coverage): queued terminal input on startup failure and EOF before attachment acknowledgement.
+- Both new assertions failed before the fixes: a poll found queued input after rejected takeover, and unacknowledged EOF exited successfully.
+- Flush pending terminal input before restoring a writer terminal when startup never became ready, and return an attachment error for unacknowledged EOF.
+- After the cycle 2 fixes, all four takeover cases passed with race detection; `make test` and `make lint` passed again.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -250,3 +250,8 @@ Evidence:
 - `make test-cover-maintained` passed at 78.2% (75% minimum).
 - `pnpm --dir docs build` passed.
 - Rollback scope verified: only CLI behavior changes; server authorization, SDK contracts, and persistent data are unchanged. The reported desktop was not modified.
+
+PR #218 review cycle 1:
+- Scored both Copilot threads 2 (behavior fix with validation): observer attachment errors and terminal resize synchronization.
+- Added assertions that failed before the review fixes, then passed for observer NotFound errors and initial terminal dimensions. Delayed the fake server's ATTACHED event to verify a claim cannot precede acknowledgement.
+- CI's lint tooling install failed before lint ran: goimports@latest requires Go 1.26, while CI uses Go 1.25.7. Pinned goimports to v0.44.0, matching go.mod and supporting Go 1.25.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -228,3 +228,25 @@ Evidence:
 - `docker run --rm bridgectl:issue-180 id -un` -> passed; command args executed as `bridge` after initialization.
 - Detached default-start smoke with `docker run -d --name issue180-default bridgectl:issue-180` stayed running and logged `secure (mTLS+JWT on [::]:9445)`.
 - `env-secrets aws -s /bridgectl/e2e -- make test-e2e-unprotected` -> passed. Protected pass verified Claude and Codex did not write `.git` markers; unprotected pass verified Claude and Codex wrote provider-specific `.git` markers through SDK-started sessions.
+
+# Session takeover attachment order (2026-09-10)
+
+Mode: Autonomous; localized CLI ordering fix authorized by the user. Governing requirement: PRD §6.2 Human Interjection.
+
+Plan:
+- [x] Reproduce the actual CLI takeover failure with a PTY and isolated echo session.
+- [x] Wait for ATTACHED before claiming and enable input/resize only after success.
+- [x] Verify takeover, old-writer observation, input, detach, and failure behavior.
+- [x] Run formatting, full race tests, lint, and the maintained coverage gate.
+PR workflow: open a PR, request Copilot, address feedback, and record final review/CI evidence in the PR.
+
+Scope: CLI sequencing and regression coverage; preserve server permission checks and SDK contracts. Risk: starting input too early or losing claim errors in stream handling. Rollback: revert the CLI change; no deployment or data migration is involved.
+
+Evidence:
+- Before the fix, `go test ./e2e/bridgectl -run 'TestCLISuite/TestCLITakeover$' -count=1` failed with `claim writer: permission denied`.
+- Missing-session regression initially failed because the CLI printed NotFound but exited successfully.
+- `go test ./e2e/bridgectl -run 'TestCLISuite/TestCLITakeover' -race -count=1` passed all three cases after the fix.
+- `make fmt`, `make test`, and `make lint` passed; lint reported zero issues.
+- `make test-cover-maintained` passed at 78.2% (75% minimum).
+- `pnpm --dir docs build` passed.
+- Rollback scope verified: only CLI behavior changes; server authorization, SDK contracts, and persistent data are unchanged. The reported desktop was not modified.


### PR DESCRIPTION
`bridgectl session attach <id> --take-over` failed with `claim writer: permission denied` because the SDK creates a lazy attachment wrapper and the CLI claimed the writer slot before opening its stream.

Wait for the server's `ATTACHED` event before force-claiming the writer slot, and enable terminal input and resizing only after success. Preserve nonzero command errors when attachment or claiming fails, including a stream ending before acknowledgement. Discard queued terminal input on writer exit before restoring the terminal. Distinguish local cancellation from server-originated Canceled errors, and serialize terminal resize RPCs. Server authorization and SDK contracts are unchanged; no daemon restart or configuration change is required for this CLI fix.

Regression coverage runs the real CLI with a PTY against an isolated echo session. The test reproduced the exact reported error before the fix and now verifies writer transfer, input, continued observation by the previous writer, and Ctrl-] detach. Additional tests cover delayed attachment acknowledgement, rejected claims with queued input/resize, nonexistent sessions in writer and observer modes, terminal size synchronization, queued-input cleanup, and EOF/server cancellation before acknowledgement. PRD Human Interjection criteria and workflow documentation are updated.

Validation:
- `go test ./e2e/bridgectl -run 'TestCLISuite/TestCLITakeover' -race -count=1` — all four takeover cases pass; takeover failed before the fix.
- `make fmt`, `make test`, `make lint` — pass, including the full race-enabled Go suite.
- `make test-cover-maintained` — 78.2%, above the 75% gate.
- `make test-cover` — pass; subprocess instrumentation reports 77.4% for `attachSession` and 100% for Linux terminal-input cleanup.
- `pnpm --dir docs build` — pass.

The coverage harness now includes counters from the real CLI subprocess in the uploaded Go profile, so the regression coverage is visible to Codecov.

CI also pins goimports to v0.44.0 (matching go.mod): the previous @latest install now requires Go 1.26 and fails under the configured Go 1.25.7. The pinned install was verified with Go 1.25.7.

The reported desktop and its running sessions were not modified.
