### PR TITLE
chore: update Go to 1.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILD_FROM=source
 ARG INCLUDE_E2E_SCRIPTS=false
 
 # Source build stage
-FROM golang:1.25 AS source
+FROM golang:1.26 AS source
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See the Docusaurus documentation under [docs/](docs/) for architecture details.
 
 ### Prerequisites
 
-- [Go 1.25+](https://go.dev/dl/)
+- [Go 1.26+](https://go.dev/dl/)
 - **Node.js 24.x** (for provider CLIs -- use the version in `.nvmrc`). Install via any of these methods:
   - [nvm](https://github.com/nvm-sh/nvm) (recommended): `nvm install` after cloning
   - **macOS Homebrew**: `brew install node@24`

--- a/cmd/bridgectl/client_renew.go
+++ b/cmd/bridgectl/client_renew.go
@@ -262,7 +262,11 @@ func isTLSVerificationError(err error) bool {
 		return true
 	}
 	var invalidCert x509.CertificateInvalidError
-	return errors.As(err, &invalidCert)
+	if errors.As(err, &invalidCert) {
+		return true
+	}
+	var certVerifyErr *tls.CertificateVerificationError
+	return errors.As(err, &certVerifyErr)
 }
 
 func renewalToken(stepCAURL, certPath, keyPath string) (string, error) {

--- a/cmd/bridgectl/client_renew_test.go
+++ b/cmd/bridgectl/client_renew_test.go
@@ -156,7 +156,11 @@ func TestRenewAudienceUsesRenewEndpoint(t *testing.T) {
 func TestIsTLSVerificationError(t *testing.T) {
 	err := fmt.Errorf("renew with token: %w", x509.UnknownAuthorityError{})
 	if !isTLSVerificationError(err) {
-		t.Fatal("isTLSVerificationError() = false, want true")
+		t.Fatal("isTLSVerificationError() = false for UnknownAuthorityError, want true")
+	}
+	certVerifyErr := &tls.CertificateVerificationError{Err: fmt.Errorf("x509: certificate is not trusted")}
+	if !isTLSVerificationError(fmt.Errorf("renew with token: %w", certVerifyErr)) {
+		t.Fatal("isTLSVerificationError() = false for CertificateVerificationError, want true")
 	}
 	if isTLSVerificationError(fmt.Errorf("renew with token: unauthorized")) {
 		t.Fatal("isTLSVerificationError() = true for non-TLS error, want false")

--- a/docs/docs/getting-started/local-machine.md
+++ b/docs/docs/getting-started/local-machine.md
@@ -6,7 +6,7 @@ Use this setup on every machine that will run a bridge server or use the example
 
 ## Prerequisites
 
-- Go 1.25 or newer
+- Go 1.26 or newer
 - Node.js 24.x and Corepack
 - pnpm 11.22.0 through Corepack
 - Docker Compose v2 if you use the compose examples

--- a/e2e/Dockerfile.client
+++ b/e2e/Dockerfile.client
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25 AS build
+FROM golang:1.26 AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/e2e/bridgectl/Dockerfile
+++ b/e2e/bridgectl/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm
+FROM golang:1.26-bookworm
 
 WORKDIR /src
 

--- a/e2e/remote-mtls/Dockerfile.remote-client
+++ b/e2e/remote-mtls/Dockerfile.remote-client
@@ -1,5 +1,5 @@
 # Build stage — compile bridgectl and the e2e test binary.
-FROM golang:1.25 AS build
+FROM golang:1.26 AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/e2e/remote-stepca/Dockerfile.remote-client
+++ b/e2e/remote-stepca/Dockerfile.remote-client
@@ -1,5 +1,5 @@
 # Build stage — compile bridgectl and the e2e test binary.
-FROM golang:1.25 AS build
+FROM golang:1.26 AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/e2e/step-ca/Dockerfile.test-client
+++ b/e2e/step-ca/Dockerfile.test-client
@@ -1,5 +1,5 @@
 # Build stage — compile the step-ca e2e test binary.
-FROM golang:1.25.7 AS build
+FROM golang:1.26.0 AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/examples/web/Dockerfile
+++ b/examples/web/Dockerfile
@@ -7,7 +7,7 @@ RUN pnpm install --frozen-lockfile
 COPY examples/web/ui/ ./
 RUN pnpm build
 
-FROM golang:1.25 AS go-build
+FROM golang:1.26 AS go-build
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -26,7 +26,7 @@ COPY --from=ui-build /src/examples/web/ui/dist /app/ui/dist
 EXPOSE 3000
 ENTRYPOINT ["/app/web", "--port", "3000", "--vite-port", "0"]
 
-FROM golang:1.25 AS server-dev
+FROM golang:1.26 AS server-dev
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/orchael/bridgectl
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/creack/pty v1.1.24

--- a/plans/phase4-security-model-test-plan.md
+++ b/plans/phase4-security-model-test-plan.md
@@ -23,7 +23,7 @@ All tests should run on **Linux (Docker)**, **Linux (desktop)**, and
 
 | Requirement | Where |
 |---|---|
-| Go toolchain (1.25+) | local machine and Docker image |
+| Go toolchain (1.26+) | local machine and Docker image |
 | `make`, `docker`, `docker compose` | local machine |
 | `bridgectl` binary | built via `make build` or `go build ./cmd/bridgectl` |
 | Step CA server + OIDC provider | Tier-2 tests only (Sections 6, 7) |
@@ -43,7 +43,7 @@ can run inside the existing e2e Docker harness:
 make test-cli-e2e-docker
 
 # Unit tests with race detection
-docker run --rm -v "$PWD":/src -w /src golang:1.25-bookworm \
+docker run --rm -v "$PWD":/src -w /src golang:1.26-bookworm \
   go test -v -race -count=1 -timeout 120s ./...
 ```
 
@@ -427,7 +427,7 @@ The existing infrastructure supports this. All new tests run via:
 make test-cli-e2e-docker
 ```
 
-This uses `e2e/bridgectl/Dockerfile` (Go 1.25-bookworm) and
+This uses `e2e/bridgectl/Dockerfile` (Go 1.26-bookworm) and
 `e2e/bridgectl/docker-compose.yml`. No changes needed to the Docker setup
 for tests that do not require Step CA.
 


### PR DESCRIPTION
## Summary

- Update Go from 1.25.7 to 1.26.0 in `go.mod` and all 7 Dockerfiles (production, e2e, examples)
- Fix Go 1.26 x509 behavioral change: untrusted certificate errors are now wrapped as `tls.CertificateVerificationError` instead of `x509.UnknownAuthorityError`, which broke the insecure-TLS fallback in `client renew`
- GitHub Actions workflows already use `go-version-file: go.mod` so they pick up the new version automatically

## Test plan

- [x] `make test` — 699 tests pass, 0 failures
- [x] `make build` — clean build
- [x] `make fmt` + pre-commit hooks pass
- [ ] E2E tests (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)