### PR TITLE
Fix remote Step CA E2E enrollment and failure reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,16 +79,24 @@ test-remote-mtls:
 	docker compose -f e2e/remote-mtls/docker-compose.yml down -v; \
 	exit $$rc
 
+.PHONY: test-remote-stepca
 test-remote-stepca:
 	@set +e; \
 	CF=e2e/remote-stepca/docker-compose.yml; \
-	docker compose -f $$CF build; \
-	docker compose -f $$CF up -d; \
-	docker compose -f $$CF logs -f remote-client & \
-	LOG_PID=$$!; \
-	docker wait $$(docker compose -f $$CF ps -q remote-client) 2>/dev/null; \
-	rc=$$?; \
-	kill $$LOG_PID 2>/dev/null; wait $$LOG_PID 2>/dev/null; \
+	rc=0; \
+	docker compose -f $$CF build && docker compose -f $$CF up -d || rc=$$?; \
+	if [ $$rc -eq 0 ]; then \
+		docker compose -f $$CF logs -f remote-client & \
+		LOG_PID=$$!; \
+		if CLIENT_ID=$$(docker compose -f $$CF ps -a -q remote-client) && [ -n "$$CLIENT_ID" ]; then \
+			rc=$$(docker wait "$$CLIENT_ID") || rc=$$?; \
+			case "$$rc" in ''|*[!0-9]*) rc=1 ;; esac; \
+		else \
+			echo "ERROR: could not find remote-client container" >&2; \
+			rc=1; \
+		fi; \
+		kill $$LOG_PID 2>/dev/null; wait $$LOG_PID 2>/dev/null; \
+	fi; \
 	echo ""; \
 	echo "========================================"; \
 	if [ $$rc -eq 0 ]; then \

--- a/PRD.md
+++ b/PRD.md
@@ -409,6 +409,12 @@ that user sessions will use.
 - `codex`, `claude`, `opencode`, and `gemini` are available on `PATH` in the
   published-style image.
 - Docker command arguments are honored after entrypoint initialization.
+- The remote Step CA E2E client enrolls using the JWK provisioner created by
+  the test CA and connects using a DNS name in the server certificate. The SDK
+  test fixture uses that CA's root as its trust bundle.
+  `make test-remote-stepca` reports success only when setup and
+  the client succeed; build, startup, wait, and client failures return nonzero
+  after Compose cleanup, including when the client has already exited.
 - Provider unprotected mode is opt-in, provider-scoped, defaults to protected
   behavior, and fails closed on invalid boolean values.
 - Manual Docker e2e coverage starts a published-style bridge container and uses

--- a/e2e/remote-stepca/docker-compose.yml
+++ b/e2e/remote-stepca/docker-compose.yml
@@ -73,7 +73,8 @@ services:
       context: ../..
       dockerfile: e2e/remote-stepca/Dockerfile.remote-client
     environment:
-      BRIDGE_SERVER: bridge-server:9445
+      # Step CA server startup defaults to a certificate for "server".
+      BRIDGE_SERVER: server:9445
       STEP_CA_URL: "https://step-ca.local:9443"
       STEP_CA_PROVISIONER_PASSWORD: "remote-e2e-password"
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}

--- a/e2e/remote-stepca/harness_test.go
+++ b/e2e/remote-stepca/harness_test.go
@@ -42,7 +42,8 @@ if [ "$1" = wait ]; then
   case "$SCENARIO" in
     wait_failure) exit 7 ;;
     invalid_wait_output) echo invalid ;;
-    client_failure|already_exited) echo 1 ;;
+    client_failure) echo 1 ;;
+    already_exited) echo 23 ;;
     *) echo 0 ;;
   esac
   exit 0
@@ -87,6 +88,17 @@ esac
 			}
 			if tc.name == "build_failure" && strings.Contains(string(calls), " up ") {
 				t.Errorf("started containers after build failure:\n%s", calls)
+			}
+			if tc.name == "already_exited" {
+				if !strings.Contains(string(calls), " ps -a -q remote-client\n") {
+					t.Errorf("lookup did not include stopped containers:\n%s", calls)
+				}
+				if !strings.Contains(string(calls), "wait fake-client\n") {
+					t.Errorf("did not wait for the stopped client:\n%s", calls)
+				}
+				if !strings.Contains(string(output), "test-remote-stepca: FAILED (exit 23)") {
+					t.Errorf("did not preserve the stopped client's exit code:\n%s", output)
+				}
 			}
 		})
 	}

