### PR TITLE
Fix Windows portability and clean up stale TODO items

### DIFF
--- a/cmd/bridgectl/server.go
+++ b/cmd/bridgectl/server.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -171,7 +172,11 @@ infrastructure (Google, GitHub, Okta, etc.) managed through Step CA.`,
 			case discoveredMode == localserver.ModeTLS:
 				modeDesc = fmt.Sprintf("secure (TLS+JWT on %s)", srv.Addr())
 			default:
-				modeDesc = "local (unix socket, no auth)"
+				if runtime.GOOS == "windows" {
+					modeDesc = "local (TCP localhost, no auth)"
+				} else {
+					modeDesc = "local (unix socket, no auth)"
+				}
 			}
 			fmt.Fprintf(os.Stderr, "bridgectl server listening — %s (pid %d)\n", modeDesc, os.Getpid())
 

--- a/internal/localserver/pki_test.go
+++ b/internal/localserver/pki_test.go
@@ -917,7 +917,7 @@ func TestEnsurePKI_ModeChangeTriggerRegeneration(t *testing.T) {
 }
 
 func TestLoadPKIMaterial(t *testing.T) {
-	stateDir := filepath.Join(os.TempDir(), "test-state")
+	stateDir := filepath.Join(t.TempDir(), "test-state")
 	mat := LoadPKIMaterial(stateDir)
 
 	certs := filepath.Join(stateDir, "certs")

--- a/internal/provider/stdio.go
+++ b/internal/provider/stdio.go
@@ -1,10 +1,8 @@
 package provider
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,10 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/creack/pty"
 	"github.com/orchael/bridgectl/internal/bridge"
 )
 
@@ -135,111 +131,6 @@ func (p *StdioProvider) validateStartupWithEnv(ctx context.Context, env []string
 		return p.validateStartupPrompt(ctx, env)
 	default:
 		return fmt.Errorf("provider %q has unsupported startup probe %q", p.cfg.ProviderID, p.cfg.StartupProbe)
-	}
-}
-
-func (p *StdioProvider) validateStartupPrompt(ctx context.Context, env []string) error {
-	if p.promptRe == nil {
-		return nil
-	}
-	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.StartupTimeout)
-	defer cancel()
-
-	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
-	if err != nil {
-		return err
-	}
-	args, err := commandArgsForProvider(p.cfg.ProviderID, p.cfg.DefaultArgs, p.cfg.ProviderRoot)
-	if err != nil {
-		return err
-	}
-	wd, _ := os.Getwd()
-	cmd := exec.CommandContext(probeCtx, binPath, args...)
-	cmd.Dir = wd
-	cmd.Env = env
-
-	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: 120, Rows: 40})
-	if err != nil {
-		return fmt.Errorf("provider %q startup probe: %w", p.cfg.ProviderID, err)
-	}
-	defer func() {
-		_ = ptmx.Close()
-		if cmd.Process != nil {
-			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-		}
-	}()
-
-	buf := make([]byte, 4096)
-	var seen bytes.Buffer
-	for {
-		if probeCtx.Err() != nil {
-			return fmt.Errorf("provider %q startup probe timed out waiting for prompt %q; output:\n%s", p.cfg.ProviderID, p.cfg.PromptPattern, seen.String())
-		}
-		_ = ptmx.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
-		n, readErr := ptmx.Read(buf)
-		if n > 0 {
-			seen.Write(buf[:n])
-			if p.promptRe.Match(seen.Bytes()) {
-				return nil
-			}
-		}
-		if readErr != nil {
-			if os.IsTimeout(readErr) {
-				continue
-			}
-			return fmt.Errorf("provider %q startup probe failed: %v; output:\n%s", p.cfg.ProviderID, readErr, seen.String())
-		}
-	}
-}
-
-func (p *StdioProvider) validateStartupOutput(ctx context.Context, env []string) error {
-	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.StartupTimeout)
-	defer cancel()
-
-	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
-	if err != nil {
-		return err
-	}
-	args, err := commandArgsForProvider(p.cfg.ProviderID, p.cfg.DefaultArgs, p.cfg.ProviderRoot)
-	if err != nil {
-		return err
-	}
-	wd, _ := os.Getwd()
-	cmd := exec.CommandContext(probeCtx, binPath, args...)
-	cmd.Dir = wd
-	cmd.Env = env
-
-	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: 120, Rows: 40})
-	if err != nil {
-		return fmt.Errorf("provider %q startup probe: %w", p.cfg.ProviderID, err)
-	}
-	defer func() {
-		_ = ptmx.Close()
-		if cmd.Process != nil {
-			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-		}
-	}()
-
-	buf := make([]byte, 4096)
-	var seen bytes.Buffer
-	for {
-		if probeCtx.Err() != nil {
-			return fmt.Errorf("provider %q startup probe timed out waiting for output; output:\n%s", p.cfg.ProviderID, seen.String())
-		}
-		_ = ptmx.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
-		n, readErr := ptmx.Read(buf)
-		if n > 0 {
-			seen.Write(buf[:n])
-			slog.Debug("provider startup probe output", "provider", p.cfg.ProviderID, "bytes", n)
-			time.Sleep(250 * time.Millisecond)
-			return nil
-		}
-		if readErr != nil {
-			if os.IsTimeout(readErr) {
-				continue
-			}
-			return fmt.Errorf("provider %q startup probe failed: %v; output:\n%s", p.cfg.ProviderID, readErr, seen.String())
-		}
 	}
 }
 

--- a/internal/provider/stdio_pty_unix.go
+++ b/internal/provider/stdio_pty_unix.go
@@ -1,0 +1,121 @@
+//go:build !windows
+
+package provider
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+func (p *StdioProvider) validateStartupPrompt(ctx context.Context, env []string) error {
+	if p.promptRe == nil {
+		return nil
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.StartupTimeout)
+	defer cancel()
+
+	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
+	if err != nil {
+		return err
+	}
+	args, err := commandArgsForProvider(p.cfg.ProviderID, p.cfg.DefaultArgs, p.cfg.ProviderRoot)
+	if err != nil {
+		return err
+	}
+	wd, _ := os.Getwd()
+	cmd := exec.CommandContext(probeCtx, binPath, args...)
+	cmd.Dir = wd
+	cmd.Env = env
+
+	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: 120, Rows: 40})
+	if err != nil {
+		return fmt.Errorf("provider %q startup probe: %w", p.cfg.ProviderID, err)
+	}
+	defer func() {
+		_ = ptmx.Close()
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		}
+	}()
+
+	buf := make([]byte, 4096)
+	var seen bytes.Buffer
+	for {
+		if probeCtx.Err() != nil {
+			return fmt.Errorf("provider %q startup probe timed out waiting for prompt %q; output:\n%s", p.cfg.ProviderID, p.cfg.PromptPattern, seen.String())
+		}
+		_ = ptmx.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		n, readErr := ptmx.Read(buf)
+		if n > 0 {
+			seen.Write(buf[:n])
+			if p.promptRe.Match(seen.Bytes()) {
+				return nil
+			}
+		}
+		if readErr != nil {
+			if os.IsTimeout(readErr) {
+				continue
+			}
+			return fmt.Errorf("provider %q startup probe failed: %v; output:\n%s", p.cfg.ProviderID, readErr, seen.String())
+		}
+	}
+}
+
+func (p *StdioProvider) validateStartupOutput(ctx context.Context, env []string) error {
+	probeCtx, cancel := context.WithTimeout(ctx, p.cfg.StartupTimeout)
+	defer cancel()
+
+	binPath, err := resolveBinaryPath(p.cfg.Binary, p.cfg.ProviderRoot)
+	if err != nil {
+		return err
+	}
+	args, err := commandArgsForProvider(p.cfg.ProviderID, p.cfg.DefaultArgs, p.cfg.ProviderRoot)
+	if err != nil {
+		return err
+	}
+	wd, _ := os.Getwd()
+	cmd := exec.CommandContext(probeCtx, binPath, args...)
+	cmd.Dir = wd
+	cmd.Env = env
+
+	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: 120, Rows: 40})
+	if err != nil {
+		return fmt.Errorf("provider %q startup probe: %w", p.cfg.ProviderID, err)
+	}
+	defer func() {
+		_ = ptmx.Close()
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		}
+	}()
+
+	buf := make([]byte, 4096)
+	var seen bytes.Buffer
+	for {
+		if probeCtx.Err() != nil {
+			return fmt.Errorf("provider %q startup probe timed out waiting for output; output:\n%s", p.cfg.ProviderID, seen.String())
+		}
+		_ = ptmx.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		n, readErr := ptmx.Read(buf)
+		if n > 0 {
+			seen.Write(buf[:n])
+			slog.Debug("provider startup probe output", "provider", p.cfg.ProviderID, "bytes", n)
+			time.Sleep(250 * time.Millisecond)
+			return nil
+		}
+		if readErr != nil {
+			if os.IsTimeout(readErr) {
+				continue
+			}
+			return fmt.Errorf("provider %q startup probe failed: %v; output:\n%s", p.cfg.ProviderID, readErr, seen.String())
+		}
+	}
+}

--- a/internal/provider/stdio_pty_windows.go
+++ b/internal/provider/stdio_pty_windows.go
@@ -1,0 +1,14 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+)
+
+func (p *StdioProvider) validateStartupPrompt(_ context.Context, _ []string) error {
+	return fmt.Errorf("provider %q: PTY startup probes are not supported on Windows", p.cfg.ProviderID)
+}
+
+func (p *StdioProvider) validateStartupOutput(_ context.Context, _ []string) error {
+	return fmt.Errorf("provider %q: PTY startup probes are not supported on Windows", p.cfg.ProviderID)
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -167,7 +167,11 @@ Cert lifecycle items moved to GitHub Issues: #225 (cert renewal), #224 (SAN mism
 
 Previously listed items that were already fixed or addressed in later PRs:
 TestMain cleanup, Echo test assertion, Docker E2E cleanup trap, Windows status
-message, pki_test.go portability, GoReleaser Windows target (build-tag stubs).
+message, pki_test.go portability.
+
+## Remaining
+
+- [ ] **GoReleaser Windows target**: `.goreleaser.yaml` includes `windows` for the CLI but `internal/bridge/supervisor.go` uses Unix-only APIs (`syscall.Kill`, `Setpgid`, `creack/pty`) and the CLI has unguarded PTY paths. The provider package now compiles on Windows (build-tag stubs in `stdio_pty_windows.go`), but the full `cmd/bridgectl` binary still fails cross-compilation. Either add build tags across `internal/bridge` and CLI PTY paths, or remove the Windows release target.
 # Startup Step CA Client Registry
 
 Mode: Approval-Required, approved by user request on 2026-08-09.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -163,22 +163,11 @@ old seed over a refreshed file during rollback.
 
 # CLI Security Follow-ups (from PR #92 Copilot review)
 
-## Deferred — cert lifecycle
+Cert lifecycle items moved to GitHub Issues: #225 (cert renewal), #224 (SAN mismatch detection).
 
-- [ ] **Cert renewal**: Leaf certs (server, local-client) have 90-day validity but `EnsurePKI` uses `ca.crt` as sentinel and never regenerates them. Add expiry check (e.g. warn at 14 days, auto-regenerate at expiry) so secure mode doesn't silently break after 90 days.
-- [ ] **SAN mismatch detection**: If the user restarts with different `--san` values, the existing server cert is reused even though its SANs don't cover the new names. Compare requested SANs against the cert's actual SANs and regenerate if they differ.
-
-## Lower priority
-
-- [ ] **Windows status message**: `server.go:71` says "unix socket" in local mode but Windows uses TCP localhost. Make the status text platform-aware.
-- [ ] **pki_test.go portability**: `TestLoadPKIMaterial` hard-codes Unix-style `/tmp/...` paths. Use `filepath.Join` so it passes on Windows.
-- [ ] **TestMain cleanup**: `defer os.RemoveAll(dir)` in `TestMain` never runs because `os.Exit(m.Run())` terminates first. Capture exit code, clean up, then exit.
-- [ ] **Echo test assertion**: `TestSessionAttachAndInput` conditionally asserts `if got != ""` — silently passes when echo fails. Should require the expected output.
-
-## Deferred — pre-existing / out of scope
-
-- [ ] **GoReleaser Windows target**: `.goreleaser.yaml` includes `windows` for the CLI but `internal/provider/stdio.go` uses Unix-only APIs (`syscall.Kill`, `creack/pty`). Either add Windows build tags to the provider package or remove the Windows release target. (Pre-existing on parent branch.)
-- [ ] **Docker E2E cleanup trap**: `scripts/test-cli-e2e-docker.sh` doesn't install a trap for Ctrl-C — compose stack can be left behind on interrupt.
+Previously listed items that were already fixed or addressed in later PRs:
+TestMain cleanup, Echo test assertion, Docker E2E cleanup trap, Windows status
+message, pki_test.go portability, GoReleaser Windows target (build-tag stubs).
 # Startup Step CA Client Registry
 
 Mode: Approval-Required, approved by user request on 2026-08-09.


### PR DESCRIPTION
## Summary

- **Windows build-tag stubs**: Extract PTY startup probe functions (`validateStartupPrompt`, `validateStartupOutput`) from `stdio.go` into `stdio_pty_unix.go` (`//go:build !windows`) and add `stdio_pty_windows.go` stubs that return clear "not supported" errors. The provider package now compiles on Windows.
- **Windows status message**: `server.go` now says "TCP localhost" instead of "unix socket" when `runtime.GOOS == "windows"`.
- **pki_test portability**: `TestLoadPKIMaterial` switched from `os.TempDir()` to `t.TempDir()` for automatic cleanup.
- **TODO cleanup**: Removed stale items already fixed in prior PRs (TestMain cleanup, echo test assertion, Docker E2E trap). Moved cert lifecycle items to GitHub Issues #225 and #224.

## Test plan

- [x] `make test` — 822 tests pass, 0 failures
- [x] `make lint` — 0 issues
- [x] `go build ./internal/provider/` — compiles on host
- [x] `GOOS=windows GOARCH=amd64 go build ./internal/provider/` — cross-compiles for Windows
- [x] Pre-commit hooks pass (gofmt, goimports, golangci-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)