--- a/e2e/remote-stepca/harness_test.go
+++ b/e2e/remote-stepca/harness_test.go
@@ -1,0 +1,93 @@
+package remote_stepca_e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMakeTargetResult covers the PRD container acceptance criteria: setup and
+// client failures must fail the target, and cleanup must run in every case.
+func TestMakeTargetResult(t *testing.T) {
+	if _, err := exec.LookPath("make"); err != nil {
+		t.Skip("make is required")
+	}
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		pass bool
+	}{
+		{"success", true},
+		{"client_failure", false},
+		{"already_exited", false},
+		{"build_failure", false},
+		{"startup_failure", false},
+		{"ps_failure", false},
+		{"missing_container", false},
+		{"wait_failure", false},
+		{"invalid_wait_output", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			// docker wait reports the container exit code on stdout; its own
+			// status is zero when waiting succeeds, even for a failed client.
+			fakeDocker := `#!/bin/sh
+echo "$*" >> "$DOCKER_CALLS"
+if [ "$1" = wait ]; then
+  case "$SCENARIO" in
+    wait_failure) exit 7 ;;
+    invalid_wait_output) echo invalid ;;
+    client_failure|already_exited) echo 1 ;;
+    *) echo 0 ;;
+  esac
+  exit 0
+fi
+case "$4" in
+  build) [ "$SCENARIO" != build_failure ] || exit 3 ;;
+  up) [ "$SCENARIO" != startup_failure ] || exit 4 ;;
+  ps)
+    [ "$SCENARIO" != ps_failure ] || exit 5
+    [ "$SCENARIO" != missing_container ] || exit 0
+    if [ "$SCENARIO" = already_exited ]; then
+      case " $* " in *" -a "*|*" --all "*) ;; *) exit 0 ;; esac
+    fi
+    echo fake-client ;;
+esac
+`
+			if err := os.WriteFile(filepath.Join(dir, "docker"), []byte(fakeDocker), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			callsPath := filepath.Join(dir, "calls")
+			cmd := exec.Command("make", "--no-print-directory", "test-remote-stepca")
+			cmd.Dir = root
+			cmd.Env = append(os.Environ(), "PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"SCENARIO="+tc.name, "DOCKER_CALLS="+callsPath)
+			output, runErr := cmd.CombinedOutput()
+			if (runErr == nil) != tc.pass {
+				t.Errorf("make error = %v, want success %v\n%s", runErr, tc.pass, output)
+			}
+			banner := "test-remote-stepca: FAILED"
+			if tc.pass {
+				banner = "test-remote-stepca: PASSED"
+			}
+			if !strings.Contains(string(output), banner) {
+				t.Errorf("missing %q in output:\n%s", banner, output)
+			}
+			calls, err := os.ReadFile(callsPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(calls), " down -v\n") {
+				t.Errorf("cleanup did not run:\n%s", calls)
+			}
+			if tc.name == "build_failure" && strings.Contains(string(calls), " up ") {
+				t.Errorf("started containers after build failure:\n%s", calls)
+			}
+		})
+	}
+}

--- a/e2e/remote-stepca/scripts/client-entrypoint.sh
+++ b/e2e/remote-stepca/scripts/client-entrypoint.sh
@@ -43,6 +43,8 @@ done
 echo "" | tee -a "$RESULTS_FILE"
 echo "==> Step: bridgectl client init (Step CA + enroll)" | tee -a "$RESULTS_FILE"
 mkdir -p "$CLIENT_STATE/certs"
+# The SDK tests discover a local CA bundle; client init uses STEP_CA_ROOT directly.
+cp "$STEP_CA_ROOT" "$CLIENT_STATE/certs/ca-bundle.crt"
 
 PW_FILE=$(mktemp)
 echo -n "$STEP_CA_PROVISIONER_PASSWORD" > "$PW_FILE"
@@ -50,7 +52,7 @@ echo -n "$STEP_CA_PROVISIONER_PASSWORD" > "$PW_FILE"
 BRIDGECTL_STATE_DIR="$CLIENT_STATE" bridgectl client init \
   --step-ca-url "$STEP_CA_URL" \
   --step-ca-root "$STEP_CA_ROOT" \
-  --provisioner admin \
+  --provisioner bridge-jwk \
   --step-ca-provisioner-password-file "$PW_FILE" \
   --name remote-stepca-client \
   --target "$BRIDGE_SERVER" 2>&1 | tee -a "$RESULTS_FILE"

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,12 @@
 # Lessons
 
+## 2026-09-11 Remote Step CA E2E False Success
+- Incident/bug: Client enrollment requested `admin` although the test CA created `bridge-jwk`; the Make target still printed `PASSED` after the client exited 1.
+- Root cause pattern: `docker wait` prints the container status to stdout and can return success itself for a failed container. Detached setup errors were also overwritten, and default Compose `ps` can omit an already-exited client.
+- Follow-on failures: The client dialed `bridge-server` although the server certificate covered `server`; SDK tests expected a local CA bundle that client init does not create when given an external root path.
+- Preventative rule: Align enrollment with CA initialization, dial a certificate SAN, supply the SDK trust bundle, capture the container status explicitly, include stopped containers during lookup, and preserve setup errors through cleanup.
+- Validation added: `TestMakeTargetResult` exercises success, client failure, early exit, build/startup/lookup/wait errors, missing containers, and invalid wait output using a fake Docker executable against the real Make target.
+
 ## 2026-09-10 CLI Takeover Stream Ordering
 - Incident/bug: `session attach --take-over` claimed the writer slot before opening its observer stream, returning `permission denied`.
 - Root cause pattern: SDK `AttachSession` constructs a lazy wrapper; `RecvAll` performs the actual RPC. Existing handoff tests attached through the SDK and never exercised CLI ordering.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -42,6 +42,11 @@ PR preparation: a fresh `make test` run passed the full race-test suite, includi
 the previously timing-out repository-setup test. `make test-cover-maintained`
 passed with 78.8% coverage against the 75% gate.
 
+Copilot cycle 1 (PR #222, commit `b06425d`): no review threads were published,
+but the review body identified a valid coverage gap (score 2). Strengthened the
+stopped-client case to require `ps -a -q`, waiting on the discovered client, and
+propagation of its distinct exit code 23. All nine race-tested cases pass.
+
 Final Docker run log: `/tmp/bridgectl-remote-stepca-verification.log`.
 Rollback remains limited to these harness and documentation edits; disposable
 Compose containers and volumes were removed by the successful Make target.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,51 @@
+# Remote Step CA E2E failure reporting (2026-09-11)
+
+Mode: Autonomous localized test-harness bug fix. Governing requirement: PRD
+container acceptance criteria for remote Step CA E2E.
+
+- [x] Reproduce false success with a fake Docker command and regression tests.
+- [x] Align the client with the initialized JWK provisioner and propagate setup,
+  wait, and container failures while preserving cleanup.
+- [x] Run harness regressions, Compose validation, and the real Docker E2E.
+
+Scope: Make target and test client; no production authentication changes.
+Risk: a fast-exiting client disappears from the default Compose `ps` output;
+include stopped containers. Keep detached startup because CA init is a one-shot
+service. Rollback: revert the harness edits; no persistent data migration.
+
+Live verification exposed a second enrollment mismatch after certificate issuance
+succeeded: server startup defaults to a certificate for `server`, but the
+client dials `bridge-server`. Extend the harness fix to use the Compose service
+DNS name covered by that certificate; no TLS verification changes.
+
+After enrollment succeeded, SDK tests failed because their expected local
+`ca-bundle.crt` was missing. Client init uses the supplied Step CA root path;
+copy that public root into the SDK test fixture's expected bundle location.
+
+Evidence:
+- `TestMakeTargetResult` reproduced false success before the fix; all nine cases
+  pass with `go test -race -count=1 ./e2e/remote-stepca`.
+- `make test-remote-stepca` exits 0 after certificate issuance, JWT enrollment,
+  health, provider listing, and echo-session checks; cleanup completes. The
+  Claude/Codex session checks skip without credentials, and the host-only Make
+  regression skips inside the runtime image, which has no `make` binary.
+- The first live rerun correctly printed `FAILED (exit 1)` for the certificate
+  SAN mismatch, proving container failure propagation against real Docker.
+- `make lint` passes with zero issues. Compose config, shell syntax, formatting,
+  and `git diff --check` pass.
+- `make test` fails in the existing
+  `TestCLISuite/TestRepoSetupConfigEnvironmentPropagation` at its five-second
+  repository-setup timeout. An isolated race-test rerun reproduces this failure;
+  other packages passed. This separate timeout is outside the harness fix.
+
+PR preparation: a fresh `make test` run passed the full race-test suite, including
+the previously timing-out repository-setup test. `make test-cover-maintained`
+passed with 78.8% coverage against the 75% gate.
+
+Final Docker run log: `/tmp/bridgectl-remote-stepca-verification.log`.
+Rollback remains limited to these harness and documentation edits; disposable
+Compose containers and volumes were removed by the successful Make target.
+
 # Codex Authentication Lifecycle (2026-09-10)
 
 User approved security-sensitive implementation following review. Governing


### PR DESCRIPTION
The remote Step CA E2E client requested a nonexistent `admin` provisioner, while the Make target printed `PASSED` even when the client exited with an error. Use the initialized `bridge-jwk` provisioner, connect through the `server` DNS name covered by its certificate, and populate the SDK fixture's CA bundle from the test CA root.

Capture the container exit code printed by `docker wait`, preserve build/startup failures, and include stopped clients in container lookup. Nine regression cases exercise success and failure reporting through the real Make target with a fake Docker executable. Production authentication behavior is unchanged.

Validation:
- `make test-remote-stepca`: passed certificate issuance, JWT enrollment, health, provider discovery, and echo-session checks; cleanup completed. Claude/Codex session checks skipped without credentials.
- `go test -race -count=1 ./e2e/remote-stepca`: all nine harness cases passed.
- `make test`: full race-test suite passed on the PR-preparation rerun. An earlier run hit the existing five-second repository-setup timeout.
- `make test-cover-maintained`: 78.8% coverage, above the 75% gate.
- `make lint`: zero issues; Compose validation, shell syntax, and diff checks passed.

Governing requirement: PRD container acceptance criteria for remote Step CA E2E.
